### PR TITLE
Fix - forwarding msg vulnerability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "astroport-forwarding"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "astroport",
  "cosmwasm-schema",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "escrow"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "factory"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "euclid"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",

--- a/contracts/forwarding/astroport-forwarding/Cargo.toml
+++ b/contracts/forwarding/astroport-forwarding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astroport-forwarding"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Anshudhar Kumar Singh <anshudhar2001@gmail.com>"]
 edition = "2021"
 

--- a/contracts/forwarding/astroport-forwarding/src/bin/schema.rs
+++ b/contracts/forwarding/astroport-forwarding/src/bin/schema.rs
@@ -1,7 +1,9 @@
 use std::env::current_dir;
 
 use cosmwasm_schema::{export_schema_with_title, schema_for, write_api};
-use forwarding::msgs::astroport::{Cw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
+use forwarding::msgs::astroport::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use forwarding::msgs::cw20::Cw20HookMsg;
+use forwarding::msgs::euclid_receive::AstroportEuclidReceiveHook;
 
 fn main() {
     let mut out_dir = current_dir().unwrap();
@@ -14,4 +16,9 @@ fn main() {
     }
 
     export_schema_with_title(&schema_for!(Cw20HookMsg), &out_dir, "cw20receive");
+    export_schema_with_title(
+        &schema_for!(AstroportEuclidReceiveHook),
+        &out_dir,
+        "euclid-receive",
+    );
 }

--- a/contracts/forwarding/astroport-forwarding/src/contract.rs
+++ b/contracts/forwarding/astroport-forwarding/src/contract.rs
@@ -44,7 +44,7 @@ pub fn execute(
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
     match msg {
-        ExecuteMsg::Swap(msg) => execute_forward(deps.borrow_mut(), &env, &info, msg),
+        ExecuteMsg::EuclidReceive(msg) => execute_forward(deps.borrow_mut(), &env, &info, msg),
         ExecuteMsg::Receive(msg) => execute_cw20_receive(deps.borrow_mut(), &env, &info, msg),
     }
 }

--- a/contracts/forwarding/astroport-forwarding/src/contract.rs
+++ b/contracts/forwarding/astroport-forwarding/src/contract.rs
@@ -2,13 +2,13 @@ use std::borrow::BorrowMut;
 
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::{Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError};
+use cosmwasm_std::{ensure, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError};
 
 use cw2::set_contract_version;
-use euclid::error::ContractError;
+use euclid::{error::ContractError, token::TokenType};
 
 use crate::{
-    execute::{execute_cw20_receive, execute_forward},
+    execute::{execute_cw20_receive, receive_euclid_native, swap},
     reply::{on_astro_swap_reply, ASTRO_SWAP_REPLY_ID},
     state::{State, STATE},
 };
@@ -44,8 +44,22 @@ pub fn execute(
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
     match msg {
-        ExecuteMsg::EuclidReceive(msg) => execute_forward(deps.borrow_mut(), &env, &info, msg),
+        ExecuteMsg::EuclidReceive(msg) => {
+            receive_euclid_native(deps.borrow_mut(), &env, &info, msg)
+        }
         ExecuteMsg::Receive(msg) => execute_cw20_receive(deps.borrow_mut(), &env, &info, msg),
+        ExecuteMsg::Swap(swap_msg) => {
+            ensure!(
+                info.funds.len() == 1,
+                ContractError::new("only one token is supported")
+            );
+            let from_token = TokenType::Native {
+                denom: info.funds[0].denom.to_string(),
+            };
+            let from_amount = info.funds[0].amount;
+
+            swap(deps.borrow_mut(), &env, swap_msg, from_token, from_amount)
+        }
     }
 }
 

--- a/contracts/forwarding/astroport-forwarding/src/execute.rs
+++ b/contracts/forwarding/astroport-forwarding/src/execute.rs
@@ -5,6 +5,7 @@ use cosmwasm_std::{
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 use euclid::{
     error::ContractError,
+    events::simple_event,
     msgs::hook::{EuclidForwardSwap, EuclidReceive},
     token::TokenType,
 };
@@ -32,7 +33,10 @@ pub fn execute_cw20_receive(
     match msg {
         Cw20HookMsg::EuclidReceive(euclid_receive) => match euclid_receive {
             EuclidReceive::ForwardSwap(swap_msg) => {
-                swap(deps, env, info, swap_msg, from_token, amount)
+                let event =
+                    simple_event().add_attribute("meta", swap_msg.meta.clone().unwrap_or_default());
+                let response = swap(deps, env, info, swap_msg, from_token, amount)?;
+                Ok(response.add_event(event))
             }
         },
     }
@@ -55,7 +59,11 @@ pub fn execute_forward(
             };
             let from_amount = info.funds[0].amount;
 
-            swap(deps, env, info, swap_msg, from_token, from_amount)
+            let event =
+                simple_event().add_attribute("meta", swap_msg.meta.clone().unwrap_or_default());
+
+            let response = swap(deps, env, info, swap_msg, from_token, from_amount)?;
+            Ok(response.add_event(event))
         }
     }
 }
