### PR TITLE
test: Cases for parse_swap_id

### DIFF
--- a/packages/euclid/src/swap.rs
+++ b/packages/euclid/src/swap.rs
@@ -9,7 +9,7 @@ use crate::{
 // Struct that stores a certain swap info
 #[cw_serde]
 pub struct SwapInfo {
-    // The asset being swappet
+    // The asset being swapped
     pub asset: TokenInfo,
     // The asset being received
     pub asset_out: TokenInfo,


### PR DESCRIPTION
Wrote some test cases for `parse_swap_id` in the `swap.rs` file.
The cases are: `ID with sender and count`, `ID with empty sender`, and `ID with empty count`.