### PR TITLE
fix: add missing meta field in ExecuteSwapRequest initialization

### DIFF
--- a/packages/euclid/src/chain.rs
+++ b/packages/euclid/src/chain.rs
@@ -54,13 +54,13 @@ impl<'a> PrimaryKey<'a> for ChainUid {
     type Suffix = Self;
     type SuperSuffix = Self;
 
-    fn key(&self) -> Vec<Key> {
+    fn key(&self) -> Vec<Key<'_>> {
         vec![Key::Ref(self.0.as_bytes())]
     }
 }
 
 impl<'a> Prefixer<'a> for ChainUid {
-    fn prefix(&self) -> Vec<Key> {
+    fn prefix(&self) -> Vec<Key<'_>> {
         vec![Key::Ref(self.0.as_bytes())]
     }
 }

--- a/packages/euclid/src/token.rs
+++ b/packages/euclid/src/token.rs
@@ -97,13 +97,13 @@ impl<'a> PrimaryKey<'a> for Token {
     type Suffix = Self;
     type SuperSuffix = Self;
 
-    fn key(&self) -> Vec<Key> {
+    fn key(&self) -> Vec<Key<'_>> {
         vec![Key::Ref(self.as_bytes())]
     }
 }
 
 impl<'a> Prefixer<'a> for Token {
-    fn prefix(&self) -> Vec<Key> {
+    fn prefix(&self) -> Vec<Key<'_>> {
         vec![Key::Ref(self.as_bytes())]
     }
 }
@@ -200,7 +200,7 @@ impl<'a> PrimaryKey<'a> for Pair {
     type Suffix = Token;
     type SuperSuffix = Self;
 
-    fn key(&self) -> Vec<Key> {
+    fn key(&self) -> Vec<Key<'_>> {
         let token_1_key_size = self.token_1.joined_key().len();
         assert!(
             token_1_key_size <= u16::MAX as usize,

--- a/tests-integration/src/helpers/factory.rs
+++ b/tests-integration/src/helpers/factory.rs
@@ -162,6 +162,7 @@ pub fn swap_request(
                 swaps,
                 cross_chain_addresses,
                 partner_fee,
+                meta: None,
             }),
             Some(&funds),
         )

--- a/tests-integration/src/tests/factory.rs
+++ b/tests-integration/src/tests/factory.rs
@@ -1971,6 +1971,7 @@ fn test_swap_request() {
                     forwarding_message: None,
                 }],
                 partner_fee: None,
+                meta: None,
             }),
             Some(&[coin(100u128, "eucl")]),
         )


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes a compilation error in the integration tests caused by a missing meta field in the initialization of the ExecuteSwapRequest struct.
The meta field was recently added to the euclid::msgs::factory::ExecuteSwapRequest definition, but the test modules (factory.rs and helpers) were not updated accordingly.

This update ensures that all ExecuteSwapRequest initializations now include meta: None, restoring successful compilation and test execution.

## Type of Change

- [✅] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor/Chore

## Related Issue

No official issue number, but this resolves the build error:

' error[E0063]: missing field `meta` in initializer of `euclid::msgs::factory::ExecuteSwapRequest`
    --> tests-integration\src\tests\factory.rs:1946:68
     |
1946 |             &euclid::msgs::factory::ExecuteMsg::ExecuteSwapRequest(ExecuteSwapRequest {
     |                                                                    ^^^^^^^^^^^^^^^^^^ missing `meta`

error[E0063]: missing field `meta` in initializer of `euclid::msgs::factory::ExecuteSwapRequest`
   --> tests-integration\src\helpers\factory.rs:155:68
    |
155 |             &euclid::msgs::factory::ExecuteMsg::ExecuteSwapRequest(ExecuteSwapRequest {
    |                                                                    ^^^^^^^^^^^^^^^^^^ missing `meta` '

## Testing

Steps to test:

1. Pull the latest code and apply this fix.
2. Run integration tests:
    ' cargo test '
3. Ensure all tests compile and pass successfully.

## Checklist

- [✔] Self-review completed
- [✔] Tests compile successfully
- [✔] No functionality changed
- [ ] Documentation updated (not required for this fix)

## Screenshots (if applicable)

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/db1f88d9-f242-4930-9646-c26af5e648a6" />

## Additional Notes

This fix does not introduce any behavioral or functional change.
It only restores compatibility between the integration test suite and the latest euclid message definitions that include the meta field.