### PR TITLE
refactor: Request Pool Creation Refinement

### DIFF
--- a/contracts/liquidity/factory/src/execute.rs
+++ b/contracts/liquidity/factory/src/execute.rs
@@ -22,8 +22,6 @@ pub fn execute_request_pool_creation(
     // Load the state
     let state = STATE.load(deps.storage)?;
 
-    let mut msgs: Vec<CosmosMsg> = Vec::new();
-
     // Create a Request in state
     let pool_request = generate_pool_req(deps, &info.sender, env.block.chain_id, channel.clone())?;
 
@@ -41,11 +39,9 @@ pub fn execute_request_pool_creation(
         timeout: IbcTimeout::with_timestamp(env.block.time.plus_seconds(timeout)),
     };
 
-    msgs.push(ibc_packet.into());
-
     Ok(Response::new()
         .add_attribute("method", "request_pool_creation")
-        .add_messages(msgs))
+        .add_message(ibc_packet))
 }
 
 // Function to send IBC request to Router in VLS to perform a swap

--- a/packages/euclid/src/timeout.rs
+++ b/packages/euclid/src/timeout.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::ensure;
 
 use crate::error::ContractError;
 
-/// Ensures that the timeout is between 30 and 240 seconds, and if not provided, defaults the timeout to 60 seconds
+/// Ensures that the timeout is between 30 and 240 seconds. It defaults to 60 seconds if the timeout isn't provided.
 pub fn get_timeout(timeout: Option<u64>) -> Result<u64, ContractError> {
     if let Some(timeout) = timeout {
         // Validate that the timeout is between 30 and 240 seconds inclusive


### PR DESCRIPTION
A vector of `ComsosMsg` was being sent for a single `IbcPacket`, so I removed the vector and used `.add_message(ibc_packet)` instead of `.add_messages(msgs)`