### PR TITLE
refactor: Remove Zero Allowance and Balance from Virtual Balance

### DIFF
--- a/contracts/hub/virtual_balance/src/contract.rs
+++ b/contracts/hub/virtual_balance/src/contract.rs
@@ -4,7 +4,8 @@ use cosmwasm_std::{Binary, Deps, DepsMut, Env, MessageInfo, Response};
 use cw2::set_contract_version;
 
 use crate::execute::{
-    execute_approve, execute_burn, execute_mint, execute_transfer, execute_update_state,
+    execute_approve, execute_burn, execute_mint, execute_remove_zero_state_values,
+    execute_transfer, execute_update_state,
 };
 use crate::query::{query_balance, query_state, query_user_balances};
 use crate::state::STATE;
@@ -52,6 +53,7 @@ pub fn execute(
             execute_update_state(deps, info, router, admin)
         }
         ExecuteMsg::Approve(msg) => execute_approve(deps, info, msg),
+        ExecuteMsg::RemoveZeroStateValues {} => execute_remove_zero_state_values(deps, info),
     }
 }
 

--- a/contracts/hub/virtual_balance/src/execute.rs
+++ b/contracts/hub/virtual_balance/src/execute.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{ensure, Addr, DepsMut, MessageInfo, Response, Uint128};
+use cosmwasm_std::{ensure, Addr, DepsMut, MessageInfo, Order, Response, Uint128};
 use euclid::{
     chain::ChainUid,
     error::ContractError,
@@ -290,4 +290,43 @@ pub fn execute_approve(
         .add_attribute("approve_token_id", msg.token_id)
         .add_attribute("approve_spender", msg.spender.to_sender_string())
         .add_attribute("approve_owner", msg.owner.to_sender_string()))
+}
+
+pub fn execute_remove_zero_state_values(
+    deps: DepsMut,
+    info: MessageInfo,
+) -> Result<Response, ContractError> {
+    let state = STATE.load(deps.storage)?;
+
+    // Sender should either be router or admin
+    ensure!(
+        state.router == info.sender.to_string() || (state.admin == info.sender),
+        ContractError::Unauthorized {}
+    );
+
+    // Remove Allowances with a value of zero
+    let allowance_keys: Vec<_> = ALLOWANCES
+        .keys(deps.storage, None, None, Order::Ascending)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    for key in allowance_keys {
+        let allowance = ALLOWANCES.load(deps.storage, key.clone())?;
+        if allowance.amount.is_zero() {
+            ALLOWANCES.remove(deps.storage, key);
+        }
+    }
+
+    // Remove Balances with a value of zero
+    let balance_keys: Vec<_> = BALANCES
+        .keys(deps.storage, None, None, Order::Ascending)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    for key in balance_keys {
+        let balance = BALANCES.load(deps.storage, key.clone())?;
+        if balance.is_zero() {
+            BALANCES.remove(deps.storage, key);
+        }
+    }
+
+    Ok(Response::new().add_attribute("action", "execute_remove_zero_state_values"))
 }

--- a/contracts/hub/virtual_balance/src/execute.rs
+++ b/contracts/hub/virtual_balance/src/execute.rs
@@ -149,7 +149,11 @@ pub fn execute_transfer(
     );
 
     let sender_new_balance = sender_old_balance.checked_sub(msg.amount)?;
