### PR TITLE
Fix: LP share in pool ack and refund on failed ack pool creation

### DIFF
--- a/contracts/hub/stable_vlp/src/execute.rs
+++ b/contracts/hub/stable_vlp/src/execute.rs
@@ -415,6 +415,7 @@ pub fn execute_swap(
         .lp_fees
         .add_fee(asset_in.to_string(), lp_fee);
 
+
     // Calcuate the sum of fees
     let total_fee = lp_fee.checked_add(euclid_fee)?;
 
@@ -424,7 +425,7 @@ pub fn execute_swap(
     let amp_factor = AMP_FACTOR.load(deps.storage).unwrap_or(DEFAULT_AMP_FACTOR);
 
     let receive_amount = compute_swap(
-        &Decimal256::from_integer(amount_in),
+        &Decimal256::from_integer(swap_amount),
         &Decimal256::from_integer(token_in_reserve),
         &Decimal256::from_integer(token_out_reserve),
         amp_factor,

--- a/contracts/hub/stable_vlp/src/execute.rs
+++ b/contracts/hub/stable_vlp/src/execute.rs
@@ -415,7 +415,6 @@ pub fn execute_swap(
         .lp_fees
         .add_fee(asset_in.to_string(), lp_fee);
 
-
     // Calcuate the sum of fees
     let total_fee = lp_fee.checked_add(euclid_fee)?;
 

--- a/contracts/liquidity/factory/src/ibc/ack_and_timeout.rs
+++ b/contracts/liquidity/factory/src/ibc/ack_and_timeout.rs
@@ -190,7 +190,7 @@ fn ack_pool_creation(
     is_native: bool,
 ) -> Result<Response, ContractError> {
     let sender = deps.api.addr_validate(&sender)?;
-    let req_key = (sender, tx_id.clone());
+    let req_key = (sender.clone(), tx_id.clone());
     let existing_req = PENDING_POOL_REQUESTS
         .may_load(deps.storage, req_key.clone())?
         .ok_or(ContractError::PoolRequestDoesNotExists { req: tx_id.clone() })?;
@@ -309,10 +309,25 @@ fn ack_pool_creation(
             if is_native {
                 return Err(ContractError::new(&err));
             }
+            // Refund tokens back to sender
+            let mut msgs: Vec<CosmosMsg> = Vec::new();
+            for token_info in existing_req.pair_info.get_vec_token_info() {
+                if token_info.token_type.is_voucher() {
+                    continue;
+                }
+                let msg = token_info.token_type.create_transfer_msg(
+                    token_info.amount,
+                    sender.to_string(),
+                    None,
+                    None,
+                )?;
+                msgs.push(msg);
+            }
             Ok(Response::new()
                 .add_attribute("tx_id", tx_id)
                 .add_attribute("method", "reject_pool_request")
-                .add_attribute("error", err.clone()))
+                .add_attribute("error", err.clone())
+                .add_messages(msgs))
         }
     }
 }

--- a/contracts/liquidity/factory/src/ibc/ack_and_timeout.rs
+++ b/contracts/liquidity/factory/src/ibc/ack_and_timeout.rs
@@ -287,13 +287,15 @@ fn ack_pool_creation(
                     }],
                     mint: lp_token_instantiate_data.mint,
                     marketing: lp_token_instantiate_data.marketing,
-                    vlp: data.vlp_contract,
+                    vlp: data.vlp_contract.clone(),
                     factory: env.contract.address,
                     token_pair: existing_req.pair_info.get_pair()?,
                 })?,
                 funds: vec![],
                 label: "cw20".to_string(),
             });
+            // Save lp shares against vlp address
+            VLP_TO_LP_SHARES.save(deps.storage, data.vlp_contract, &data.mint_lp_tokens.into())?;
 
             Ok(res.add_submessage(SubMsg {
                 id: CW20_INSTANTIATE_REPLY_ID,

--- a/tests-integration/src/tests/factory.rs
+++ b/tests-integration/src/tests/factory.rs
@@ -3273,7 +3273,7 @@ fn test_stable_pool() {
                 token_2: Token::create("osmo".to_string()).unwrap(),
             },
             token_1_reserve: Uint128::new(10_999),
-            token_2_reserve: Uint128::new(9_009),
+            token_2_reserve: Uint128::new(9011),
             total_lp_tokens: Uint128::new(9000),
         }
     );


### PR DESCRIPTION
# Pull Request

## Description

Pool shares increment was missed in create pool ack causing negative share values in remove liquidity.
Also add refund on failed ack for pool creation
Fix bug in stable swap swap amount calculation without fee

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor/Chore

## Related Issue

[Link to related issue, if applicable]

## Testing

Steps to test:

1. [Step 1]
2. [Step 2]
3. [Step 3]

## Checklist

- [ ] Self-review completed
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated (if applicable)

## Screenshots (if applicable)

[Add screenshots here]

## Additional Notes

[Any additional information or context]