### PR TITLE
fix: maximum_partner_fee_bps set to 30, created ContractError for it

### DIFF
--- a/contracts/liquidity/factory/src/execute.rs
+++ b/contracts/liquidity/factory/src/execute.rs
@@ -488,7 +488,7 @@ pub fn execute_swap_request(
 
     ensure!(
         partner_fee_bps <= MAX_PARTNER_FEE_BPS,
-        ContractError::new("Invalid partner fee")
+        ContractError::InvalidPartnerFee {}
     );
 
     let partner_fee_amount = amount_in.checked_mul_ceil(Decimal::bps(partner_fee_bps))?;

--- a/packages/euclid/src/error.rs
+++ b/packages/euclid/src/error.rs
@@ -74,6 +74,9 @@ pub enum ContractError {
     #[error("ChainNotFound")]
     ChainNotFound {},
 
+    #[error("InvalidPartnerFee")]
+    InvalidPartnerFee {},
+
     #[error("Instantiate Error - {err}")]
     InstantiateError { err: String },
 

--- a/packages/euclid/src/fee.rs
+++ b/packages/euclid/src/fee.rs
@@ -16,7 +16,7 @@ pub struct Fee {
 }
 
 // Set maximum fee as 0.3%
-pub const MAX_PARTNER_FEE_BPS: u64 = 100;
+pub const MAX_PARTNER_FEE_BPS: u64 = 30;
 
 // Fee Config for a VLP contract
 #[cw_serde]


### PR DESCRIPTION
Closes #37 

Limits partner fees to 30 bps instead of 100