### PR TITLE
feat: Relayer Addresses Vector

### DIFF
--- a/contracts/hub/router/src/contract.rs
+++ b/contracts/hub/router/src/contract.rs
@@ -40,7 +40,7 @@ use crate::reply::{
     SOLANA_RECEIVE_REPLY_ID, SWAP_REPLY_ID, VIRTUAL_BALANCE_INSTANTIATE_REPLY_ID,
     VLP_INSTANTIATE_REPLY_ID, VLP_POOL_REGISTER_REPLY_ID,
 };
-use crate::state::{State, DEREGISTERED_CHAINS, MOCK_RELAYER_ADDRESS, STATE};
+use crate::state::{State, DEREGISTERED_CHAINS, MOCK_RELAYER_ADDRESSES, STATE};
 use euclid::msgs::router::{ExecuteMsg, InstantiateMsg, QueryMsg};
 
 // version info for migration info
@@ -63,8 +63,8 @@ pub fn instantiate(
     };
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
-    if let Some(mock_relayer_address) = msg.mock_relayer_address {
-        MOCK_RELAYER_ADDRESS.save(deps.storage, &mock_relayer_address)?;
+    if let Some(mock_relayer_addresses) = msg.mock_relayer_addresses {
+        MOCK_RELAYER_ADDRESSES.save(deps.storage, &mock_relayer_addresses)?;
     }
 
     STATE.save(deps.storage, &state)?;
@@ -168,7 +168,7 @@ pub fn execute(
                     stable_vlp_code_id,
                     virtual_balance_address,
                     locked,
-                    mock_relayer_address,
+                    mock_relayer_addresses,
                 } => execute_update_router_state(
                     deps,
                     info,
@@ -177,7 +177,7 @@ pub fn execute(
                     stable_vlp_code_id,
                     virtual_balance_address,
                     locked,
-                    mock_relayer_address,
+                    mock_relayer_addresses,
                 ),
                 ExecuteMsg::EvmSendPacket { msg, chain_uid } => {
                     execute_evm_send_packet(deps, info, env, chain_uid, msg)

--- a/contracts/hub/router/src/execute/base.rs
+++ b/contracts/hub/router/src/execute/base.rs
@@ -26,7 +26,7 @@ use crate::{
     query::verify_cross_chain_addresses,
     state::{
         State, CHAIN_UID_TO_CHAIN, CHANNEL_TO_CHAIN_UID, DEREGISTERED_CHAINS, ESCROW_BALANCES,
-        MOCK_RELAYER_ADDRESS, STATE, TOKEN_DENOMS,
+        MOCK_RELAYER_ADDRESSES, STATE, TOKEN_DENOMS,
     },
 };
 
@@ -484,7 +484,7 @@ pub fn execute_update_router_state(
     stable_vlp_code_id: Option<u64>,
     virtual_balance_address: Option<Addr>,
     locked: Option<bool>,
-    mock_relayer_address: Option<String>,
+    mock_relayer_addresses: Option<Vec<String>>,
 ) -> Result<Response, ContractError> {
     let state = STATE.load(deps.storage)?;
     ensure!(info.sender == state.admin, ContractError::Unauthorized {});
@@ -517,9 +517,16 @@ pub fn execute_update_router_state(
 
     let mut response = Response::new();
 
-    if let Some(ref mock_relayer_address) = mock_relayer_address {
-        MOCK_RELAYER_ADDRESS.save(deps.storage, mock_relayer_address)?;
-        response = response.add_attribute("mock_relayer_update", mock_relayer_address);
+    if let Some(ref mock_relayer_addresses) = mock_relayer_addresses {
+        MOCK_RELAYER_ADDRESSES.save(deps.storage, mock_relayer_addresses)?;
+        response = response.add_attribute(
+            "mock_relayer_update",
+            mock_relayer_addresses
+                .iter()
+                .map(|x| x.to_string())
+                .collect::<Vec<String>>()
+                .join(","),
+        );
     }
 
     Ok(response

--- a/contracts/hub/router/src/execute/cosmos.rs
+++ b/contracts/hub/router/src/execute/cosmos.rs
@@ -19,7 +19,7 @@ use crate::{
     reply::COSMOS_RECEIVE_REPLY_ID,
     state::{
         CHAIN_UID_TO_CHAIN, COSMOS_PACKET_RELAY_MAP, COSMOS_PACKET_RELAY_SEQUENCE_COUNT,
-        MOCK_RELAYER_ADDRESS,
+        MOCK_RELAYER_ADDRESSES,
     },
 };
 
@@ -65,7 +65,9 @@ pub fn execute_cosmos_receive_packet(
     hash: String,
 ) -> Result<Response, ContractError> {
     ensure!(
-        info.sender == MOCK_RELAYER_ADDRESS.load(deps.storage)?,
+        MOCK_RELAYER_ADDRESSES
+            .load(deps.storage)?
+            .contains(&info.sender.to_string()),
         ContractError::Unauthorized {}
     );
 
@@ -130,7 +132,9 @@ pub fn execute_cosmos_receive_acknowledgement(
     ack: Binary,
 ) -> Result<Response, ContractError> {
     ensure!(
-        info.sender == MOCK_RELAYER_ADDRESS.load(deps.storage)?,
+        MOCK_RELAYER_ADDRESSES
+            .load(deps.storage)?
+            .contains(&info.sender.to_string()),
         ContractError::Unauthorized {}
     );
     let _existing_request =

--- a/contracts/hub/router/src/execute/evm.rs
+++ b/contracts/hub/router/src/execute/evm.rs
@@ -19,7 +19,7 @@ use crate::{
     reply::EVM_RECEIVE_REPLY_ID,
     state::{
         CHAIN_UID_TO_CHAIN, EVM_PACKET_RELAY_MAP, EVM_PACKET_RELAY_SEQUENCE_COUNT,
-        MOCK_RELAYER_ADDRESS,
+        MOCK_RELAYER_ADDRESSES,
     },
 };
 
@@ -65,7 +65,9 @@ pub fn execute_evm_receive_packet(
     hash: String,
 ) -> Result<Response, ContractError> {
     ensure!(
-        info.sender == MOCK_RELAYER_ADDRESS.load(deps.storage)?,
+        MOCK_RELAYER_ADDRESSES
+            .load(deps.storage)?
+            .contains(&info.sender.to_string()),
         ContractError::Unauthorized {}
     );
 
@@ -130,7 +132,9 @@ pub fn execute_evm_receive_acknowledgement(
     ack: Binary,
 ) -> Result<Response, ContractError> {
     ensure!(
-        info.sender == MOCK_RELAYER_ADDRESS.load(deps.storage)?,
+        MOCK_RELAYER_ADDRESSES
+            .load(deps.storage)?
+            .contains(&info.sender.to_string()),
         ContractError::Unauthorized {}
     );
     let _existing_request =

--- a/contracts/hub/router/src/execute/solana.rs
+++ b/contracts/hub/router/src/execute/solana.rs
@@ -18,7 +18,7 @@ use crate::{
     ibc::{ack_and_timeout, receive},
     reply::SOLANA_RECEIVE_REPLY_ID,
     state::{
-        CHAIN_UID_TO_CHAIN, MOCK_RELAYER_ADDRESS, SOLANA_PACKET_RELAY_MAP,
+        CHAIN_UID_TO_CHAIN, MOCK_RELAYER_ADDRESSES, SOLANA_PACKET_RELAY_MAP,
         SOLANA_PACKET_RELAY_SEQUENCE_COUNT,
     },
 };
@@ -65,7 +65,9 @@ pub fn execute_solana_receive_packet(
     hash: String,
 ) -> Result<Response, ContractError> {
     ensure!(
-        info.sender == MOCK_RELAYER_ADDRESS.load(deps.storage)?,
+        MOCK_RELAYER_ADDRESSES
+            .load(deps.storage)?
+            .contains(&info.sender.to_string()),
         ContractError::Unauthorized {}
     );
     let chain = CHAIN_UID_TO_CHAIN.load(deps.storage, chain_uid.clone())?;
@@ -129,7 +131,9 @@ pub fn execute_solana_receive_acknowledgement(
     ack: Binary,
 ) -> Result<Response, ContractError> {
     ensure!(
-        info.sender == MOCK_RELAYER_ADDRESS.load(deps.storage)?,
+        MOCK_RELAYER_ADDRESSES
+            .load(deps.storage)?
+            .contains(&info.sender.to_string()),
         ContractError::Unauthorized {}
     );
     let _existing_request =

--- a/contracts/hub/router/src/mock.rs
+++ b/contracts/hub/router/src/mock.rs
@@ -27,7 +27,7 @@ impl MockRouter {
             vlp_code_id,
             stable_vlp_code_id,
             virtual_balance_code_id,
-            Some(sender.to_string()),
+            Some(vec![sender.to_string()]),
         );
         let res = app.instantiate_contract(code_id, sender, &msg, &[], "Euclid router", None);
 
@@ -65,13 +65,13 @@ pub fn mock_router_instantiate_msg(
     constant_product_vlp_code_id: u64,
     stable_vlp_code_id: u64,
     virtual_balance_code_id: u64,
-    mock_relayer_address: Option<String>,
+    mock_relayer_addresses: Option<Vec<String>>,
 ) -> InstantiateMsg {
     InstantiateMsg {
         constant_product_vlp_code_id,
         stable_vlp_code_id,
         virtual_balance_code_id,
-        mock_relayer_address,
+        mock_relayer_addresses,
     }
 }
 

--- a/contracts/hub/router/src/state.rs
+++ b/contracts/hub/router/src/state.rs
@@ -22,7 +22,7 @@ pub struct State {
 
 pub const STATE: Item<State> = Item::new("state");
 
-pub const MOCK_RELAYER_ADDRESS: Item<String> = Item::new("mock_relayer_address");
+pub const MOCK_RELAYER_ADDRESSES: Item<Vec<String>> = Item::new("mock_relayer_addresses");
 
 // Convert it to multi index map?
 pub const VLPS: Map<(Token, Token), String> = Map::new("vlps");

--- a/contracts/hub/router/src/tests.rs
+++ b/contracts/hub/router/src/tests.rs
@@ -22,7 +22,7 @@ mod tests {
             constant_product_vlp_code_id: 1,
             stable_vlp_code_id: 3,
             virtual_balance_code_id: 2,
-            mock_relayer_address: None,
+            mock_relayer_addresses: None,
         };
         instantiate(deps, mock_env(), info, msg).unwrap()
     }
@@ -56,7 +56,7 @@ mod tests {
             constant_product_vlp_code_id: 1,
             stable_vlp_code_id: 3,
             virtual_balance_code_id: 2,
-            mock_relayer_address: None,
+            mock_relayer_addresses: None,
         };
         instantiate(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
 
@@ -208,7 +208,7 @@ mod tests {
             stable_vlp_code_id: Some(0),
             virtual_balance_address: Some(Addr::unchecked("new_virtual_balance_address")),
             locked: Some(true),
-            mock_relayer_address: Some("new_mock_relayer_address".to_string()),
+            mock_relayer_addresses: Some(vec!["new_mock_relayer_address".to_string()]),
         };
         let info = mock_info("not_owner", &[]);
         let err = execute(deps.as_mut(), env.clone(), info, msg.clone()).unwrap_err();

--- a/contracts/liquidity/factory/src/execute/cosmos.rs
+++ b/contracts/liquidity/factory/src/execute/cosmos.rs
@@ -132,7 +132,7 @@ pub fn execute_cosmos_receive_acknowledgement(
     // Remove the existing request as its already relayed now
     COSMOS_PACKET_RELAY_MAP.remove(deps.storage, sequence);
 
-    let chain_type = euclid::chain::ChainType::Ibc(IbcChain {
+    let _chain_type = euclid::chain::ChainType::Ibc(IbcChain {
         from_hub_channel: "".to_string(),
         from_factory_channel: "".to_string(),
     });

--- a/contracts/liquidity/factory/src/ibc/receive.rs
+++ b/contracts/liquidity/factory/src/ibc/receive.rs
@@ -168,7 +168,7 @@ fn execute_update_factory_channel(
 
 fn execute_release_escrow(
     deps: DepsMut,
-    env: Env,
+    _env: Env,
     amount: Uint128,
     recipient: CrossChainUserWithLimit,
     token: Token,

--- a/packages/euclid/src/msgs/router.rs
+++ b/packages/euclid/src/msgs/router.rs
@@ -13,7 +13,7 @@ pub struct InstantiateMsg {
     pub stable_vlp_code_id: u64,
 
     pub virtual_balance_code_id: u64,
-    pub mock_relayer_address: Option<String>,
+    pub mock_relayer_addresses: Option<Vec<String>>,
 }
 
 #[cw_serde]
@@ -69,7 +69,7 @@ pub enum ExecuteMsg {
         stable_vlp_code_id: Option<u64>,
         virtual_balance_address: Option<Addr>,
         locked: Option<bool>,
-        mock_relayer_address: Option<String>,
+        mock_relayer_addresses: Option<Vec<String>>,
     },
 
     EvmSendPacket {

--- a/packages/euclid_ibc/src/msg.rs
+++ b/packages/euclid_ibc/src/msg.rs
@@ -1,9 +1,7 @@
 use std::ops::Add;
 
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{
-    ensure, to_json_binary, CosmosMsg, DepsMut, Env, IbcMsg, IbcTimeout, SubMsg, Uint128, WasmMsg,
-};
+use cosmwasm_std::{ensure, to_json_binary, DepsMut, Env, SubMsg, Uint128, WasmMsg};
 use cw_storage_plus::{Item, Map};
 use euclid::{
     chain::{Chain, ChainType, ChainUid, CrossChainUser, CrossChainUserWithLimit},

--- a/tests-integration/src/helpers/chains.rs
+++ b/tests-integration/src/helpers/chains.rs
@@ -127,7 +127,7 @@ pub fn setup_router(chain: &MockBase) -> RouterContract<MockBase> {
                 constant_product_vlp_code_id: vlp.code_id().unwrap(),
                 stable_vlp_code_id: stable_vlp.code_id().unwrap(),
                 virtual_balance_code_id: virtual_balance.code_id().unwrap(),
-                mock_relayer_address: Some(router.environment().sender.to_string()),
+                mock_relayer_addresses: Some(vec![router.environment().sender.to_string()]),
             },
             None,
             None,

--- a/tests-integration/src/helpers/factory.rs
+++ b/tests-integration/src/helpers/factory.rs
@@ -2,28 +2,24 @@
 
 use cosmwasm_std::{coin, Uint128};
 use cw20::Cw20Contract;
-use cw_orch::mock::MockBase;
-use cw_orch::prelude::*;
-
-use cw_orch_interchain::IbcQueryHandler;
-use euclid::chain::{CrossChainUser, CrossChainUserWithLimit};
-use euclid::fee::PartnerFee;
-use euclid::msgs::cw20::ExecuteMsgFns;
-use euclid::msgs::factory::{
-    ExecuteMsgFns as FactoryExecuteMsgFns, ExecuteSwapRequest, QueryMsgFns as FactoryQueryMsgFns,
+use cw_orch::{mock::MockBase, prelude::*};
+use cw_orch_interchain::{IbcQueryHandler, InterchainEnv, MockInterchainEnv};
+use euclid::{
+    chain::{CrossChainUser, CrossChainUserWithLimit},
+    fee::PartnerFee,
+    msgs::{
+        cw20::ExecuteMsgFns,
+        factory::{
+            ExecuteMsgFns as FactoryExecuteMsgFns, ExecuteSwapRequest,
+            QueryMsgFns as FactoryQueryMsgFns,
+        },
+    },
+    pool::PoolConfig,
+    swap::NextSwapPair,
+    token::{PairWithDenomAndAmount, Token, TokenType, TokenWithDenom},
 };
-
-use cw_orch_interchain::InterchainEnv;
-use cw_orch_interchain::MockInterchainEnv;
-use euclid::msgs::router::QueryMsgFns;
-use euclid::pool::PoolConfig;
-use euclid::swap::NextSwapPair;
-use euclid::token::TokenType;
-use euclid::token::TokenWithDenom;
-use euclid::token::{PairWithDenomAndAmount, Token};
 use factory::FactoryContract;
 use router::RouterContract;
-use vlp::VlpContract;
 
 use crate::helpers::relayer::relay_factory_router_factory;
 
@@ -154,7 +150,7 @@ pub fn add_liquidity(
 }
 
 pub fn swap_request(
-    interchain: &MockInterchainEnv,
+    _interchain: &MockInterchainEnv,
     factory: &FactoryContract<MockBase>,
     router: &RouterContract<MockBase>,
     sender: Option<CrossChainUser>,

--- a/tests-integration/src/helpers/relayer.rs
+++ b/tests-integration/src/helpers/relayer.rs
@@ -1,5 +1,5 @@
-use cosmwasm_std::{from_binary, from_json, Binary, Event};
-use cw_orch::{core::serde_json::from_str, mock::MockBase};
+use cosmwasm_std::{from_json, Binary, Event};
+use cw_orch::mock::MockBase;
 use euclid::{
     chain::ChainUid,
     msgs::{

--- a/tests-integration/src/tests/factory.rs
+++ b/tests-integration/src/tests/factory.rs
@@ -6,7 +6,7 @@ use cw20::Cw20Contract;
 use cw_orch::prelude::{
     ContractInstance, CwOrchExecute, CwOrchInstantiate, CwOrchQuery, CwOrchUpload, Environment,
 };
-use cw_orch_interchain::{prelude::*, types::IbcPacketOutcome, InterchainEnv};
+use cw_orch_interchain::{prelude::*, InterchainEnv};
 use escrow::{mock::mock_escrow, EscrowContract};
 use euclid::chain::CrossChainUser;
 use euclid::chain::CrossChainUserWithLimit;
@@ -143,7 +143,7 @@ fn test_create_pool_with_funds() {
                 constant_product_vlp_code_id: 3,
                 stable_vlp_code_id: 4,
                 virtual_balance_code_id: 2,
-                mock_relayer_address: Some(nibiru.sender.to_string()),
+                mock_relayer_addresses: Some(vec![nibiru.sender.to_string()]),
             },
             None,
             None,
@@ -951,7 +951,7 @@ fn test_add_liquidity() {
             &euclid::msgs::router::InstantiateMsg {
                 constant_product_vlp_code_id: 3,
                 virtual_balance_code_id: 2,
-                mock_relayer_address: Some(router_nibiru.environment().sender.to_string()),
+                mock_relayer_addresses: Some(vec![router_nibiru.environment().sender.to_string()]),
                 stable_vlp_code_id: 4,
             },
             None,
@@ -1819,7 +1819,7 @@ fn test_swap_request() {
             &euclid::msgs::router::InstantiateMsg {
                 constant_product_vlp_code_id: 3,
                 virtual_balance_code_id: 2,
-                mock_relayer_address: Some(router_nibiru.environment().sender.to_string()),
+                mock_relayer_addresses: Some(vec![router_nibiru.environment().sender.to_string()]),
                 stable_vlp_code_id: 4,
             },
             None,
@@ -2955,7 +2955,7 @@ fn test_stable_pool() {
                 constant_product_vlp_code_id: vlp_nibiru.code_id().unwrap(),
                 stable_vlp_code_id: stable_vlp_nibiru.code_id().unwrap(),
                 virtual_balance_code_id: virtual_balance_nibiru.code_id().unwrap(),
-                mock_relayer_address: Some(router_nibiru.environment().sender.to_string()),
+                mock_relayer_addresses: Some(vec![router_nibiru.environment().sender.to_string()]),
             },
             None,
             None,

--- a/tests-integration/src/tests/router.rs
+++ b/tests-integration/src/tests/router.rs
@@ -17,14 +17,11 @@ const _NATIVE_DENOM: &str = "native";
 const _IBC_DENOM_1: &str = "ibc/denom1";
 const _IBC_DENOM_2: &str = "ibc/denom2";
 const _SUPPLY: u128 = 1_000_000;
+use crate::helpers::relayer::relay_router_factory_router;
 use cw_orch_interchain::prelude::*;
 use cw_orch_interchain::InterchainEnv;
 use router::RouterContract;
 use virtual_balance::VirtualBalanceContract;
-
-use crate::helpers::relayer::relay_factory_router_factory;
-use crate::helpers::relayer::relay_router_ack_packet;
-use crate::helpers::relayer::relay_router_factory_router;
 
 #[test]
 fn test_register_factory() {
@@ -75,7 +72,7 @@ fn test_register_factory() {
                 constant_product_vlp_code_id: 3,
                 stable_vlp_code_id: 4,
                 virtual_balance_code_id,
-                mock_relayer_address: Some(router_osmo.environment().sender.to_string()),
+                mock_relayer_addresses: Some(vec![router_osmo.environment().sender.to_string()]),
             },
             None,
             None,


### PR DESCRIPTION
# Pull Request

## Description
Turned `MOCK_RELAYER_ADDRESS` which holds a String into `MOCK_RELAYER_ADDRESSES` that holds a vector of strings. 
Made the necessary adjustments after that. 
Resolved lint errors. 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor/Chore

## Related Issue
None

## Testing
All tests still pass, adjusted input type of relayer addresses. 

## Checklist

- [x] Self-review completed
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated (if applicable)

## Additional Notes
None