@@ -71,7 +79,7 @@ pub fn swap(
     let state = STATE.load(deps.storage)?;
     let swap_msg: SwapMsg = from_json(msg.data.clone())?;
 
-    let operations = swap_msg.operations;
+    let operations = swap_msg.operations.clone();
     ensure!(
         !operations.is_empty(),
         ContractError::new("min 1 operation is required")
@@ -79,13 +87,13 @@ pub fn swap(
 
     let astro_execute_msg = AstroportExecuteMsg::ExecuteSwapOperations {
         operations,
-        minimum_receive: Some(msg.minimum_receive),
+        minimum_receive: Some(swap_msg.minimum_receive),
         // Contract will receive the tokens
         to: Some(env.contract.address.to_string()),
         max_spread: swap_msg.max_spread,
     };
 
-    let previous_balance = msg
+    let previous_balance = swap_msg
         .to_token
         .get_balance(deps.as_ref(), env.contract.address.to_string())?;
 
@@ -95,7 +103,7 @@ pub fn swap(
             from_token: from_token.clone(),
             from_amount,
             previous_balance,
-            msg,
+            swap_msg,
         },
     )?;
 

--- a/contracts/forwarding/astroport-forwarding/src/execute.rs
+++ b/contracts/forwarding/astroport-forwarding/src/execute.rs
@@ -33,8 +33,10 @@ pub fn execute_cw20_receive(
     match msg {
         Cw20HookMsg::EuclidReceive(euclid_receive) => match euclid_receive {
             EuclidReceive::ForwardSwap(swap_msg) => {
-                let event =
-                    simple_event().add_attribute("meta", swap_msg.meta.clone().unwrap_or_default());
+                let event = simple_event().add_attribute(
+                    "meta",
+                    swap_msg.meta.clone().unwrap_or("no_meta".to_string()),
+                );
                 let response = swap(deps, env, info, swap_msg, from_token, amount)?;
                 Ok(response.add_event(event))
             }
@@ -59,8 +61,10 @@ pub fn execute_forward(
             };
             let from_amount = info.funds[0].amount;
 
-            let event =
-                simple_event().add_attribute("meta", swap_msg.meta.clone().unwrap_or_default());
+            let event = simple_event().add_attribute(
+                "meta",
+                swap_msg.meta.clone().unwrap_or("no_meta".to_string()),
+            );
 
             let response = swap(deps, env, info, swap_msg, from_token, from_amount)?;
             Ok(response.add_event(event))

--- a/contracts/forwarding/astroport-forwarding/src/execute.rs
+++ b/contracts/forwarding/astroport-forwarding/src/execute.rs
@@ -3,7 +3,11 @@ use cosmwasm_std::{
     WasmMsg,
 };
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
-use euclid::{error::ContractError, token::TokenType};
+use euclid::{
+    error::ContractError,
+    msgs::hook::{EuclidForwardSwap, EuclidReceive},
+    token::TokenType,
+};
 use forwarding::msgs::astroport::{Cw20HookMsg, SwapMsg};
 
 use astroport::router::ExecuteMsg as AstroportExecuteMsg;
@@ -26,7 +30,11 @@ pub fn execute_cw20_receive(
 
     let msg: Cw20HookMsg = from_json(msg.msg)?;
     match msg {
-        Cw20HookMsg::Swap(swap_msg) => swap(deps, env, info, swap_msg, from_token, amount),
+        Cw20HookMsg::EuclidReceive(euclid_receive) => match euclid_receive {
+            EuclidReceive::ForwardSwap(swap_msg) => {
+                swap(deps, env, info, swap_msg, from_token, amount)
+            }
+        },
     }
 }
 
@@ -34,33 +42,36 @@ pub fn execute_forward(
     deps: &mut DepsMut,
     env: &Env,
     info: &MessageInfo,
-    msg: SwapMsg,
+    euclid_receive: EuclidReceive,
 ) -> Result<Response, ContractError> {
-    ensure!(
-        info.funds.len() == 1,
-        ContractError::new("only one token is supported")
-    );
-    let from_token = TokenType::Native {
-        denom: info.funds[0].denom.to_string(),
-    };
-    let from_amount = info.funds[0].amount;
+    match euclid_receive {
+        EuclidReceive::ForwardSwap(swap_msg) => {
+            ensure!(
+                info.funds.len() == 1,
+                ContractError::new("only one token is supported")
+            );
+            let from_token = TokenType::Native {
+                denom: info.funds[0].denom.to_string(),
+            };
+            let from_amount = info.funds[0].amount;
 
-    swap(deps, env, info, msg, from_token, from_amount)
+            swap(deps, env, info, swap_msg, from_token, from_amount)
+        }
+    }
 }
 
 pub fn swap(
     deps: &mut DepsMut,
     env: &Env,
     _info: &MessageInfo,
-    swap_msg: SwapMsg,
+    msg: EuclidForwardSwap,
     from_token: TokenType,
     from_amount: Uint128,
 ) -> Result<Response, ContractError> {
     let state = STATE.load(deps.storage)?;
+    let swap_msg: SwapMsg = from_json(msg.data.clone())?;
 
-    let operations = swap_msg
-        .operations
-        .ok_or(ContractError::new("operations is required"))?;
+    let operations = swap_msg.operations;
     ensure!(
         !operations.is_empty(),
         ContractError::new("min 1 operation is required")
@@ -68,12 +79,13 @@ pub fn swap(
 
     let astro_execute_msg = AstroportExecuteMsg::ExecuteSwapOperations {
         operations,
-        minimum_receive: Some(swap_msg.minimum_receive),
-        to: None,
+        minimum_receive: Some(msg.minimum_receive),
+        // Contract will receive the tokens
+        to: Some(env.contract.address.to_string()),
         max_spread: swap_msg.max_spread,
     };
 
-    let previous_balance = swap_msg
+    let previous_balance = msg
         .to_token
         .get_balance(deps.as_ref(), env.contract.address.to_string())?;
 
@@ -81,16 +93,13 @@ pub fn swap(
         deps.storage,
         &ForwardingState {
             from_token: from_token.clone(),
-            to_token: swap_msg.to_token,
             from_amount,
             previous_balance,
-            min_received: swap_msg.minimum_receive,
-            forwarding_message: swap_msg.forwarding_message,
-            reciepient: swap_msg.reciepient,
+            msg,
         },
     )?;
 
-    let msg = match from_token {
+    let msg = match &from_token {
         TokenType::Native { denom } => WasmMsg::Execute {
             contract_addr: state.astro_router_address.to_string(),
             msg: to_json_binary(&astro_execute_msg)?,
@@ -103,7 +112,7 @@ pub fn swap(
                 msg: to_json_binary(&astro_execute_msg)?,
             };
             WasmMsg::Execute {
-                contract_addr: contract_address,
+                contract_addr: contract_address.to_string(),
                 msg: to_json_binary(&send_msg)?,
                 funds: vec![],
             }
@@ -111,5 +120,9 @@ pub fn swap(
         _ => return Err(ContractError::new("unsupported token type")),
     };
 
-    Ok(Response::new().add_submessage(SubMsg::reply_always(msg, ASTRO_SWAP_REPLY_ID)))
+    Ok(Response::new()
+        .add_attribute("dex", "astroport")
+        .add_attribute("start_swap_amount", from_amount)
+        .add_attribute("start_swap_token", from_token.get_key())
+        .add_submessage(SubMsg::reply_always(msg, ASTRO_SWAP_REPLY_ID)))
 }

--- a/contracts/forwarding/astroport-forwarding/src/execute.rs
+++ b/contracts/forwarding/astroport-forwarding/src/execute.rs
@@ -4,12 +4,11 @@ use cosmwasm_std::{
 };
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 use euclid::{
-    error::ContractError,
-    events::simple_event,
-    msgs::hook::{EuclidForwardSwap, EuclidReceive},
-    token::TokenType,
+    error::ContractError, events::simple_event, msgs::hook::EuclidReceive, token::TokenType,
 };
-use forwarding::msgs::astroport::{Cw20HookMsg, SwapMsg};
+use forwarding::msgs::{
+    astroport::SwapMsg, cw20::Cw20HookMsg, euclid_receive::AstroportEuclidReceiveHook,
+};
 
 use astroport::router::ExecuteMsg as AstroportExecuteMsg;
 
@@ -22,51 +21,68 @@ pub fn execute_cw20_receive(
     deps: &mut DepsMut,
     env: &Env,
     info: &MessageInfo,
-    msg: Cw20ReceiveMsg,
+    receive_msg: Cw20ReceiveMsg,
 ) -> Result<Response, ContractError> {
-    let amount = msg.amount;
+    let amount = receive_msg.amount;
     let from_token = TokenType::Smart {
         contract_address: info.sender.to_string(),
     };
 
-    let msg: Cw20HookMsg = from_json(msg.msg)?;
+    let msg: Cw20HookMsg = from_json(receive_msg.msg)?;
     match msg {
-        Cw20HookMsg::EuclidReceive(euclid_receive) => match euclid_receive {
-            EuclidReceive::ForwardSwap(swap_msg) => {
-                let event = simple_event().add_attribute(
-                    "meta",
-                    swap_msg.meta.clone().unwrap_or("no_meta".to_string()),
-                );
-                let response = swap(deps, env, info, swap_msg, from_token, amount)?;
-                Ok(response.add_event(event))
-            }
-        },
+        Cw20HookMsg::EuclidReceive(euclid_receive) => receive_euclid_cw20(
+            deps,
+            env,
+            info,
+            receive_msg.sender.to_string(),
+            euclid_receive,
+            amount,
+        ),
+        Cw20HookMsg::Swap(swap_msg) => swap(deps, env, swap_msg, from_token, amount),
     }
 }
 
-pub fn execute_forward(
+pub fn receive_euclid_native(
     deps: &mut DepsMut,
     env: &Env,
     info: &MessageInfo,
     euclid_receive: EuclidReceive,
 ) -> Result<Response, ContractError> {
-    match euclid_receive {
-        EuclidReceive::ForwardSwap(swap_msg) => {
-            ensure!(
-                info.funds.len() == 1,
-                ContractError::new("only one token is supported")
-            );
-            let from_token = TokenType::Native {
-                denom: info.funds[0].denom.to_string(),
-            };
-            let from_amount = info.funds[0].amount;
-
+    match from_json::<AstroportEuclidReceiveHook>(euclid_receive.data.clone())? {
+        AstroportEuclidReceiveHook::Swap(swap_msg) => {
+            let response = crate::contract::execute(
+                deps.branch(),
+                env.clone(),
+                info.clone(),
+                forwarding::msgs::astroport::ExecuteMsg::Swap(swap_msg),
+            )?;
             let event = simple_event().add_attribute(
                 "meta",
-                swap_msg.meta.clone().unwrap_or("no_meta".to_string()),
+                euclid_receive.meta.clone().unwrap_or("no_meta".to_string()),
             );
+            Ok(response.add_event(event))
+        }
+    }
+}
 
-            let response = swap(deps, env, info, swap_msg, from_token, from_amount)?;
+pub fn receive_euclid_cw20(
+    deps: &mut DepsMut,
+    env: &Env,
+    _info: &MessageInfo,
+    sender: String,
+    euclid_receive: EuclidReceive,
+    amount: Uint128,
+) -> Result<Response, ContractError> {
+    match from_json::<AstroportEuclidReceiveHook>(euclid_receive.data.clone())? {
+        AstroportEuclidReceiveHook::Swap(swap_msg) => {
+            let from_token = TokenType::Smart {
+                contract_address: sender.to_string(),
+            };
+            let response = swap(deps, env, swap_msg, from_token, amount)?;
+            let event = simple_event().add_attribute(
+                "meta",
+                euclid_receive.meta.clone().unwrap_or("no_meta".to_string()),
+            );
             Ok(response.add_event(event))
         }
     }
@@ -75,13 +91,11 @@ pub fn execute_forward(
 pub fn swap(
     deps: &mut DepsMut,
     env: &Env,
-    _info: &MessageInfo,
-    msg: EuclidForwardSwap,
+    swap_msg: SwapMsg,
     from_token: TokenType,
     from_amount: Uint128,
 ) -> Result<Response, ContractError> {
     let state = STATE.load(deps.storage)?;
-    let swap_msg: SwapMsg = from_json(msg.data.clone())?;
 
     let operations = swap_msg.operations.clone();
     ensure!(

--- a/contracts/forwarding/astroport-forwarding/src/reply.rs
+++ b/contracts/forwarding/astroport-forwarding/src/reply.rs
@@ -1,8 +1,5 @@
-use cosmwasm_std::{
-    ensure, from_json, to_json_binary, DepsMut, Env, Reply, Response, SubMsgResult,
-};
+use cosmwasm_std::{ensure, to_json_binary, DepsMut, Env, Reply, Response, SubMsgResult};
 use euclid::{error::ContractError, msgs::hook::EuclidReceiverMsg};
-use forwarding::msgs::astroport::SwapMsg;
 
 use crate::state::{ForwardingState, FORWARDING_STATE};
 
@@ -19,22 +16,21 @@ pub fn on_astro_swap_reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Respon
                 from_token,
                 from_amount,
                 previous_balance,
-                msg,
+                swap_msg,
             } = FORWARDING_STATE.load(deps.storage)?;
-            let swap_msg = from_json::<SwapMsg>(&msg.data)?;
 
             FORWARDING_STATE.remove(deps.storage);
 
-            let new_balance = msg
+            let new_balance = swap_msg
                 .to_token
                 .get_balance(deps.as_ref(), env.contract.address.to_string())?;
 
             let swap_amount = new_balance.checked_sub(previous_balance)?;
 
             ensure!(
-                swap_amount >= msg.minimum_receive,
+                swap_amount >= swap_msg.minimum_receive,
                 ContractError::MinReceived {
-                    expected: msg.minimum_receive,
+                    expected: swap_msg.minimum_receive,
                     received: swap_amount,
                 }
             );
@@ -46,9 +42,9 @@ pub fn on_astro_swap_reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Respon
                 None => None,
             };
 
-            let transfer_msg = msg.to_token.create_transfer_msg(
+            let transfer_msg = swap_msg.to_token.create_transfer_msg(
                 swap_amount,
-                msg.recipient,
+                swap_msg.recipient,
                 None,
                 forwading_msg,
             )?;
@@ -59,7 +55,7 @@ pub fn on_astro_swap_reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Respon
                 .add_attribute("complete_swap_in_amount", from_amount)
                 .add_attribute("complete_swap_in_token", from_token.get_key())
                 .add_attribute("complete_swap_out_amount", swap_amount)
-                .add_attribute("complete_swap_out_token", msg.to_token.get_key())
+                .add_attribute("complete_swap_out_token", swap_msg.to_token.get_key())
                 .add_message(transfer_msg))
         }
     }

--- a/contracts/forwarding/astroport-forwarding/src/reply.rs
+++ b/contracts/forwarding/astroport-forwarding/src/reply.rs
@@ -1,7 +1,10 @@
-use cosmwasm_std::{ensure, DepsMut, Env, Reply, Response, SubMsgResult};
-use euclid::error::ContractError;
+use cosmwasm_std::{
+    ensure, from_json, to_json_binary, DepsMut, Env, Reply, Response, SubMsgResult,
+};
+use euclid::{error::ContractError, msgs::hook::EuclidReceiverMsg};
+use forwarding::msgs::astroport::SwapMsg;
 
-use crate::state::FORWARDING_STATE;
+use crate::state::{ForwardingState, FORWARDING_STATE};
 
 pub const ASTRO_SWAP_REPLY_ID: u64 = 1;
 
@@ -12,32 +15,51 @@ pub fn on_astro_swap_reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Respon
             err
         ))),
         SubMsgResult::Ok(..) => {
-            let forwarding_state = FORWARDING_STATE.load(deps.storage)?;
+            let ForwardingState {
+                from_token,
+                from_amount,
+                previous_balance,
+                msg,
+            } = FORWARDING_STATE.load(deps.storage)?;
+            let swap_msg = from_json::<SwapMsg>(&msg.data)?;
+
             FORWARDING_STATE.remove(deps.storage);
-            let new_balance = forwarding_state
+
+            let new_balance = msg
                 .to_token
                 .get_balance(deps.as_ref(), env.contract.address.to_string())?;
 
-            let swap_amount = new_balance.checked_sub(forwarding_state.previous_balance)?;
+            let swap_amount = new_balance.checked_sub(previous_balance)?;
 
             ensure!(
-                swap_amount >= forwarding_state.min_received,
+                swap_amount >= msg.minimum_receive,
                 ContractError::MinReceived {
-                    expected: forwarding_state.min_received,
+                    expected: msg.minimum_receive,
                     received: swap_amount,
                 }
             );
 
-            let transfer_msg = forwarding_state.to_token.create_transfer_msg(
+            let forwading_msg = match swap_msg.forwarding_msg {
+                Some(forwarding_msg) => Some(to_json_binary(&EuclidReceiverMsg::EuclidReceive(
+                    forwarding_msg,
+                ))?),
+                None => None,
+            };
+
+            let transfer_msg = msg.to_token.create_transfer_msg(
                 swap_amount,
-                forwarding_state.reciepient.to_string(),
+                msg.recipient,
                 None,
-                forwarding_state.forwarding_message,
+                forwading_msg,
             )?;
 
             Ok(Response::new()
                 .add_attribute("action", "reply_astro_swap")
-                .add_attribute("swap_amount", swap_amount.to_string())
+                .add_attribute("dex", "astroport")
+                .add_attribute("complete_swap_in_amount", from_amount)
+                .add_attribute("complete_swap_in_token", from_token.get_key())
+                .add_attribute("complete_swap_out_amount", swap_amount)
+                .add_attribute("complete_swap_out_token", msg.to_token.get_key())
                 .add_message(transfer_msg))
         }
     }

--- a/contracts/forwarding/astroport-forwarding/src/state.rs
+++ b/contracts/forwarding/astroport-forwarding/src/state.rs
@@ -1,8 +1,8 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, Binary, Uint128};
+use cosmwasm_std::{Addr, Uint128};
 use cw_storage_plus::Item;
+use euclid::msgs::hook::EuclidForwardSwap;
 use euclid::token::TokenType;
-
 #[cw_serde]
 pub struct State {
     pub astro_router_address: Addr,
@@ -13,12 +13,9 @@ pub const STATE: Item<State> = Item::new("state");
 #[cw_serde]
 pub struct ForwardingState {
     pub from_token: TokenType,
-    pub to_token: TokenType,
     pub from_amount: Uint128,
     pub previous_balance: Uint128,
-    pub min_received: Uint128,
-    pub forwarding_message: Option<Binary>,
-    pub reciepient: Addr,
+    pub msg: EuclidForwardSwap,
 }
 
 pub const FORWARDING_STATE: Item<ForwardingState> = Item::new("forwarding_state");

--- a/contracts/forwarding/astroport-forwarding/src/state.rs
+++ b/contracts/forwarding/astroport-forwarding/src/state.rs
@@ -1,8 +1,8 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Uint128};
 use cw_storage_plus::Item;
-use euclid::msgs::hook::EuclidForwardSwap;
 use euclid::token::TokenType;
+use forwarding::msgs::astroport::SwapMsg;
 #[cw_serde]
 pub struct State {
     pub astro_router_address: Addr,
@@ -15,7 +15,7 @@ pub struct ForwardingState {
     pub from_token: TokenType,
     pub from_amount: Uint128,
     pub previous_balance: Uint128,
-    pub msg: EuclidForwardSwap,
+    pub swap_msg: SwapMsg,
 }
 
 pub const FORWARDING_STATE: Item<ForwardingState> = Item::new("forwarding_state");

--- a/contracts/hub/vlp/src/tests.rs
+++ b/contracts/hub/vlp/src/tests.rs
@@ -2,10 +2,10 @@
 #[cfg(test)]
 mod tests {
     use crate::contract::{execute, instantiate};
-    use crate::query::{calculate_lp_allocation, calculate_lp_allocation_for_liquidity};
+    use crate::query::calculate_lp_allocation_for_liquidity;
     use crate::state::{State, BALANCES, CHAIN_LP_TOKENS, STATE};
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-    use cosmwasm_std::{coins, Decimal256, DepsMut, Response, Uint128};
+    use cosmwasm_std::{coins, DepsMut, Response, Uint128};
     use euclid::chain::{ChainUid, CrossChainUser};
     use euclid::error::ContractError;
     use euclid::fee::{DenomFees, Fee, TotalFees};

--- a/contracts/liquidity/escrow/Cargo.toml
+++ b/contracts/liquidity/escrow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "escrow"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
   "gachouchani1999 <georgeschouchani1@gmail.com>",
   "Anshudhar Kumar Singh <anshudhar2001@gmail.com>",

--- a/contracts/liquidity/escrow/src/execute.rs
+++ b/contracts/liquidity/escrow/src/execute.rs
@@ -281,7 +281,7 @@ pub fn execute_withdraw(
 
         // Wrap the forwading message into EuclidReceive Cosmos Msg
         let forwarding_message = match &forwarding_message {
-            Some(forwarding_msg) => Some(forwarding_msg.to_cosmos_msg()?),
+            Some(forwarding_msg) => Some(forwarding_msg.to_receiver_msg()?),
             None => None,
         };
         let send_msg = denom.create_transfer_msg(

--- a/contracts/liquidity/escrow/src/execute.rs
+++ b/contracts/liquidity/escrow/src/execute.rs
@@ -1,10 +1,13 @@
 use cosmwasm_std::{
-    ensure, from_json, Addr, Binary, CosmosMsg, DepsMut, Env, MessageInfo, Response, SubMsg,
-    Uint128,
+    ensure, from_json, Addr, CosmosMsg, DepsMut, Env, MessageInfo, Response, SubMsg, Uint128,
 };
 
 use cw20::Cw20ReceiveMsg;
-use euclid::{error::ContractError, msgs::escrow::cw20::EscrowCw20HookMsg, token::TokenType};
+use euclid::{
+    error::ContractError,
+    msgs::{escrow::cw20::EscrowCw20HookMsg, hook::EuclidReceive},
+    token::TokenType,
+};
 
 use crate::{
     reply::FORWARDING_MESSAGE_REPLY_ID,
@@ -215,7 +218,7 @@ pub fn execute_withdraw(
     recipient: Addr,
     amount: Uint128,
     preferred_denom: Option<TokenType>,
-    forwarding_message: Option<Binary>,
+    forwarding_message: Option<EuclidReceive>,
     refund_address: Option<String>,
 ) -> Result<Response, ContractError> {
     // Clean any old refund address
@@ -276,6 +279,11 @@ pub fn execute_withdraw(
             &denom_balance.checked_sub(transfer_amount)?,
         )?;
 
+        // Wrap the forwading message into EuclidReceive Cosmos Msg
+        let forwarding_message = match &forwarding_message {
+            Some(forwarding_msg) => Some(forwarding_msg.to_cosmos_msg()?),
+            None => None,
+        };
         let send_msg = denom.create_transfer_msg(
             transfer_amount,
             recipient.to_string(),

--- a/contracts/liquidity/factory/Cargo.toml
+++ b/contracts/liquidity/factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factory"
-version = "0.2.2"
+version = "0.2.3"
 authors = [
   "gachouchani1999 <georgeschouchani1@gmail.com>",
   "Anshudhar Kumar Singh <anshudhar2001@gmail.com>",

--- a/contracts/liquidity/factory/src/bin/schema.rs
+++ b/contracts/liquidity/factory/src/bin/schema.rs
@@ -2,7 +2,10 @@ use std::env::current_dir;
 
 use cosmwasm_schema::{export_schema_with_title, schema_for, write_api};
 
-use euclid::msgs::factory::{cw20::FactoryCw20HookMsg, ExecuteMsg, InstantiateMsg, QueryMsg};
+use euclid::msgs::factory::{
+    cw20::FactoryCw20HookMsg, euclid_receive::FactoryEuclidReceiveHook, ExecuteMsg, InstantiateMsg,
+    QueryMsg,
+};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();
@@ -15,4 +18,9 @@ fn main() {
     }
 
     export_schema_with_title(&schema_for!(FactoryCw20HookMsg), &out_dir, "cw20receive");
+    export_schema_with_title(
+        &schema_for!(FactoryEuclidReceiveHook),
+        &out_dir,
+        "euclid-receive",
+    );
 }

--- a/contracts/liquidity/factory/src/contract.rs
+++ b/contracts/liquidity/factory/src/contract.rs
@@ -15,7 +15,7 @@ use crate::execute::{
     execute_request_deregister_denom, execute_request_pool_creation,
     execute_request_register_denom, execute_swap_request, execute_transfer_virtual_balance,
     execute_update_hub_channel, execute_update_state, execute_withdraw_virtual_balance,
-    receive_cw20,
+    receive_cw20, receive_euclid_native,
 };
 use crate::query::{
     get_escrow, get_lp_token_address, get_partner_fees_collected, get_vlp, pending_liquidity,
@@ -85,17 +85,7 @@ pub fn execute(
             slippage_tolerance_bps,
             timeout,
         ),
-        ExecuteMsg::ExecuteSwapRequest {
-            sender,
-            asset_in,
-            asset_out,
-            mut amount_in,
-            min_amount_out,
-            timeout,
-            swaps,
-            cross_chain_addresses,
-            partner_fee,
-        } => {
+        ExecuteMsg::ExecuteSwapRequest(msg) => {
             let state = STATE.load(deps.storage)?;
             let mut verified_sender = CrossChainUser {
                 address: info.sender.to_string(),
@@ -103,12 +93,12 @@ pub fn execute(
             };
 
             // If token is not a voucher, verify custom sender and use it. Using custom sender is security issue if voucher is used
-            if !asset_in.token_type.is_voucher() {
-                verified_sender = sender.unwrap_or(verified_sender);
+            if !msg.asset_in.token_type.is_voucher() {
+                verified_sender = msg.sender.unwrap_or(verified_sender);
             }
-
+            let mut amount_in = msg.amount_in;
             // If this asset is native, lets get the actual amount of funds sent because these amount can vary depending on forwarding contract swaps
-            if let TokenType::Native { denom } = &asset_in.token_type {
+            if let TokenType::Native { denom } = &msg.asset_in.token_type {
                 amount_in = info
                     .funds
                     .iter()
@@ -122,14 +112,14 @@ pub fn execute(
                 env,
                 info,
                 verified_sender,
-                asset_in,
+                msg.asset_in,
                 amount_in,
-                asset_out,
-                min_amount_out,
-                swaps,
-                timeout,
-                cross_chain_addresses,
-                partner_fee,
+                msg.asset_out,
+                msg.min_amount_out,
+                msg.swaps,
+                msg.timeout,
+                msg.cross_chain_addresses,
+                msg.partner_fee,
             )
         }
         ExecuteMsg::DepositToken {
@@ -221,6 +211,7 @@ pub fn execute(
             is_native,
         ),
         ExecuteMsg::Receive(msg) => receive_cw20(deps, env, info, msg),
+        ExecuteMsg::EuclidReceive(msg) => receive_euclid_native(deps, env, info, msg),
         ExecuteMsg::IbcCallbackAckAndTimeout { ack } => {
             ibc::ack_and_timeout::ibc_ack_packet_internal_call(deps, info, env, ack)
         }

--- a/contracts/liquidity/factory/src/execute.rs
+++ b/contracts/liquidity/factory/src/execute.rs
@@ -12,8 +12,11 @@ use euclid::{
     liquidity::{AddLiquidityRequest, RemoveLiquidityRequest},
     msgs::{
         escrow::{AllowedTokenResponse, QueryMsg as EscrowQueryMsg},
-        factory::{cw20::FactoryCw20HookMsg, ExecuteMsg, ExecuteSwapRequest},
-        hook::{EuclidForwardSwap, EuclidReceive},
+        factory::{
+            cw20::FactoryCw20HookMsg, euclid_receive::FactoryEuclidReceiveHook, ExecuteMsg,
+            ExecuteSwapRequest,
+        },
+        hook::EuclidReceive,
     },
     pool::{DenomRegisterDeregisterRequest, PoolCreateRequest},
     swap::{NextSwapPair, SwapRequest},
@@ -848,17 +851,42 @@ pub fn receive_euclid_native(
     info: MessageInfo,
     euclid_receive: EuclidReceive,
 ) -> Result<Response, ContractError> {
-    match euclid_receive {
-        EuclidReceive::ForwardSwap(EuclidForwardSwap { data, meta }) => {
-            let swap_msg = from_json::<ExecuteSwapRequest>(data)?;
+    match from_json::<FactoryEuclidReceiveHook>(euclid_receive.data.clone())? {
+        FactoryEuclidReceiveHook::Swap {
+            sender,
+            asset_in,
+            asset_out,
+            min_amount_out,
+            swaps,
+            timeout,
+            cross_chain_addresses,
+            partner_fee,
+        } => {
+            ensure!(
+                asset_in.token_type.is_native(),
+                ContractError::InvalidAsset {
+                    asset: asset_in.token.to_string(),
+                }
+            );
+            let swap_msg = ExecuteSwapRequest {
+                sender: sender.clone(),
+                asset_in,
+                amount_in: Uint128::zero(),
+                asset_out,
+                min_amount_out,
+                swaps,
+                timeout,
+                cross_chain_addresses,
+                partner_fee,
+            };
             let response = crate::contract::execute(
                 deps,
                 env,
                 info,
                 ExecuteMsg::ExecuteSwapRequest(swap_msg),
             )?;
-            let event =
-                simple_event().add_attribute("meta", meta.clone().unwrap_or("no_meta".to_string()));
+            let event = simple_event()
+                .add_attribute("meta", euclid_receive.meta.unwrap_or("no_meta".to_string()));
             Ok(response.add_event(event))
         }
     }
@@ -872,29 +900,39 @@ pub fn receive_euclid_cw20(
     amount: Uint128,
     euclid_msg: EuclidReceive,
 ) -> Result<Response, ContractError> {
-    match euclid_msg {
-        EuclidReceive::ForwardSwap(EuclidForwardSwap { data, meta }) => {
-            let swap_msg = from_json::<ExecuteSwapRequest>(data)?;
+    match from_json::<FactoryEuclidReceiveHook>(euclid_msg.data.clone())? {
+        FactoryEuclidReceiveHook::Swap {
+            sender: _sender,
+            asset_in,
+            asset_out,
+            min_amount_out,
+            swaps,
+            timeout,
+            cross_chain_addresses,
+            partner_fee,
+        } => {
             ensure!(
-                info.sender == swap_msg.asset_in.token_type.get_smart_contract_address()?,
+                info.sender == asset_in.token_type.get_smart_contract_address()?,
                 ContractError::Unauthorized {}
             );
             let response = execute_swap_request(
                 &mut deps,
                 env,
                 info,
-                sender,
-                swap_msg.asset_in,
+                _sender.unwrap_or(sender),
+                asset_in,
                 amount,
-                swap_msg.asset_out,
-                swap_msg.min_amount_out,
-                swap_msg.swaps,
-                swap_msg.timeout,
-                swap_msg.cross_chain_addresses,
-                swap_msg.partner_fee,
+                asset_out,
+                min_amount_out,
+                swaps,
+                timeout,
+                cross_chain_addresses,
+                partner_fee,
             )?;
-            let event =
-                simple_event().add_attribute("meta", meta.clone().unwrap_or("no_meta".to_string()));
+            let event = simple_event().add_attribute(
+                "meta",
+                euclid_msg.meta.clone().unwrap_or("no_meta".to_string()),
+            );
             Ok(response.add_event(event))
         }
     }

--- a/contracts/liquidity/factory/src/execute.rs
+++ b/contracts/liquidity/factory/src/execute.rs
@@ -287,7 +287,7 @@ pub fn add_liquidity_request(
     let tokens = pair_info.get_vec_token_info();
     for token in tokens {
         // validate token
-        token.token_type.validate(deps.as_ref())?;
+        token.token_type.validate(&deps.as_ref())?;
 
         // Ensure liquidity is not zero
         ensure!(!token.amount.is_zero(), ContractError::ZeroAssetAmount {});
@@ -480,7 +480,7 @@ pub fn execute_swap_request(
     partner_fee: Option<PartnerFee>,
 ) -> Result<Response, ContractError> {
     // Validate asset in
-    asset_in.token_type.validate(deps.as_ref())?;
+    asset_in.token_type.validate(&deps.as_ref())?;
     asset_in.token.validate()?;
 
     let state = STATE.load(deps.storage)?;
@@ -657,7 +657,7 @@ pub fn execute_deposit_token(
 
     // Validate asset in
     asset_in.token.validate()?;
-    asset_in.token_type.validate(deps.as_ref())?;
+    asset_in.token_type.validate(&deps.as_ref())?;
 
     let tx_id = generate_tx(deps.branch(), &env, &sender)?;
     let channel = if !state.is_native {

--- a/contracts/liquidity/factory/src/execute.rs
+++ b/contracts/liquidity/factory/src/execute.rs
@@ -7,12 +7,13 @@ use euclid::{
     chain::{CrossChainUser, CrossChainUserWithLimit},
     deposit::DepositTokenRequest,
     error::ContractError,
-    events::{deposit_token_event, swap_event, tx_event, TxType},
+    events::{deposit_token_event, simple_event, swap_event, tx_event, TxType},
     fee::{PartnerFee, BPS_100_PERCENT, MAX_PARTNER_FEE_BPS},
     liquidity::{AddLiquidityRequest, RemoveLiquidityRequest},
     msgs::{
         escrow::{AllowedTokenResponse, QueryMsg as EscrowQueryMsg},
-        factory::cw20::FactoryCw20HookMsg,
+        factory::{cw20::FactoryCw20HookMsg, ExecuteMsg, ExecuteSwapRequest},
+        hook::{EuclidForwardSwap, EuclidReceive},
     },
     pool::{DenomRegisterDeregisterRequest, PoolCreateRequest},
     swap::{NextSwapPair, SwapRequest},
@@ -834,6 +835,65 @@ pub fn receive_cw20(
             execute_deposit_token(
                 &mut deps, env, info, sender, asset_in, amount_in, timeout, recipient,
             )
+        }
+        FactoryCw20HookMsg::EuclidReceive(euclid_receive) => {
+            receive_euclid_cw20(deps, env, info, sender, cw20_msg.amount, euclid_receive)
+        }
+    }
+}
+
+pub fn receive_euclid_native(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    euclid_receive: EuclidReceive,
+) -> Result<Response, ContractError> {
+    match euclid_receive {
+        EuclidReceive::ForwardSwap(EuclidForwardSwap { data, meta }) => {
+            let swap_msg = from_json::<ExecuteSwapRequest>(data)?;
+            let response = crate::contract::execute(
+                deps,
+                env,
+                info,
+                ExecuteMsg::ExecuteSwapRequest(swap_msg),
+            )?;
+            let event = simple_event().add_attribute("meta", meta.unwrap_or_default());
+            Ok(response.add_event(event))
+        }
+    }
+}
+
+pub fn receive_euclid_cw20(
+    mut deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    sender: CrossChainUser,
+    amount: Uint128,
+    euclid_msg: EuclidReceive,
+) -> Result<Response, ContractError> {
+    match euclid_msg {
+        EuclidReceive::ForwardSwap(EuclidForwardSwap { data, meta }) => {
+            let swap_msg = from_json::<ExecuteSwapRequest>(data)?;
+            ensure!(
+                info.sender == swap_msg.asset_in.token_type.get_smart_contract_address()?,
+                ContractError::Unauthorized {}
+            );
+            let response = execute_swap_request(
+                &mut deps,
+                env,
+                info,
+                sender,
+                swap_msg.asset_in,
+                amount,
+                swap_msg.asset_out,
+                swap_msg.min_amount_out,
+                swap_msg.swaps,
+                swap_msg.timeout,
+                swap_msg.cross_chain_addresses,
+                swap_msg.partner_fee,
+            )?;
+            let event = simple_event().add_attribute("meta", meta.unwrap_or_default());
+            Ok(response.add_event(event))
         }
     }
 }

--- a/contracts/liquidity/factory/src/execute.rs
+++ b/contracts/liquidity/factory/src/execute.rs
@@ -857,7 +857,8 @@ pub fn receive_euclid_native(
                 info,
                 ExecuteMsg::ExecuteSwapRequest(swap_msg),
             )?;
-            let event = simple_event().add_attribute("meta", meta.unwrap_or_default());
+            let event =
+                simple_event().add_attribute("meta", meta.clone().unwrap_or("no_meta".to_string()));
             Ok(response.add_event(event))
         }
     }
@@ -892,7 +893,8 @@ pub fn receive_euclid_cw20(
                 swap_msg.cross_chain_addresses,
                 swap_msg.partner_fee,
             )?;
-            let event = simple_event().add_attribute("meta", meta.unwrap_or_default());
+            let event =
+                simple_event().add_attribute("meta", meta.clone().unwrap_or("no_meta".to_string()));
             Ok(response.add_event(event))
         }
     }

--- a/packages/euclid/Cargo.toml
+++ b/packages/euclid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
     "gachouchani1999 <georgeschouchani1@gmail.com>",
     "Anshudhar Kumar Singh <anshudhar2001@gmail.com>",

--- a/packages/euclid/src/chain.rs
+++ b/packages/euclid/src/chain.rs
@@ -1,10 +1,10 @@
 use std::ops::Deref;
 
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{ensure, Binary, StdError, StdResult, Uint128};
+use cosmwasm_std::{ensure, StdError, StdResult, Uint128};
 use cw_storage_plus::{Key, KeyDeserialize, Prefixer, PrimaryKey};
 
-use crate::{error::ContractError, token::TokenType};
+use crate::{error::ContractError, msgs::hook::EuclidReceive, token::TokenType};
 
 #[cw_serde]
 #[derive(PartialOrd)]
@@ -108,7 +108,7 @@ impl CrossChainUser {
         limit: Option<Limit>,
         preferred_denom: Option<TokenType>,
         refund_address: Option<String>,
-        forwarding_message: Option<Binary>,
+        forwarding_message: Option<EuclidReceive>,
     ) -> CrossChainUserWithLimit {
         CrossChainUserWithLimit {
             user: self,
@@ -133,7 +133,7 @@ pub struct CrossChainUserWithLimit {
     pub limit: Option<Limit>,
     pub preferred_denom: Option<TokenType>,
     pub refund_address: Option<String>,
-    pub forwarding_message: Option<Binary>,
+    pub forwarding_message: Option<EuclidReceive>,
 }
 
 #[cw_serde]

--- a/packages/euclid/src/error.rs
+++ b/packages/euclid/src/error.rs
@@ -256,6 +256,9 @@ pub enum ContractError {
 
     #[error("Invalid Address: {address} {msg}")]
     InvalidAddress { address: String, msg: String },
+
+    #[error("Unsupported Euclid Receive Message")]
+    UnsupportedEuclidReceiveMessage {},
 }
 
 impl ContractError {

--- a/packages/euclid/src/msgs/escrow/msg.rs
+++ b/packages/euclid/src/msgs/escrow/msg.rs
@@ -1,6 +1,9 @@
-use crate::token::{Pair, Token, TokenType};
+use crate::{
+    msgs::hook::EuclidReceive,
+    token::{Pair, Token, TokenType},
+};
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Binary, Uint128};
+use cosmwasm_std::{Addr, Uint128};
 use cw20::Cw20ReceiveMsg;
 
 #[cw_serde]
@@ -31,7 +34,7 @@ pub enum ExecuteMsg {
         recipient: Addr,
         amount: Uint128,
         preferred_denom: Option<TokenType>,
-        forwarding_message: Option<Binary>,
+        forwarding_message: Option<EuclidReceive>,
         refund_address: Option<String>,
     },
 }

--- a/packages/euclid/src/msgs/factory/cw20.rs
+++ b/packages/euclid/src/msgs/factory/cw20.rs
@@ -4,6 +4,7 @@ use cosmwasm_std::Uint128;
 use crate::{
     chain::{CrossChainUser, CrossChainUserWithLimit},
     fee::PartnerFee,
+    msgs::hook::EuclidReceive,
     swap::NextSwapPair,
     token::{Pair, Token, TokenWithDenom},
 };
@@ -31,4 +32,5 @@ pub enum FactoryCw20HookMsg {
         // First element in array has highest priority
         cross_chain_addresses: Vec<CrossChainUserWithLimit>,
     },
+    EuclidReceive(EuclidReceive),
 }

--- a/packages/euclid/src/msgs/factory/euclid_receive.rs
+++ b/packages/euclid/src/msgs/factory/euclid_receive.rs
@@ -1,0 +1,23 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::Uint128;
+
+use crate::{
+    chain::{CrossChainUser, CrossChainUserWithLimit},
+    fee::PartnerFee,
+    swap::NextSwapPair,
+    token::{Token, TokenWithDenom},
+};
+
+#[cw_serde]
+pub enum FactoryEuclidReceiveHook {
+    Swap {
+        sender: Option<CrossChainUser>,
+        asset_in: TokenWithDenom,
+        asset_out: Token,
+        min_amount_out: Uint128,
+        swaps: Vec<NextSwapPair>,
+        timeout: Option<u64>,
+        cross_chain_addresses: Vec<CrossChainUserWithLimit>,
+        partner_fee: Option<PartnerFee>,
+    },
+}

--- a/packages/euclid/src/msgs/factory/mod.rs
+++ b/packages/euclid/src/msgs/factory/mod.rs
@@ -1,4 +1,5 @@
 pub mod cw20;
+pub mod euclid_receive;
 pub mod msg;
 
 pub use msg::*;

--- a/packages/euclid/src/msgs/factory/msg.rs
+++ b/packages/euclid/src/msgs/factory/msg.rs
@@ -2,6 +2,7 @@ use crate::{
     chain::{ChainUid, CrossChainUser, CrossChainUserWithLimit},
     fee::{DenomFees, PartnerFee},
     liquidity::{AddLiquidityRequest, RemoveLiquidityRequest},
+    msgs::hook::EuclidReceive,
     swap::{NextSwapPair, SwapRequest},
     token::{Pair, PairWithDenomAndAmount, Token, TokenType, TokenWithDenom},
     utils::pagination::Pagination,
@@ -28,18 +29,7 @@ pub enum ExecuteMsg {
         slippage_tolerance_bps: u64,
         timeout: Option<u64>,
     },
-    ExecuteSwapRequest {
-        sender: Option<CrossChainUser>,
-        asset_in: TokenWithDenom,
-        amount_in: Uint128,
-        asset_out: Token,
-        min_amount_out: Uint128,
-        timeout: Option<u64>,
-        swaps: Vec<NextSwapPair>,
-        // First element in array has highest priority
-        cross_chain_addresses: Vec<CrossChainUserWithLimit>,
-        partner_fee: Option<PartnerFee>,
-    },
+    ExecuteSwapRequest(ExecuteSwapRequest),
     RequestRegisterDenom {
         token: TokenWithDenom,
         timeout: Option<u64>,
@@ -92,6 +82,8 @@ pub enum ExecuteMsg {
     // Recieve CW20 TOKENS structure
     Receive(Cw20ReceiveMsg),
 
+    EuclidReceive(EuclidReceive),
+
     // IBC Callbacks
     IbcCallbackAckAndTimeout {
         ack: IbcPacketAckMsg,
@@ -103,6 +95,20 @@ pub enum ExecuteMsg {
     NativeReceiveCallback {
         msg: Binary,
     },
+}
+
+#[cw_serde]
+pub struct ExecuteSwapRequest {
+    pub sender: Option<CrossChainUser>,
+    pub asset_in: TokenWithDenom,
+    pub amount_in: Uint128,
+    pub asset_out: Token,
+    pub min_amount_out: Uint128,
+    pub timeout: Option<u64>,
+    pub swaps: Vec<NextSwapPair>,
+    // First element in array has highest priority
+    pub cross_chain_addresses: Vec<CrossChainUserWithLimit>,
+    pub partner_fee: Option<PartnerFee>,
 }
 
 #[cw_serde]

--- a/packages/euclid/src/msgs/hook.rs
+++ b/packages/euclid/src/msgs/hook.rs
@@ -4,12 +4,7 @@ use cosmwasm_std::{to_json_binary, Binary};
 use crate::error::ContractError;
 
 #[cw_serde]
-pub enum EuclidReceive {
-    ForwardSwap(EuclidForwardSwap),
-}
-
-#[cw_serde]
-pub struct EuclidForwardSwap {
+pub struct EuclidReceive {
     pub data: Binary,
     // Metadata to be logged into events for some off chain oracle/analytics
     pub meta: Option<String>,

--- a/packages/euclid/src/msgs/hook.rs
+++ b/packages/euclid/src/msgs/hook.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{to_json_binary, Binary, Uint128};
+use cosmwasm_std::{to_json_binary, Binary};
 
-use crate::{error::ContractError, token::TokenType};
+use crate::error::ContractError;
 
 #[cw_serde]
 pub enum EuclidReceive {
@@ -11,9 +11,8 @@ pub enum EuclidReceive {
 #[cw_serde]
 pub struct EuclidForwardSwap {
     pub data: Binary,
-    pub to_token: TokenType,
-    pub minimum_receive: Uint128,
-    pub recipient: String,
+    // Metadata to be logged into events for some off chain oracle/analytics
+    pub meta: Option<String>,
 }
 
 // This is just a helper to properly serialize the above message

--- a/packages/euclid/src/msgs/hook.rs
+++ b/packages/euclid/src/msgs/hook.rs
@@ -17,7 +17,7 @@ pub enum EuclidReceiverMsg {
 }
 
 impl EuclidReceive {
-    pub fn to_cosmos_msg(&self) -> Result<Binary, ContractError> {
+    pub fn to_receiver_msg(&self) -> Result<Binary, ContractError> {
         Ok(to_json_binary(&EuclidReceiverMsg::EuclidReceive(
             self.clone(),
         ))?)

--- a/packages/euclid/src/msgs/hook.rs
+++ b/packages/euclid/src/msgs/hook.rs
@@ -1,0 +1,31 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{to_json_binary, Binary, Uint128};
+
+use crate::{error::ContractError, token::TokenType};
+
+#[cw_serde]
+pub enum EuclidReceive {
+    ForwardSwap(EuclidForwardSwap),
+}
+
+#[cw_serde]
+pub struct EuclidForwardSwap {
+    pub data: Binary,
+    pub to_token: TokenType,
+    pub minimum_receive: Uint128,
+    pub recipient: String,
+}
+
+// This is just a helper to properly serialize the above message
+#[cw_serde]
+pub enum EuclidReceiverMsg {
+    EuclidReceive(EuclidReceive),
+}
+
+impl EuclidReceive {
+    pub fn to_cosmos_msg(&self) -> Result<Binary, ContractError> {
+        Ok(to_json_binary(&EuclidReceiverMsg::EuclidReceive(
+            self.clone(),
+        ))?)
+    }
+}

--- a/packages/euclid/src/msgs/mod.rs
+++ b/packages/euclid/src/msgs/mod.rs
@@ -4,3 +4,4 @@ pub mod factory;
 pub mod router;
 pub mod virtual_balance;
 pub mod vlp;
+pub mod hook;

--- a/packages/euclid/src/msgs/mod.rs
+++ b/packages/euclid/src/msgs/mod.rs
@@ -1,7 +1,7 @@
 pub mod cw20;
 pub mod escrow;
 pub mod factory;
+pub mod hook;
 pub mod router;
 pub mod virtual_balance;
 pub mod vlp;
-pub mod hook;

--- a/packages/euclid/src/token.rs
+++ b/packages/euclid/src/token.rs
@@ -274,7 +274,7 @@ impl TokenType {
     }
 
     /// Validates smart contract addresses, checks against empty denom and zero supply
-    pub fn validate(&self, deps: Deps) -> Result<(), ContractError> {
+    pub fn validate(&self, deps: &Deps) -> Result<(), ContractError> {
         if let Self::Native { denom } = &self {
             let potential_supply = deps.querier.query_supply(denom.clone())?;
             let non_zero_supply = !potential_supply.amount.is_zero();

--- a/packages/euclid/src/utils/fund_manager.rs
+++ b/packages/euclid/src/utils/fund_manager.rs
@@ -67,6 +67,15 @@ impl FundManager {
         );
         Ok(())
     }
+
+    /// Validate that there are n number of funds in the manager
+    pub fn validate_n_funds(&self, n: usize) -> Result<(), ContractError> {
+        ensure!(
+            self.funds.len() == n,
+            ContractError::new(&format!("Expected {} funds, got {}", n, self.funds.len()))
+        );
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/packages/forwarding/src/msgs/astroport.rs
+++ b/packages/forwarding/src/msgs/astroport.rs
@@ -1,8 +1,8 @@
 use astroport::router::SwapOperation;
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Binary, Decimal, Uint128};
+use cosmwasm_std::{Addr, Decimal};
 use cw20::Cw20ReceiveMsg;
-use euclid::token::TokenType;
+use euclid::msgs::hook::EuclidReceive;
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -12,13 +12,13 @@ pub struct InstantiateMsg {
 #[cw_serde]
 #[derive(cw_orch::ExecuteFns)]
 pub enum ExecuteMsg {
-    Swap(SwapMsg),
     Receive(Cw20ReceiveMsg),
+    EuclidReceive(EuclidReceive),
 }
 
 #[cw_serde]
 pub enum Cw20HookMsg {
-    Swap(SwapMsg),
+    EuclidReceive(EuclidReceive),
 }
 
 #[cw_serde]
@@ -27,10 +27,7 @@ pub enum QueryMsg {}
 
 #[cw_serde]
 pub struct SwapMsg {
-    pub operations: Option<Vec<SwapOperation>>,
+    pub operations: Vec<SwapOperation>,
     pub max_spread: Option<Decimal>,
-    pub minimum_receive: Uint128,
-    pub to_token: TokenType,
-    pub forwarding_message: Option<Binary>,
-    pub reciepient: Addr,
+    pub forwarding_msg: Option<EuclidReceive>,
 }

--- a/packages/forwarding/src/msgs/astroport.rs
+++ b/packages/forwarding/src/msgs/astroport.rs
@@ -14,11 +14,7 @@ pub struct InstantiateMsg {
 pub enum ExecuteMsg {
     Receive(Cw20ReceiveMsg),
     EuclidReceive(EuclidReceive),
-}
-
-#[cw_serde]
-pub enum Cw20HookMsg {
-    EuclidReceive(EuclidReceive),
+    Swap(SwapMsg),
 }
 
 #[cw_serde]

--- a/packages/forwarding/src/msgs/astroport.rs
+++ b/packages/forwarding/src/msgs/astroport.rs
@@ -1,8 +1,8 @@
 use astroport::router::SwapOperation;
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Decimal};
+use cosmwasm_std::{Addr, Decimal, Uint128};
 use cw20::Cw20ReceiveMsg;
-use euclid::msgs::hook::EuclidReceive;
+use euclid::{msgs::hook::EuclidReceive, token::TokenType};
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -30,4 +30,7 @@ pub struct SwapMsg {
     pub operations: Vec<SwapOperation>,
     pub max_spread: Option<Decimal>,
     pub forwarding_msg: Option<EuclidReceive>,
+    pub to_token: TokenType,
+    pub minimum_receive: Uint128,
+    pub recipient: String,
 }

--- a/packages/forwarding/src/msgs/cw20.rs
+++ b/packages/forwarding/src/msgs/cw20.rs
@@ -1,0 +1,10 @@
+use cosmwasm_schema::cw_serde;
+use euclid::msgs::hook::EuclidReceive;
+
+use super::astroport::SwapMsg;
+
+#[cw_serde]
+pub enum Cw20HookMsg {
+    EuclidReceive(EuclidReceive),
+    Swap(SwapMsg),
+}

--- a/packages/forwarding/src/msgs/euclid_receive.rs
+++ b/packages/forwarding/src/msgs/euclid_receive.rs
@@ -1,0 +1,8 @@
+use cosmwasm_schema::cw_serde;
+
+use super::astroport::SwapMsg;
+
+#[cw_serde]
+pub enum AstroportEuclidReceiveHook {
+    Swap(SwapMsg),
+}

--- a/packages/forwarding/src/msgs/mod.rs
+++ b/packages/forwarding/src/msgs/mod.rs
@@ -1,1 +1,3 @@
 pub mod astroport;
+pub mod cw20;
+pub mod euclid_receive;

--- a/tests-integration/src/tests/factory.rs
+++ b/tests-integration/src/tests/factory.rs
@@ -14,7 +14,9 @@ use euclid::{
     fee::{DenomFees, BPS_1_PERCENT},
     msgs::{
         escrow::StateResponse as EscrowStateResponse,
-        factory::{AllPoolsResponse, ExecuteMsgFns, PoolVlpResponse, StateResponse},
+        factory::{
+            AllPoolsResponse, ExecuteMsgFns, ExecuteSwapRequest, PoolVlpResponse, StateResponse,
+        },
         router::{
             RegisterFactoryChainIbc, RegisterFactoryChainNative, TokenDenom, TokenDenomsResponse,
             VlpResponse,
@@ -726,7 +728,7 @@ fn test_create_pool_with_funds() {
     };
     factory_nibiru
         .execute(
-            &euclid::msgs::factory::ExecuteMsg::ExecuteSwapRequest {
+            &euclid::msgs::factory::ExecuteMsg::ExecuteSwapRequest(ExecuteSwapRequest {
                 sender: None,
                 asset_in: eucl_token.clone(),
                 amount_in: Uint128::from(1_000u128),
@@ -749,7 +751,7 @@ fn test_create_pool_with_funds() {
                     forwarding_message: None,
                 }],
                 partner_fee: None,
-            },
+            }),
             Some(&[coin(1_000u128, "eucl")]),
         )
         .unwrap();


### PR DESCRIPTION
# Pull Request

## Description

Fix Vulnerability where forwarding message can execute any message on behalf of escrow. Now Forwarding messages are always typed as EuclidReceive and Contracts need to implement it to interact with Euclid related forwarding messages

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update
- [ ] Refactor/Chore

## Related Issue

[Link to related issue, if applicable]

## Testing

Steps to test:

1. [Step 1]
2. [Step 2]
3. [Step 3]

## Checklist

- [x] Self-review completed
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated (if applicable)

## Screenshots (if applicable)

[Add screenshots here]

## Additional Notes

[Any additional information or context]