### PR TITLE
fix: migrate msg references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "cw-multicall"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "cw20"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "escrow"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "factory"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2084,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "router"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2647,7 +2647,7 @@ dependencies = [
  "cw-orch-interchain",
  "cw-storage-plus",
  "cw-utils",
- "cw20 0.2.0",
+ "cw20 0.2.1",
  "escrow",
  "euclid",
  "factory",
@@ -2953,7 +2953,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "virtual_balance"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2970,7 +2970,7 @@ dependencies = [
 
 [[package]]
 name = "vlp"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/common/cw-multicall/Cargo.toml
+++ b/contracts/common/cw-multicall/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-multicall"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Anshudhar Kumar Singh <anshudhar2001@gmail.com>"]
 edition = "2021"
 

--- a/contracts/common/cw-multicall/src/migrate.rs
+++ b/contracts/common/cw-multicall/src/migrate.rs
@@ -1,5 +1,7 @@
 use cosmwasm_std::{entry_point, DepsMut, Env, Response};
-use euclid::{error::ContractError, msgs::vlp::MigrateMsg};
+use euclid::error::ContractError;
+
+use euclid_utils::msgs::multicall::MigrateMsg;
 
 /// This is the migrate entry point for the contract.
 /// Currently, it does not perform any migration logic and simply returns an empty response.

--- a/contracts/hub/router/Cargo.toml
+++ b/contracts/hub/router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "router"
-version = "0.2.2"
+version = "0.2.3"
 authors = [
   "Anshudhar Kumar Singh <anshudhar2001@gmail.com>",
   "Joe Monem <jmonem@icloud.com>",

--- a/contracts/hub/router/src/migrate.rs
+++ b/contracts/hub/router/src/migrate.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{entry_point, DepsMut, Env, Response};
 use cw2::CONTRACT;
-use euclid::{error::ContractError, msgs::vlp::MigrateMsg};
+use euclid::{error::ContractError, msgs::router::MigrateMsg};
 
 use crate::state::TOKEN_DENOMS;
 

--- a/contracts/hub/virtual_balance/Cargo.toml
+++ b/contracts/hub/virtual_balance/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtual_balance"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
   "Anshudhar Kumar Singh <anshudhar2001@gmail.com>",
   "Joe Monem <jmonem@icloud.com>",

--- a/contracts/hub/virtual_balance/src/migrate.rs
+++ b/contracts/hub/virtual_balance/src/migrate.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{entry_point, DepsMut, Env, Response};
-use euclid::{error::ContractError, msgs::vlp::MigrateMsg};
+use euclid::{error::ContractError, msgs::virtual_balance::MigrateMsg};
 
 /// This is the migrate entry point for the contract.
 /// Currently, it does not perform any migration logic and simply returns an empty response.

--- a/contracts/hub/vlp/Cargo.toml
+++ b/contracts/hub/vlp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vlp"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
   "gachouchani1999 <georgeschouchani1@gmail.com>",
   "Anshudhar Kumar Singh <anshudhar2001@gmail.com>",

--- a/contracts/liquidity/cw20/Cargo.toml
+++ b/contracts/liquidity/cw20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
   "Anshudhar Kumar Singh <anshudhar2001@gmail.com>",
   "Joe Monem <jmonem@icloud.com>",

--- a/contracts/liquidity/cw20/src/migrate.rs
+++ b/contracts/liquidity/cw20/src/migrate.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{entry_point, DepsMut, Env, Response};
-use euclid::{error::ContractError, msgs::vlp::MigrateMsg};
+use euclid::{error::ContractError, msgs::cw20::MigrateMsg};
 
 /// This is the migrate entry point for the contract.
 /// Currently, it does not perform any migration logic and simply returns an empty response.

--- a/contracts/liquidity/escrow/Cargo.toml
+++ b/contracts/liquidity/escrow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "escrow"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
   "gachouchani1999 <georgeschouchani1@gmail.com>",
   "Anshudhar Kumar Singh <anshudhar2001@gmail.com>",

--- a/contracts/liquidity/escrow/src/migrate.rs
+++ b/contracts/liquidity/escrow/src/migrate.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{entry_point, DepsMut, Env, Response};
-use euclid::{error::ContractError, msgs::vlp::MigrateMsg};
+use euclid::{error::ContractError, msgs::escrow::MigrateMsg};
 
 /// This is the migrate entry point for the contract.
 /// Currently, it does not perform any migration logic and simply returns an empty response.

--- a/contracts/liquidity/factory/Cargo.toml
+++ b/contracts/liquidity/factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factory"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
   "gachouchani1999 <georgeschouchani1@gmail.com>",
   "Anshudhar Kumar Singh <anshudhar2001@gmail.com>",

--- a/contracts/liquidity/factory/src/migrate.rs
+++ b/contracts/liquidity/factory/src/migrate.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{entry_point, DepsMut, Env, Response};
-use euclid::{error::ContractError, msgs::vlp::MigrateMsg};
+use euclid::{error::ContractError, msgs::factory::MigrateMsg};
 
 /// This is the migrate entry point for the contract.
 /// Currently, it does not perform any migration logic and simply returns an empty response.

--- a/packages/euclid/src/msgs/cw20.rs
+++ b/packages/euclid/src/msgs/cw20.rs
@@ -256,3 +256,6 @@ impl From<QueryMsg> for Cw20QueryMsg {
         }
     }
 }
+
+#[cw_serde]
+pub struct MigrateMsg {}

--- a/packages/euclid/src/msgs/router.rs
+++ b/packages/euclid/src/msgs/router.rs
@@ -110,7 +110,9 @@ pub enum QueryMsg {
 }
 // We define a custom struct for each query response
 #[cw_serde]
-pub struct MigrateMsg {}
+pub struct MigrateMsg {
+    pub denoms: Vec<(Token, TokenDenom)>,
+}
 
 #[cw_serde]
 pub struct QuerySimulateSwap {

--- a/packages/euclid/src/msgs/vlp.rs
+++ b/packages/euclid/src/msgs/vlp.rs
@@ -7,8 +7,6 @@ use crate::{
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Uint128;
 
-use super::router::TokenDenom;
-
 #[cw_serde]
 pub struct InstantiateMsg {
     pub router: String,
@@ -164,9 +162,7 @@ pub struct AllPoolsResponse {
 }
 
 #[cw_serde]
-pub struct MigrateMsg {
-    pub denoms: Vec<(Token, TokenDenom)>,
-}
+pub struct MigrateMsg {}
 
 #[cw_serde]
 pub struct VlpRemoveLiquidityResponse {

--- a/packages/euclid_utils/src/msgs/multicall.rs
+++ b/packages/euclid_utils/src/msgs/multicall.rs
@@ -33,3 +33,6 @@ pub struct SingleQueryResponse {
     pub result: Option<QueryResponse>,
     pub err: Option<String>,
 }
+
+#[cw_serde]
+pub struct MigrateMsg {}


### PR DESCRIPTION
# Pull Request

## Description

Migrate msg struct was wrongly mapped to vlp migrate for all contracts. This PR fixes all the reference with correct package imports

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor/Chore

## Related Issue

[Link to related issue, if applicable]

## Testing

Steps to test:

1. [Step 1]
2. [Step 2]
3. [Step 3]

## Checklist

- [ ] Self-review completed
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated (if applicable)

## Screenshots (if applicable)

[Add screenshots here]

## Additional Notes

[Any additional information or context]