### PR TITLE
Fix VLP issue with LP calculation, and large values in liquidity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3243,7 +3243,7 @@ dependencies = [
 
 [[package]]
 name = "stable_vlp"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
@@ -3802,7 +3802,7 @@ dependencies = [
 
 [[package]]
 name = "vlp"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",

--- a/contracts/hub/stable_vlp/Cargo.toml
+++ b/contracts/hub/stable_vlp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stable_vlp"
-version = "0.2.0"
+version = "0.2.2"
 authors = [
   "gachouchani1999 <georgeschouchani1@gmail.com>",
   "Anshudhar Kumar Singh <anshudhar2001@gmail.com>",

--- a/contracts/hub/stable_vlp/src/contract.rs
+++ b/contracts/hub/stable_vlp/src/contract.rs
@@ -11,7 +11,7 @@ use crate::query::{
     query_total_fees_collected, query_total_fees_per_denom,
 };
 use crate::reply;
-use crate::state::{AMP_FACTOR, BALANCES, CHAIN_LP_TOKENS, STATE};
+use crate::state::{AMP_FACTOR, BALANCES, CHAIN_LP_TOKENS, COLLATERAL_LP_TOKENS, STATE};
 use euclid::error::ContractError;
 use euclid::msgs::stable_vlp::{ExecuteMsg, InstantiateMsg, QueryMsg, DEFAULT_AMP_FACTOR};
 use euclid::pool::{
@@ -129,6 +129,7 @@ pub fn execute(
             &STATE,
             &BALANCES,
             &CHAIN_LP_TOKENS,
+            &COLLATERAL_LP_TOKENS,
             sender,
             liquidity,
             slippage_tolerance_bps,

--- a/contracts/hub/stable_vlp/src/migrate.rs
+++ b/contracts/hub/stable_vlp/src/migrate.rs
@@ -22,7 +22,7 @@ pub fn migrate(mut deps: DepsMut, env: Env, _msg: MigrateMsg) -> Result<Response
     Ok(response)
 }
 
-// Migrate v0.2.0 to 0.2.1 with token denoms
+// Migrate v0.2.0 to 0.2.2
 fn migrate_v0_2_0_to_v0_2_2(deps: &mut DepsMut, _env: Env) -> Result<Response, ContractError> {
     let mut state = STATE.load(deps.storage)?;
     state.total_lp_tokens = state
@@ -36,7 +36,7 @@ fn migrate_v0_2_0_to_v0_2_2(deps: &mut DepsMut, _env: Env) -> Result<Response, C
         .add_attribute("collateral_lp_tokens", MINIMUM_LIQUIDITY.to_string()))
 }
 
-// Migrate patch v0.2.2 to 0.2.2 with token denoms
+// Migrate patch v0.2.2 to 0.2.2
 fn migrate_patch_v0_2_2_to_v0_2_2(
     deps: &mut DepsMut,
     _env: Env,

--- a/contracts/hub/stable_vlp/src/migrate.rs
+++ b/contracts/hub/stable_vlp/src/migrate.rs
@@ -1,9 +1,40 @@
-use cosmwasm_std::{entry_point, DepsMut, Env, Response};
-use euclid::{error::ContractError, msgs::stable_vlp::MigrateMsg};
+use cosmwasm_std::{entry_point, DepsMut, Env, Response, Uint128};
+use euclid::{error::ContractError, msgs::stable_vlp::MigrateMsg, pool::MINIMUM_LIQUIDITY};
+
+use cw2::{get_contract_version, set_contract_version, CONTRACT};
+
+use crate::state::{COLLATERAL_LP_TOKENS, STATE};
+
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// This is the migrate entry point for the contract.
-/// Currently, it does not perform any migration logic and simply returns an empty response.
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    Ok(Response::default())
+pub fn migrate(deps: &mut DepsMut, env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    let mut version = get_contract_version(deps.storage)?;
+    let response = match version.version.as_str() {
+        "0.2.0" => migrate_v0_2_0_to_v0_2_2(deps, env),
+        _ => Ok(Response::default()),
+    }?;
+
+    version.version = CONTRACT_VERSION.to_string();
+    set_contract_version(deps.storage, &version.contract, &version.version)?;
+    Ok(response)
+}
+
+// Migrate v0.2.0 to 0.2.1 with token denoms
+fn migrate_v0_2_0_to_v0_2_2(deps: &mut DepsMut, _env: Env) -> Result<Response, ContractError> {
+    let contract_version = CONTRACT.load(deps.storage)?;
+    if contract_version.version != "0.2.2" {
+        return Ok(Response::default());
+    }
+    let mut state = STATE.load(deps.storage)?;
+    state.total_lp_tokens = state
+        .total_lp_tokens
+        .checked_add(Uint128::from(MINIMUM_LIQUIDITY))?;
+    STATE.save(deps.storage, &state)?;
+    COLLATERAL_LP_TOKENS.save(deps.storage, &Uint128::from(MINIMUM_LIQUIDITY))?;
+
+    Ok(Response::default()
+        .add_attribute("action", "migrate")
+        .add_attribute("collateral_lp_tokens", MINIMUM_LIQUIDITY.to_string()))
 }

--- a/contracts/hub/stable_vlp/src/migrate.rs
+++ b/contracts/hub/stable_vlp/src/migrate.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::{entry_point, DepsMut, Env, Response, Uint128};
 use euclid::{error::ContractError, msgs::stable_vlp::MigrateMsg, pool::MINIMUM_LIQUIDITY};
 
-use cw2::{get_contract_version, set_contract_version, CONTRACT};
+use cw2::{get_contract_version, set_contract_version};
 
 use crate::state::{COLLATERAL_LP_TOKENS, STATE};
 
@@ -13,6 +13,7 @@ pub fn migrate(mut deps: DepsMut, env: Env, _msg: MigrateMsg) -> Result<Response
     let mut version = get_contract_version(deps.storage)?;
     let response = match version.version.as_str() {
         "0.2.0" => migrate_v0_2_0_to_v0_2_2(&mut deps, env),
+        "0.2.2" => migrate_patch_v0_2_2_to_v0_2_2(&mut deps, env),
         _ => Ok(Response::default()),
     }?;
 
@@ -23,16 +24,29 @@ pub fn migrate(mut deps: DepsMut, env: Env, _msg: MigrateMsg) -> Result<Response
 
 // Migrate v0.2.0 to 0.2.1 with token denoms
 fn migrate_v0_2_0_to_v0_2_2(deps: &mut DepsMut, _env: Env) -> Result<Response, ContractError> {
-    let contract_version = CONTRACT.load(deps.storage)?;
-    if contract_version.version != "0.2.2" {
-        return Ok(Response::default());
-    }
     let mut state = STATE.load(deps.storage)?;
     state.total_lp_tokens = state
         .total_lp_tokens
         .checked_add(Uint128::from(MINIMUM_LIQUIDITY))?;
     STATE.save(deps.storage, &state)?;
     COLLATERAL_LP_TOKENS.save(deps.storage, &Uint128::from(MINIMUM_LIQUIDITY))?;
+
+    Ok(Response::default()
+        .add_attribute("action", "migrate")
+        .add_attribute("collateral_lp_tokens", MINIMUM_LIQUIDITY.to_string()))
+}
+
+// Migrate patch v0.2.2 to 0.2.2 with token denoms
+fn migrate_patch_v0_2_2_to_v0_2_2(
+    deps: &mut DepsMut,
+    _env: Env,
+) -> Result<Response, ContractError> {
+    let state = STATE.load(deps.storage)?;
+    STATE.save(deps.storage, &state)?;
+    let collateral_lp_tokens = COLLATERAL_LP_TOKENS.may_load(deps.storage)?;
+    if collateral_lp_tokens.is_none() {
+        COLLATERAL_LP_TOKENS.save(deps.storage, &Uint128::from(MINIMUM_LIQUIDITY))?;
+    }
 
     Ok(Response::default()
         .add_attribute("action", "migrate")

--- a/contracts/hub/stable_vlp/src/migrate.rs
+++ b/contracts/hub/stable_vlp/src/migrate.rs
@@ -41,8 +41,6 @@ fn migrate_patch_v0_2_2_to_v0_2_2(
     deps: &mut DepsMut,
     _env: Env,
 ) -> Result<Response, ContractError> {
-    let state = STATE.load(deps.storage)?;
-    STATE.save(deps.storage, &state)?;
     let collateral_lp_tokens = COLLATERAL_LP_TOKENS.may_load(deps.storage)?;
     if collateral_lp_tokens.is_none() {
         COLLATERAL_LP_TOKENS.save(deps.storage, &Uint128::from(MINIMUM_LIQUIDITY))?;

--- a/contracts/hub/stable_vlp/src/migrate.rs
+++ b/contracts/hub/stable_vlp/src/migrate.rs
@@ -9,10 +9,10 @@ const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// This is the migrate entry point for the contract.
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(deps: &mut DepsMut, env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+pub fn migrate(mut deps: DepsMut, env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
     let mut version = get_contract_version(deps.storage)?;
     let response = match version.version.as_str() {
-        "0.2.0" => migrate_v0_2_0_to_v0_2_2(deps, env),
+        "0.2.0" => migrate_v0_2_0_to_v0_2_2(&mut deps, env),
         _ => Ok(Response::default()),
     }?;
 

--- a/contracts/hub/stable_vlp/src/query.rs
+++ b/contracts/hub/stable_vlp/src/query.rs
@@ -5,7 +5,9 @@ use euclid::msgs::stable_vlp::{
     AllStablePoolsResponse, FeeResponse, GetLiquidityResponse, GetStateResponse, StablePoolInfo,
     StablePoolResponse, TotalFeesPerDenomResponse, TotalFeesResponse, DEFAULT_AMP_FACTOR,
 };
-use euclid::pool::{simulate_swap, GetSwapResponse, PoolConfig, SwapCalculationMethod};
+use euclid::pool::{
+    calculate_amount_from_shares, simulate_swap, GetSwapResponse, PoolConfig, SwapCalculationMethod,
+};
 use euclid::swap::NextSwapVlp;
 use euclid::token::Token;
 
@@ -144,11 +146,9 @@ fn get_pool(
     reserve_2: Uint128,
 ) -> Result<StablePoolResponse, ContractError> {
     Ok(StablePoolResponse {
-        reserve_1: reserve_1
-            .checked_multiply_ratio(chain_lp_tokens, state.total_lp_tokens)
+        reserve_1: calculate_amount_from_shares(reserve_1, chain_lp_tokens, state.total_lp_tokens)
             .unwrap_or(Uint128::zero()),
-        reserve_2: reserve_2
-            .checked_multiply_ratio(chain_lp_tokens, state.total_lp_tokens)
+        reserve_2: calculate_amount_from_shares(reserve_2, chain_lp_tokens, state.total_lp_tokens)
             .unwrap_or(Uint128::zero()),
         lp_shares: chain_lp_tokens,
     })

--- a/contracts/hub/stable_vlp/src/state.rs
+++ b/contracts/hub/stable_vlp/src/state.rs
@@ -11,3 +11,5 @@ pub const BALANCES: Map<Token, Uint128> = Map::new("balances");
 
 // The amplification factor for the stableswap invariant, default is 1000
 pub const AMP_FACTOR: Item<Uint64> = Item::new("amp_factor");
+
+pub const COLLATERAL_LP_TOKENS: Item<Uint128> = Item::new("collateral_lp_tokens");

--- a/contracts/hub/vlp/Cargo.toml
+++ b/contracts/hub/vlp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vlp"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
   "gachouchani1999 <georgeschouchani1@gmail.com>",
   "Anshudhar Kumar Singh <anshudhar2001@gmail.com>",

--- a/contracts/hub/vlp/src/contract.rs
+++ b/contracts/hub/vlp/src/contract.rs
@@ -21,7 +21,7 @@ use crate::{
         query_total_fees_collected, query_total_fees_per_denom,
     },
     reply,
-    state::{BALANCES, CHAIN_LP_TOKENS, STATE},
+    state::{BALANCES, CHAIN_LP_TOKENS, COLLATERAL_LP_TOKENS, STATE},
 };
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:vlp";
@@ -129,6 +129,7 @@ pub fn execute(
             &STATE,
             &BALANCES,
             &CHAIN_LP_TOKENS,
+            &COLLATERAL_LP_TOKENS,
             sender,
             liquidity,
             slippage_tolerance_bps,

--- a/contracts/hub/vlp/src/migrate.rs
+++ b/contracts/hub/vlp/src/migrate.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{entry_point, DepsMut, Env, Response, Uint128};
-use cw2::{get_contract_version, set_contract_version, CONTRACT};
+use cw2::{get_contract_version, set_contract_version};
 use euclid::{error::ContractError, msgs::vlp::MigrateMsg, pool::MINIMUM_LIQUIDITY};
 
 use crate::state::{COLLATERAL_LP_TOKENS, STATE};
@@ -40,8 +40,6 @@ fn migrate_patch_v0_2_2_to_v0_2_2(
     deps: &mut DepsMut,
     _env: Env,
 ) -> Result<Response, ContractError> {
-    let state = STATE.load(deps.storage)?;
-    STATE.save(deps.storage, &state)?;
     let collateral_lp_tokens = COLLATERAL_LP_TOKENS.may_load(deps.storage)?;
     if collateral_lp_tokens.is_none() {
         COLLATERAL_LP_TOKENS.save(deps.storage, &Uint128::from(MINIMUM_LIQUIDITY))?;

--- a/contracts/hub/vlp/src/migrate.rs
+++ b/contracts/hub/vlp/src/migrate.rs
@@ -12,6 +12,7 @@ pub fn migrate(mut deps: DepsMut, env: Env, _msg: MigrateMsg) -> Result<Response
     let mut version = get_contract_version(deps.storage)?;
     let response = match version.version.as_str() {
         "0.2.1" => migrate_v0_2_1_to_v0_2_2(&mut deps, env),
+        "0.2.2" => migrate_patch_v0_2_2_to_v0_2_2(&mut deps, env),
         _ => Ok(Response::default()),
     }?;
 
@@ -22,16 +23,29 @@ pub fn migrate(mut deps: DepsMut, env: Env, _msg: MigrateMsg) -> Result<Response
 
 // Migrate v0.2.0 to 0.2.1 with token denoms
 fn migrate_v0_2_1_to_v0_2_2(deps: &mut DepsMut, _env: Env) -> Result<Response, ContractError> {
-    let contract_version = CONTRACT.load(deps.storage)?;
-    if contract_version.version != "0.2.2" {
-        return Ok(Response::default());
-    }
     let mut state = STATE.load(deps.storage)?;
     state.total_lp_tokens = state
         .total_lp_tokens
         .checked_add(Uint128::from(MINIMUM_LIQUIDITY))?;
     STATE.save(deps.storage, &state)?;
     COLLATERAL_LP_TOKENS.save(deps.storage, &Uint128::from(MINIMUM_LIQUIDITY))?;
+
+    Ok(Response::default()
+        .add_attribute("action", "migrate")
+        .add_attribute("collateral_lp_tokens", MINIMUM_LIQUIDITY.to_string()))
+}
+
+// Migrate patch v0.2.2 to 0.2.2 with token denoms
+fn migrate_patch_v0_2_2_to_v0_2_2(
+    deps: &mut DepsMut,
+    _env: Env,
+) -> Result<Response, ContractError> {
+    let state = STATE.load(deps.storage)?;
+    STATE.save(deps.storage, &state)?;
+    let collateral_lp_tokens = COLLATERAL_LP_TOKENS.may_load(deps.storage)?;
+    if collateral_lp_tokens.is_none() {
+        COLLATERAL_LP_TOKENS.save(deps.storage, &Uint128::from(MINIMUM_LIQUIDITY))?;
+    }
 
     Ok(Response::default()
         .add_attribute("action", "migrate")

--- a/contracts/hub/vlp/src/migrate.rs
+++ b/contracts/hub/vlp/src/migrate.rs
@@ -8,10 +8,10 @@ const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// This is the migrate entry point for the contract.
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(deps: &mut DepsMut, env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+pub fn migrate(mut deps: DepsMut, env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
     let mut version = get_contract_version(deps.storage)?;
     let response = match version.version.as_str() {
-        "0.2.1" => migrate_v0_2_1_to_v0_2_2(deps, env),
+        "0.2.1" => migrate_v0_2_1_to_v0_2_2(&mut deps, env),
         _ => Ok(Response::default()),
     }?;
 

--- a/contracts/hub/vlp/src/migrate.rs
+++ b/contracts/hub/vlp/src/migrate.rs
@@ -1,9 +1,39 @@
-use cosmwasm_std::{entry_point, DepsMut, Env, Response};
-use euclid::{error::ContractError, msgs::vlp::MigrateMsg};
+use cosmwasm_std::{entry_point, DepsMut, Env, Response, Uint128};
+use cw2::{get_contract_version, set_contract_version, CONTRACT};
+use euclid::{error::ContractError, msgs::vlp::MigrateMsg, pool::MINIMUM_LIQUIDITY};
+
+use crate::state::{COLLATERAL_LP_TOKENS, STATE};
+
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// This is the migrate entry point for the contract.
-/// Currently, it does not perform any migration logic and simply returns an empty response.
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    Ok(Response::default())
+pub fn migrate(deps: &mut DepsMut, env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    let mut version = get_contract_version(deps.storage)?;
+    let response = match version.version.as_str() {
+        "0.2.1" => migrate_v0_2_1_to_v0_2_2(deps, env),
+        _ => Ok(Response::default()),
+    }?;
+
+    version.version = CONTRACT_VERSION.to_string();
+    set_contract_version(deps.storage, &version.contract, &version.version)?;
+    Ok(response)
+}
+
+// Migrate v0.2.0 to 0.2.1 with token denoms
+fn migrate_v0_2_1_to_v0_2_2(deps: &mut DepsMut, _env: Env) -> Result<Response, ContractError> {
+    let contract_version = CONTRACT.load(deps.storage)?;
+    if contract_version.version != "0.2.2" {
+        return Ok(Response::default());
+    }
+    let mut state = STATE.load(deps.storage)?;
+    state.total_lp_tokens = state
+        .total_lp_tokens
+        .checked_add(Uint128::from(MINIMUM_LIQUIDITY))?;
+    STATE.save(deps.storage, &state)?;
+    COLLATERAL_LP_TOKENS.save(deps.storage, &Uint128::from(MINIMUM_LIQUIDITY))?;
+
+    Ok(Response::default()
+        .add_attribute("action", "migrate")
+        .add_attribute("collateral_lp_tokens", MINIMUM_LIQUIDITY.to_string()))
 }

--- a/contracts/hub/vlp/src/migrate.rs
+++ b/contracts/hub/vlp/src/migrate.rs
@@ -21,7 +21,7 @@ pub fn migrate(mut deps: DepsMut, env: Env, _msg: MigrateMsg) -> Result<Response
     Ok(response)
 }
 
-// Migrate v0.2.0 to 0.2.1 with token denoms
+// Migrate v0.2.1 to 0.2.2
 fn migrate_v0_2_1_to_v0_2_2(deps: &mut DepsMut, _env: Env) -> Result<Response, ContractError> {
     let mut state = STATE.load(deps.storage)?;
     state.total_lp_tokens = state
@@ -35,7 +35,7 @@ fn migrate_v0_2_1_to_v0_2_2(deps: &mut DepsMut, _env: Env) -> Result<Response, C
         .add_attribute("collateral_lp_tokens", MINIMUM_LIQUIDITY.to_string()))
 }
 
-// Migrate patch v0.2.2 to 0.2.2 with token denoms
+// Migrate patch v0.2.2 to 0.2.2
 fn migrate_patch_v0_2_2_to_v0_2_2(
     deps: &mut DepsMut,
     _env: Env,

--- a/contracts/hub/vlp/src/query.rs
+++ b/contracts/hub/vlp/src/query.rs
@@ -1,12 +1,7 @@
-use cosmwasm_std::{
-    ensure, to_json_binary, Binary, Decimal, Decimal256, Deps, Env, Isqrt, Uint128,
-};
+use cosmwasm_std::{ensure, to_json_binary, Binary, Decimal256, Deps, Env, Uint128};
 use euclid::chain::ChainUid;
 use euclid::error::ContractError;
-use euclid::fee::BPS_50_PERCENT;
-use euclid::pool::{
-    simulate_swap, GetSwapResponse, PoolConfig, SwapCalculationMethod, MINIMUM_LIQUIDITY,
-};
+use euclid::pool::{simulate_swap, GetSwapResponse, PoolConfig, SwapCalculationMethod};
 use euclid::swap::NextSwapVlp;
 use euclid::token::{Pair, PairWithAmount, Token};
 
@@ -169,26 +164,6 @@ fn get_pool(
     })
 }
 
-pub fn calculate_lp_allocation(
-    token_1_amount: Uint128,
-    token_2_amount: Uint128,
-    total_liquidity_1: Uint128,
-    total_liquidity_2: Uint128,
-    total_lp_supply: Uint128,
-) -> Result<Uint128, ContractError> {
-    // IF LP supply is 0 use original function
-    if total_lp_supply.is_zero() {
-        let sq_root = Isqrt::isqrt(token_1_amount.checked_mul(token_2_amount)?);
-        return Ok(sq_root.checked_sub(Uint128::new(MINIMUM_LIQUIDITY))?);
-    }
-
-    let lp_allocation = token_1_amount
-        .checked_multiply_ratio(total_lp_supply, total_liquidity_1)?
-        .min(token_2_amount.checked_multiply_ratio(total_lp_supply, total_liquidity_2)?);
-
-    Ok(lp_allocation)
-}
-
 // Function to assert slippage is tolerated during transaction
 pub fn assert_slippage_tolerance(
     ratio: Decimal256,
@@ -206,66 +181,6 @@ pub fn assert_slippage_tolerance(
         }
     );
     Ok(true)
-}
-
-/// Calculates the LP allocation for provided liquidity amounts
-///
-/// # Arguments
-///
-/// * `liquidity` - The pair of tokens with amounts being provided as liquidity
-/// * `pair` - The token pair configuration for the pool
-/// * `total_reserve_1` - Current total reserve of token 1
-/// * `total_reserve_2` - Current total reserve of token 2
-/// * `total_lp_tokens` - Total LP tokens currently in circulation
-/// * `slippage_tolerance_bps` - Slippage tolerance in basis points (optional)
-///
-/// # Returns
-///
-/// Returns the calculated LP allocation amount
-pub fn calculate_lp_allocation_for_liquidity(
-    token_1_liquidity: Uint128,
-    token_2_liquidity: Uint128,
-    total_reserve_1: Uint128,
-    total_reserve_2: Uint128,
-    total_lp_tokens: Uint128,
-    slippage_tolerance_bps: u64,
-) -> Result<Uint128, ContractError> {
-    // Verify that ratio of assets provided is equal to the ratio of assets in the pool
-    let ratio =
-        Decimal256::checked_from_ratio(token_1_liquidity, token_2_liquidity).map_err(|err| {
-            ContractError::Generic {
-                err: err.to_string(),
-            }
-        })?;
-
-    // Get liquidity ratio (current ratio of token reserves or provided ratio if first time)
-    let lq_ratio =
-        Decimal256::checked_from_ratio(total_reserve_1, total_reserve_2).unwrap_or(ratio);
-
-    // Check slippage if tolerance is provided
-    ensure!(
-        slippage_tolerance_bps.le(&BPS_50_PERCENT),
-        ContractError::InvalidSlippageTolerance {}
-    );
-    assert_slippage_tolerance(ratio, lq_ratio, slippage_tolerance_bps)?;
-
-    // Calculate liquidity added share for LP provider from total liquidity
-    let lp_allocation = calculate_lp_allocation(
-        token_1_liquidity,
-        token_2_liquidity,
-        total_reserve_1,
-        total_reserve_2,
-        total_lp_tokens,
-    )?;
-
-    ensure!(
-        !lp_allocation.is_zero(),
-        ContractError::Generic {
-            err: "LP Allocation cannot be zero".to_string()
-        }
-    );
-
-    Ok(lp_allocation)
 }
 
 /// Extracts the token amount for a given token from a pair with amounts

--- a/contracts/hub/vlp/src/query.rs
+++ b/contracts/hub/vlp/src/query.rs
@@ -1,7 +1,9 @@
-use cosmwasm_std::{ensure, to_json_binary, Binary, Decimal256, Deps, Env, Uint128};
+use cosmwasm_std::{ensure, to_json_binary, Binary, Deps, Env, Uint128};
 use euclid::chain::ChainUid;
 use euclid::error::ContractError;
-use euclid::pool::{simulate_swap, GetSwapResponse, PoolConfig, SwapCalculationMethod};
+use euclid::pool::{
+    calculate_amount_from_shares, simulate_swap, GetSwapResponse, PoolConfig, SwapCalculationMethod,
+};
 use euclid::swap::NextSwapVlp;
 use euclid::token::{Pair, PairWithAmount, Token};
 
@@ -154,33 +156,12 @@ fn get_pool(
     reserve_2: Uint128,
 ) -> Result<PoolResponse, ContractError> {
     Ok(PoolResponse {
-        reserve_1: reserve_1
-            .checked_multiply_ratio(chain_lp_tokens, state.total_lp_tokens)
+        reserve_1: calculate_amount_from_shares(reserve_1, chain_lp_tokens, state.total_lp_tokens)
             .unwrap_or(Uint128::zero()),
-        reserve_2: reserve_2
-            .checked_multiply_ratio(chain_lp_tokens, state.total_lp_tokens)
+        reserve_2: calculate_amount_from_shares(reserve_2, chain_lp_tokens, state.total_lp_tokens)
             .unwrap_or(Uint128::zero()),
         lp_shares: chain_lp_tokens,
     })
-}
-
-// Function to assert slippage is tolerated during transaction
-pub fn assert_slippage_tolerance(
-    ratio: Decimal256,
-    pool_ratio: Decimal256,
-    slippage_tolerance_bps: u64,
-) -> Result<bool, ContractError> {
-    let slippage = ratio.abs_diff(pool_ratio).checked_div(pool_ratio)?;
-
-    let slippage_tolerance = Decimal256::bps(slippage_tolerance_bps);
-    ensure!(
-        slippage.le(&slippage_tolerance),
-        ContractError::LiquiditySlippageExceeded {
-            expected: slippage,
-            received: slippage_tolerance,
-        }
-    );
-    Ok(true)
 }
 
 /// Extracts the token amount for a given token from a pair with amounts

--- a/contracts/hub/vlp/src/state.rs
+++ b/contracts/hub/vlp/src/state.rs
@@ -8,3 +8,5 @@ pub const STATE: Item<State> = Item::new("state");
 pub const CHAIN_LP_TOKENS: Map<ChainUid, Uint128> = Map::new("chain_lp_tokens");
 
 pub const BALANCES: Map<Token, Uint128> = Map::new("balances");
+
+pub const COLLATERAL_LP_TOKENS: Item<Uint128> = Item::new("collateral_lp_tokens");

--- a/contracts/hub/vlp/src/tests.rs
+++ b/contracts/hub/vlp/src/tests.rs
@@ -2,7 +2,7 @@
 #[cfg(test)]
 mod tests {
     use crate::contract::{execute, instantiate};
-    use crate::query::{calculate_lp_allocation_for_liquidity, query_simulate_swap};
+    use crate::query::query_simulate_swap;
     use crate::state::{BALANCES, CHAIN_LP_TOKENS, STATE};
     use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env, MockQuerier};
     use cosmwasm_std::{coins, from_json, Response, Uint128};
@@ -196,57 +196,6 @@ mod tests {
             err,
             ContractError::new("Euclid Fee cannot exceed maximum limit")
         );
-    }
-
-    #[test]
-    fn test_calculate_lp_allocation_for_liquidity() {
-        let token_1_liquidity = Uint128::new(980);
-        let token_2_liquidity = Uint128::new(1000);
-        let total_reserve_1 = Uint128::new(10000);
-        let total_reserve_2 = Uint128::new(10000);
-        let total_lp_tokens = Uint128::new(10000); // 1:1 ratio for lp tokens to tokens present
-        let slippage_tolerance_bps = 200; // 2% slippage tolerance
-
-        // Call the function to test
-        let lp_allocation = calculate_lp_allocation_for_liquidity(
-            token_1_liquidity,
-            token_2_liquidity,
-            total_reserve_1,
-            total_reserve_2,
-            total_lp_tokens,
-            slippage_tolerance_bps,
-        )
-        .unwrap();
-
-        // Assert the expected LP allocation
-        let expected_allocation = Uint128::new(980); // This value should be calculated based on the logic
-        assert_eq!(lp_allocation, expected_allocation);
-    }
-
-    #[test]
-    fn test_calculate_lp_allocation_for_liquidity_exceeded_slippage() {
-        let token_1_liquidity = Uint128::new(100);
-        let token_2_liquidity = Uint128::new(99);
-        let total_reserve_1 = Uint128::new(100);
-        let total_reserve_2 = Uint128::new(100);
-        let total_lp_tokens = Uint128::new(100);
-        let slippage_tolerance_bps = 0; // 0% slippage tolerance to force failure
-
-        // Call the function to test and expect an error
-        let err = calculate_lp_allocation_for_liquidity(
-            token_1_liquidity,
-            token_2_liquidity,
-            total_reserve_1,
-            total_reserve_2,
-            total_lp_tokens,
-            slippage_tolerance_bps,
-        )
-        .unwrap_err();
-
-        match err {
-            ContractError::LiquiditySlippageExceeded { .. } => (),
-            _ => panic!("Expected slippage exceeded error, got {:?}", err),
-        }
     }
 
     #[test]

--- a/packages/euclid/src/pool/mod.rs
+++ b/packages/euclid/src/pool/mod.rs
@@ -2,3 +2,6 @@ pub mod pool;
 pub mod stable_math;
 
 pub use pool::*;
+
+#[cfg(test)]
+pub mod test;

--- a/packages/euclid/src/pool/pool.rs
+++ b/packages/euclid/src/pool/pool.rs
@@ -164,17 +164,29 @@ pub fn calculate_lp_allocation(
     total_liquidity_2: Uint128,
     total_lp_supply: Uint128,
 ) -> Result<Uint128, ContractError> {
+    let token_1_amount = Uint512::from(token_1_amount);
+    let token_2_amount = Uint512::from(token_2_amount);
+    let total_liquidity_1 = Uint512::from(total_liquidity_1);
+    let total_liquidity_2 = Uint512::from(total_liquidity_2);
+    let total_lp_supply = Uint512::from(total_lp_supply);
+
     // IF LP supply is 0 use original function
     if total_lp_supply.is_zero() {
-        let sq_root = Isqrt::isqrt(token_1_amount.checked_mul(token_2_amount)?);
-        return Ok(sq_root.checked_sub(Uint128::new(MINIMUM_LIQUIDITY))?);
+        let sq_root = Uint128::try_from(Isqrt::isqrt(token_1_amount.checked_mul(token_2_amount)?))
+            .map_err(|_| ContractError::new("Overflow total supply"))?;
+        return Ok(sq_root);
     }
 
     let lp_allocation = token_1_amount
-        .checked_multiply_ratio(total_lp_supply, total_liquidity_1)?
-        .min(token_2_amount.checked_multiply_ratio(total_lp_supply, total_liquidity_2)?);
+        .checked_mul(total_lp_supply)?
+        .checked_div(total_liquidity_1)?
+        .min(
+            token_2_amount
+                .checked_mul(total_lp_supply)?
+                .checked_div(total_liquidity_2)?,
+        );
 
-    Ok(lp_allocation)
+    Uint128::try_from(lp_allocation).map_err(|_| ContractError::new("Overflow lp allocation"))
 }
 
 // Function to assert slippage is tolerated during transaction
@@ -472,6 +484,7 @@ pub fn add_liquidity(
     state_storage: &Item<State>,
     balances_storage: &Map<Token, Uint128>,
     chain_lp_tokens_storage: &Map<ChainUid, Uint128>,
+    collateral_lp_tokens_storage: &Item<Uint128>,
     sender: CrossChainUser,
     liquidity: PairWithAmount,
     slippage_tolerance_bps: u64,
@@ -549,6 +562,15 @@ pub fn add_liquidity(
         state.total_lp_tokens,
     )?;
 
+    state.total_lp_tokens = state.total_lp_tokens.checked_add(lp_allocation)?;
+
+    let lp_allocation = if state.total_lp_tokens.is_zero() {
+        collateral_lp_tokens_storage.save(deps.storage, &Uint128::from(MINIMUM_LIQUIDITY))?;
+        lp_allocation.checked_sub(Uint128::from(MINIMUM_LIQUIDITY))?
+    } else {
+        lp_allocation
+    };
+
     ensure!(
         !lp_allocation.is_zero(),
         ContractError::Generic {
@@ -563,7 +585,6 @@ pub fn add_liquidity(
     total_reserve_1 = total_reserve_1.checked_add(token_1_liquidity)?;
     total_reserve_2 = total_reserve_2.checked_add(token_2_liquidity)?;
 
-    state.total_lp_tokens = state.total_lp_tokens.checked_add(lp_allocation)?;
     state_storage.save(deps.storage, &state)?;
 
     balances_storage.save(deps.storage, pair.token_1.clone(), &total_reserve_1)?;
@@ -980,4 +1001,13 @@ pub fn simulate_swap(
         lp_fee: pre_swap_response.lp_fee,
         euclid_fee: pre_swap_response.euclid_fee,
     })
+}
+
+pub fn calculate_amount_from_shares(
+    reserve: Uint128,
+    shares: Uint128,
+    total_shares: Uint128,
+) -> Result<Uint128, ContractError> {
+    let amount = reserve.checked_multiply_ratio(shares, total_shares)?;
+    Ok(amount)
 }

--- a/packages/euclid/src/pool/pool.rs
+++ b/packages/euclid/src/pool/pool.rs
@@ -562,9 +562,10 @@ pub fn add_liquidity(
         state.total_lp_tokens,
     )?;
 
+    let is_new_pool = state.total_lp_tokens.is_zero();
     state.total_lp_tokens = state.total_lp_tokens.checked_add(lp_allocation)?;
 
-    let lp_allocation = if state.total_lp_tokens.is_zero() {
+    let lp_allocation = if is_new_pool {
         collateral_lp_tokens_storage.save(deps.storage, &Uint128::from(MINIMUM_LIQUIDITY))?;
         lp_allocation.checked_sub(Uint128::from(MINIMUM_LIQUIDITY))?
     } else {

--- a/packages/euclid/src/pool/test.rs
+++ b/packages/euclid/src/pool/test.rs
@@ -1,0 +1,172 @@
+#[cfg(test)]
+mod tests {
+    use crate::pool::{calculate_amount_from_shares, calculate_lp_allocation};
+    use cosmwasm_std::Uint128;
+
+    #[test]
+    fn test_calculate_lp_allocation() {
+        // Test initial liquidity provision (empty pool)
+        let token_1_amount = Uint128::new(1000);
+        let token_2_amount = Uint128::new(1000);
+        let total_liquidity_1 = Uint128::zero();
+        let total_liquidity_2 = Uint128::zero();
+        let total_lp_supply = Uint128::zero();
+
+        let lp_tokens = calculate_lp_allocation(
+            token_1_amount,
+            token_2_amount,
+            total_liquidity_1,
+            total_liquidity_2,
+            total_lp_supply,
+        )
+        .unwrap();
+
+        // For initial provision, LP tokens should be sqrt(token1 * token2) - MINIMUM_LIQUIDITY
+        assert_eq!(lp_tokens, Uint128::new(1000));
+
+        let amount_1 = calculate_amount_from_shares(
+            token_1_amount + total_liquidity_1,
+            lp_tokens,
+            total_lp_supply + lp_tokens,
+        )
+        .unwrap();
+        assert_eq!(
+            amount_1, token_1_amount,
+            "Token 1 amount from shares is not correct"
+        );
+
+        let amount_2 = calculate_amount_from_shares(
+            token_2_amount + total_liquidity_2,
+            lp_tokens,
+            total_lp_supply + lp_tokens,
+        )
+        .unwrap();
+        assert_eq!(
+            amount_2, token_2_amount,
+            "Token 2 amount from shares is not correct"
+        );
+
+        // Test subsequent liquidity provision
+        let token_1_amount = Uint128::new(100);
+        let token_2_amount = Uint128::new(100);
+        let total_liquidity_1 = Uint128::new(1000);
+        let total_liquidity_2 = Uint128::new(1000);
+        let total_lp_supply = Uint128::new(1000); // From previous provision
+
+        let lp_tokens = calculate_lp_allocation(
+            token_1_amount,
+            token_2_amount,
+            total_liquidity_1,
+            total_liquidity_2,
+            total_lp_supply,
+        )
+        .unwrap();
+
+        // For subsequent provisions, LP tokens should be proportional to liquidity added
+        assert_eq!(lp_tokens, Uint128::new(100));
+
+        let amount_1 = calculate_amount_from_shares(
+            token_1_amount + total_liquidity_1,
+            lp_tokens,
+            total_lp_supply + lp_tokens,
+        )
+        .unwrap();
+
+        assert_eq!(
+            amount_1, token_1_amount,
+            "Token 1 amount from shares is not correct"
+        );
+        let amount_2 = calculate_amount_from_shares(
+            token_2_amount + total_liquidity_2,
+            lp_tokens,
+            total_lp_supply + lp_tokens,
+        )
+        .unwrap();
+        assert_eq!(
+            amount_2, token_2_amount,
+            "Token 2 amount from shares is not correct"
+        );
+
+        // Test uneven liquidity provision
+        let token_1_amount = Uint128::new(200);
+        let token_2_amount = Uint128::new(100);
+        let total_liquidity_1 = Uint128::new(2000);
+        let total_liquidity_2 = Uint128::new(1000);
+        let total_lp_supply = Uint128::new(1990);
+
+        let lp_tokens = calculate_lp_allocation(
+            token_1_amount,
+            token_2_amount,
+            total_liquidity_1,
+            total_liquidity_2,
+            total_lp_supply,
+        )
+        .unwrap();
+
+        // Should use the minimum ratio to prevent dilution
+        assert_eq!(lp_tokens, Uint128::new(199));
+
+        let amount_1 = calculate_amount_from_shares(
+            token_1_amount + total_liquidity_1,
+            lp_tokens,
+            total_lp_supply + lp_tokens,
+        )
+        .unwrap();
+        assert_eq!(
+            amount_1, token_1_amount,
+            "Token 1 amount from shares is not correct"
+        );
+
+        let amount_2 = calculate_amount_from_shares(
+            token_2_amount + total_liquidity_2,
+            lp_tokens,
+            total_lp_supply + lp_tokens,
+        )
+        .unwrap();
+        assert_eq!(
+            amount_2, token_2_amount,
+            "Token 2 amount from shares is not correct"
+        );
+    }
+
+    #[test]
+    fn test_big_token_amount() {
+        // Test with large token amounts
+        let token_1_amount = Uint128::new(5_000_000_000_000_000_000_000_000);
+        let token_2_amount = Uint128::new(5_000_000_000_000_000_000_000_000);
+        let total_liquidity_1 = Uint128::new(0);
+        let total_liquidity_2 = Uint128::new(0);
+        let total_lp_supply = Uint128::new(0);
+
+        let lp_tokens = calculate_lp_allocation(
+            token_1_amount,
+            token_2_amount,
+            total_liquidity_1,
+            total_liquidity_2,
+            total_lp_supply,
+        )
+        .unwrap();
+
+        // For initial provision with large amounts
+        assert_eq!(lp_tokens, Uint128::new(5_000_000_000_000_000_000_000_000));
+
+        // Test subsequent large liquidity provision
+        let token_1_amount = Uint128::new(5_000_000_000_000_000_000_000_000);
+        let token_2_amount = Uint128::new(5_000_000_000_000_000_000_000_000);
+        let total_liquidity_1 = Uint128::new(5_000_000_000_000_000_000_000_000);
+        let total_liquidity_2 = Uint128::new(5_000_000_000_000_000_000_000_000);
+        let total_lp_supply = Uint128::new(5_000_000_000_000_000_000_000_000);
+
+        let lp_tokens = calculate_lp_allocation(
+            token_1_amount,
+            token_2_amount,
+            total_liquidity_1,
+            total_liquidity_2,
+            total_lp_supply,
+        )
+        .unwrap();
+
+        // For subsequent provisions with large amounts
+        assert_eq!(lp_tokens, Uint128::new(5_000_000_000_000_000_000_000_000));
+    }
+}

--- a/tests-integration/src/tests/factory.rs
+++ b/tests-integration/src/tests/factory.rs
@@ -283,7 +283,7 @@ fn run_create_pool_with_funds(router_chain_id: &str, factory_chain_id: &str) {
             },
             token_1_reserve: Uint128::new(10_000),
             token_2_reserve: Uint128::new(100_000),
-            total_lp_tokens: Uint128::new(30622),
+            total_lp_tokens: Uint128::new(31622),
         }
     );
 
@@ -356,7 +356,7 @@ fn run_create_pool_with_funds(router_chain_id: &str, factory_chain_id: &str) {
             },
             token_1_reserve: Uint128::new(10_000u128 * 2),
             token_2_reserve: Uint128::new(100_000u128 * 2),
-            total_lp_tokens: Uint128::new(30622u128 * 2),
+            total_lp_tokens: Uint128::new(31622u128 * 2),
         }
     );
     // Euclid escrow contract
@@ -565,7 +565,7 @@ fn run_add_liquidity(factory_chain_id: &str, router_chain_id: &str) {
             },
             token_1_reserve: Uint128::new(10_000),
             token_2_reserve: Uint128::new(100_000),
-            total_lp_tokens: Uint128::new(30622),
+            total_lp_tokens: Uint128::new(31622),
         }
     );
 
@@ -637,7 +637,7 @@ fn run_add_liquidity(factory_chain_id: &str, router_chain_id: &str) {
             },
             token_1_reserve: Uint128::new(10_000u128 * 2),
             token_2_reserve: Uint128::new(100_000u128 * 2),
-            total_lp_tokens: Uint128::new(30622u128 * 2),
+            total_lp_tokens: Uint128::new(31622u128 * 2),
         }
     );
     // Euclid escrow contract
@@ -1241,7 +1241,7 @@ fn run_test_swap_request(factory_chain_id: &str, router_chain_id: &str) {
             },
             token_1_reserve: Uint128::new(10_000),
             token_2_reserve: Uint128::new(100_000),
-            total_lp_tokens: Uint128::new(30622),
+            total_lp_tokens: Uint128::new(31622),
         }
     );
 
@@ -1409,7 +1409,7 @@ fn run_test_multi_hop_swap_request(factory_chain_id: &str, router_chain_id: &str
                 },
                 token_1_reserve: Uint128::new(10_000),
                 token_2_reserve: Uint128::new(100_000),
-                total_lp_tokens: Uint128::new(30622),
+                total_lp_tokens: Uint128::new(31622),
             }
         );
     }
@@ -2384,7 +2384,7 @@ fn run_test_stable_pool_swap_request(factory_chain_id: &str, router_chain_id: &s
             },
             token_1_reserve: Uint128::new(10_000),
             token_2_reserve: Uint128::new(100_000),
-            total_lp_tokens: Uint128::new(30622),
+            total_lp_tokens: Uint128::new(31622),
         }
     );
 


### PR DESCRIPTION
# Pull Request

## Description

LP Calculation in vlp didn't store min liquidity in total LP due to which all the tokens were available for withdraw. Fixed the logic to store total liquidity and only assign total - min_liquidity to the user.
There was an overflow issue in LP calculation and shares calculation for lp tokens which is resolved now with using Uint512
Some code cleanup to use pool.rs for share calculation and remove codes that are not used anymore

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor/Chore

## Related Issue

[Link to related issue, if applicable]

## Testing

Steps to test:

1. [Step 1]
2. [Step 2]
3. [Step 3]

## Checklist

- [x] Self-review completed
- [x] Tests added/updated (if applicable)
- [ ] Documentation updated (if applicable)

## Additional Notes

[Any additional information or context]