-    BALANCES.save(deps.storage, sender_key, &sender_new_balance)?;
+    if sender_new_balance.is_zero() {
+        BALANCES.remove(deps.storage, sender_key);
+    } else {
+        BALANCES.save(deps.storage, sender_key, &sender_new_balance)?;
+    }
 
     let receiver_balance_key = BalanceKey {
         token_id: msg.token_id.clone(),

--- a/contracts/hub/virtual_balance/src/execute.rs
+++ b/contracts/hub/virtual_balance/src/execute.rs
@@ -168,11 +168,18 @@ pub fn execute_transfer(
     if allowance.amount.ge(&msg.amount) {
         let mut new_allowance = allowance;
         new_allowance.amount = new_allowance.amount.checked_sub(msg.amount)?;
-        ALLOWANCES.save(
-            deps.storage,
-            sender_balance_key.clone().to_serialized_balance_key(),
-            &new_allowance,
-        )?;
+        if new_allowance.amount.is_zero() {
+            ALLOWANCES.remove(
+                deps.storage,
+                sender_balance_key.clone().to_serialized_balance_key(),
+            );
+        } else {
+            ALLOWANCES.save(
+                deps.storage,
+                sender_balance_key.clone().to_serialized_balance_key(),
+                &new_allowance,
+            )?;
+        }
         response = response
             .add_attribute("allowance_used", msg.amount)
             .add_attribute("new_allowance", new_allowance.amount);
@@ -256,6 +263,8 @@ pub fn execute_approve(
         token_id: msg.token_id.clone(),
         cross_chain_user: msg.owner.clone(),
     };
+
+    ensure!(!msg.amount.is_zero(), ContractError::ZeroAssetAmount {});
     ALLOWANCES.save(
         deps.storage,
         key.to_serialized_balance_key(),

--- a/contracts/hub/virtual_balance/src/execute.rs
+++ b/contracts/hub/virtual_balance/src/execute.rs
@@ -61,14 +61,20 @@ pub fn execute_burn(
     ensure!(!msg.amount.is_zero(), ContractError::ZeroAssetAmount {});
 
     let key = msg.balance_key.clone().to_serialized_balance_key();
-
-    let old_balance = BALANCES
-        .may_load(deps.storage, key.clone())?
-        .unwrap_or(Uint128::zero());
+    let old_balance =
+        BALANCES
+            .may_load(deps.storage, key.clone())?
+            .ok_or(ContractError::BalanceNotFound {
+                key: format!("{:?}", key),
+            })?;
 
     let new_balance = old_balance.checked_sub(msg.amount)?;
 
-    BALANCES.save(deps.storage, key, &new_balance)?;
+    if new_balance.is_zero() {
+        BALANCES.remove(deps.storage, key);
+    } else {
+        BALANCES.save(deps.storage, key, &new_balance)?;
+    }
 
     Ok(Response::new()
         .add_attribute("action", "execute_burn")

--- a/contracts/hub/virtual_balance/src/tests.rs
+++ b/contracts/hub/virtual_balance/src/tests.rs
@@ -243,7 +243,7 @@ mod tests {
         assert_eq!(owner_balance, Uint128::new(15));
 
         let recipient_key = BalanceKey {
-            cross_chain_user: recipient,
+            cross_chain_user: recipient.clone(),
             token_id: "eucl".to_string(),
         };
         let recipient_balance = BALANCES
@@ -253,5 +253,63 @@ mod tests {
             )
             .unwrap();
         assert_eq!(recipient_balance, Uint128::new(5));
+
+        // Check spender's allowance
+        let spender_allowance = ALLOWANCES
+            .load(
+                &deps.storage,
+                balance_key.clone().to_serialized_balance_key(),
+            )
+            .unwrap();
+        assert_eq!(spender_allowance.amount, Uint128::new(5));
+
+        // Spender transfers his remaining tokens to recipient
+        let transfer_msg = ExecuteMsg::Transfer(ExecuteTransfer {
+            amount: Uint128::new(5),
+            token_id: "eucl".to_string(),
+            from: owner.clone(),
+            to: recipient.clone(),
+        });
+        let info = MessageInfo {
+            sender: Addr::unchecked(spender.address.clone()),
+            funds: vec![],
+        };
+        execute(deps.as_mut(), env.clone(), info, transfer_msg).unwrap();
+
+        // Check that spender's the allowance has been removed
+        let _spender_allowance = ALLOWANCES
+            .load(
+                &deps.storage,
+                balance_key.clone().to_serialized_balance_key(),
+            )
+            .unwrap_err();
+
+        // Check recipient's balance
+        let recipient_balance = BALANCES
+            .load(
+                &deps.storage,
+                recipient_key.clone().to_serialized_balance_key(),
+            )
+            .unwrap();
+        assert_eq!(recipient_balance, Uint128::new(10));
+
+        // Burn the recipient's remaining balance
+        let burn_msg = ExecuteMsg::Burn(ExecuteBurn {
+            amount: recipient_balance,
+            balance_key: recipient_key.clone(),
+        });
+        let info = MessageInfo {
+            sender: Addr::unchecked(router.clone()),
+            funds: vec![],
+        };
+        execute(deps.as_mut(), env.clone(), info, burn_msg).unwrap();
+
+        // Check that recipient's balance has been removed
+        let _recipient_balance = BALANCES
+            .load(
+                &deps.storage,
+                recipient_key.clone().to_serialized_balance_key(),
+            )
+            .unwrap_err();
     }
 }

--- a/contracts/hub/virtual_balance/src/tests.rs
+++ b/contracts/hub/virtual_balance/src/tests.rs
@@ -3,7 +3,7 @@
 mod tests {
 
     use crate::contract::{execute, instantiate};
-    use crate::state::{ALLOWANCES, BALANCES, STATE};
+    use crate::state::{Allowance, ALLOWANCES, BALANCES, STATE};
 
     use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env, MockQuerier};
     use cosmwasm_std::{Addr, MessageInfo, Response, Uint128};
@@ -311,5 +311,117 @@ mod tests {
                 recipient_key.clone().to_serialized_balance_key(),
             )
             .unwrap_err();
+    }
+
+    #[test]
+    fn test_remove_zero_state_values() {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+        let router = Addr::unchecked("router");
+        let admin = Addr::unchecked("admin");
+
+        // Save initial state
+        STATE
+            .save(
+                &mut deps.storage,
+                &State {
+                    router: router.to_string(),
+                    admin: admin.clone(),
+                },
+            )
+            .unwrap();
+
+        // Helper to create BalanceKey
+        let key = |user: &str| {
+            BalanceKey {
+                cross_chain_user: CrossChainUser::new(
+                    ChainUid::vsl_chain_uid().unwrap(),
+                    user.to_string(),
+                ),
+                token_id: "eucl".to_string(),
+            }
+            .to_serialized_balance_key()
+        };
+
+        // Helper to execute remove
+        let remove_zeros = |deps: &mut cosmwasm_std::OwnedDeps<_, _, _>| {
+            execute(
+                deps.as_mut(),
+                env.clone(),
+                MessageInfo {
+                    sender: router.clone(),
+                    funds: vec![],
+                },
+                ExecuteMsg::RemoveZeroStateValues {},
+            )
+            .unwrap();
+        };
+
+        // Save allowances
+        ALLOWANCES
+            .save(
+                &mut deps.storage,
+                key("spender"),
+                &Allowance {
+                    amount: Uint128::new(10),
+                    spender: CrossChainUser::new(
+                        ChainUid::vsl_chain_uid().unwrap(),
+                        "spender".to_string(),
+                    ),
+                },
+            )
+            .unwrap();
+
+        ALLOWANCES
+            .save(
+                &mut deps.storage,
+                key("spender2"),
+                &Allowance {
+                    amount: Uint128::zero(),
+                    spender: CrossChainUser::new(
+                        ChainUid::vsl_chain_uid().unwrap(),
+                        "spender2".to_string(),
+                    ),
+                },
+            )
+            .unwrap();
+
+        // Assert initial state
+        assert_eq!(
+            ALLOWANCES
+                .load(&deps.storage, key("spender"))
+                .unwrap()
+                .amount,
+            Uint128::new(10)
+        );
+        assert_eq!(
+            ALLOWANCES
+                .load(&deps.storage, key("spender2"))
+                .unwrap()
+                .amount,
+            Uint128::zero()
+        );
+
+        // Remove zero allowances
+        remove_zeros(&mut deps);
+
+        // Assert zero was removed, non-zero remains
+        assert!(ALLOWANCES.load(&deps.storage, key("spender2")).is_err());
+        assert!(ALLOWANCES.load(&deps.storage, key("spender")).is_ok());
+
+        // Save balances
+        BALANCES
+            .save(&mut deps.storage, key("owner"), &Uint128::zero())
+            .unwrap();
+        BALANCES
+            .save(&mut deps.storage, key("owner2"), &Uint128::new(10))
+            .unwrap();
+
+        // Remove zero balances
+        remove_zeros(&mut deps);
+
+        // Assert zero was removed, non-zero remains
+        assert!(BALANCES.load(&deps.storage, key("owner")).is_err());
+        assert!(BALANCES.load(&deps.storage, key("owner2")).is_ok());
     }
 }

--- a/packages/euclid/src/error.rs
+++ b/packages/euclid/src/error.rs
@@ -262,6 +262,9 @@ pub enum ContractError {
 
     #[error("Unsupported Euclid Receive Message")]
     UnsupportedEuclidReceiveMessage {},
+
+    #[error("Balance not found for key: {key}")]
+    BalanceNotFound { key: String },
 }
 
 impl ContractError {

--- a/packages/euclid/src/msgs/virtual_balance.rs
+++ b/packages/euclid/src/msgs/virtual_balance.rs
@@ -26,6 +26,7 @@ pub enum ExecuteMsg {
         router: Option<String>,
         admin: Option<Addr>,
     },
+    RemoveZeroStateValues {},
     Approve(ExecuteApprove),
 }
 


### PR DESCRIPTION
# Pull Request

## Description
After burning or transferring, if the new balance or allowance is zero, it's removed from state. 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor/Chore

## Related Issue

[Link to related issue, if applicable]

## Testing

Steps to test:

1. [Step 1]
2. [Step 2]
3. [Step 3]

## Checklist

- [ ] Self-review completed
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated (if applicable)

## Screenshots (if applicable)

[Add screenshots here]

## Additional Notes

[Any additional information or context]