### PR TITLE
Fix/liquidity pair validate

### DIFF
--- a/contracts/liquidity/factory/src/execute.rs
+++ b/contracts/liquidity/factory/src/execute.rs
@@ -219,6 +219,7 @@ pub fn add_liquidity_request(
     slippage_tolerance: u64,
     timeout: Option<u64>,
 ) -> Result<Response, ContractError> {
+    pair_info.validate()?;
     let pair = pair_info.get_pair()?;
 
     // Check that slippage tolerance is between 1 and 100

--- a/packages/euclid/src/token.rs
+++ b/packages/euclid/src/token.rs
@@ -366,6 +366,20 @@ impl PairWithDenom {
         let tokens: Vec<TokenWithDenom> = vec![self.token_1.clone(), self.token_2.clone()];
         tokens
     }
+
+    pub fn validate(&self) -> Result<bool, ContractError> {
+        let pair = self.get_pair()?;
+        ensure!(
+            pair.token_1 == self.token_1.token,
+            ContractError::new("Pair should be sorted")
+        );
+        ensure!(
+            pair.token_2 == self.token_2.token,
+            ContractError::new("Pair should be sorted")
+        );
+
+        Ok(true)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
In liquidity request, pair was not validated causing token 1 and token 2 to swap and assigning wrong token 1 and token 2 liquidity to them.