### PR TITLE
Update Rate Limit Logic and Add buckets for validators in relayer

### DIFF
--- a/contracts/common/euclid-relayer/src/contract.rs
+++ b/contracts/common/euclid-relayer/src/contract.rs
@@ -12,7 +12,7 @@ use crate::{
         execute_update_admin, execute_update_state,
     },
     query::{get_state, get_validators, nonce_relayed},
-    state::{STATE, VALIDATORS},
+    state::STATE,
 };
 
 // version info for migration info

--- a/contracts/common/euclid-relayer/src/contract.rs
+++ b/contracts/common/euclid-relayer/src/contract.rs
@@ -33,7 +33,6 @@ pub fn instantiate(
     };
     STATE.save(deps.storage, &state)?;
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-    VALIDATORS.save(deps.storage, &msg.validators)?;
     Ok(Response::new()
         .add_attribute("method", "instantiate")
         .add_attribute(
@@ -60,12 +59,14 @@ pub fn execute(
         }
         ExecuteMsg::UpdateState(msg) => execute_update_state(&mut deps, &info, msg),
         ExecuteMsg::UpdateAdmin(msg) => execute_update_admin(&mut deps, &info, msg),
-        ExecuteMsg::AddValidator { validator } => {
-            execute_add_validator(&mut deps, &info, validator)
-        }
-        ExecuteMsg::RemoveValidator { validator } => {
-            execute_remove_validator(&mut deps, &info, validator)
-        }
+        ExecuteMsg::AddValidator {
+            validator,
+            chain_uid,
+        } => execute_add_validator(&mut deps, &info, validator, chain_uid),
+        ExecuteMsg::RemoveValidator {
+            validator,
+            chain_uid,
+        } => execute_remove_validator(&mut deps, &info, validator, chain_uid),
     }
 }
 

--- a/contracts/common/euclid-relayer/src/execute.rs
+++ b/contracts/common/euclid-relayer/src/execute.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::{
     ensure, from_json, DepsMut, Env, MessageInfo, Response, Timestamp, Uint128, WasmMsg,
 };
-use euclid::error::ContractError;
+use euclid::{chain::ChainUid, error::ContractError};
 use relayer::{
     msgs::{MetaTransaction, UpdateAdminMsg, UpdateStateMsg},
     verify::verify_signature,
@@ -107,7 +107,9 @@ pub fn execute_meta_transaction(
     )?;
 
     ensure!(verified, ContractError::new("Invalid admin signature"));
-    let validators = VALIDATORS.load(deps.storage)?;
+    let validators = VALIDATORS
+        .load(deps.storage, msg.chain_uid.clone())
+        .unwrap_or(vec![]);
     let mut visited = vec![false; validators.len()];
     let mut valid_signatures = 0;
     for signature in msg.validator_signatures {
@@ -164,16 +166,19 @@ pub fn execute_add_validator(
     deps: &mut DepsMut,
     info: &MessageInfo,
     validator: Validator,
+    chain_uid: ChainUid,
 ) -> Result<Response, ContractError> {
     let state = STATE.load(deps.storage)?;
     ensure!(info.sender == state.admin, ContractError::Unauthorized {});
-    let mut validators = VALIDATORS.load(deps.storage)?;
+    let mut validators = VALIDATORS
+        .load(deps.storage, chain_uid.clone())
+        .unwrap_or(vec![]);
     ensure!(
         !validators.contains(&validator),
         ContractError::new("Validator already exists")
     );
     validators.push(validator.clone());
-    VALIDATORS.save(deps.storage, &validators)?;
+    VALIDATORS.save(deps.storage, chain_uid, &validators)?;
     Ok(Response::new().add_attribute("validator_added", validator.address.to_string()))
 }
 
@@ -181,10 +186,13 @@ pub fn execute_remove_validator(
     deps: &mut DepsMut,
     info: &MessageInfo,
     validator: Validator,
+    chain_uid: ChainUid,
 ) -> Result<Response, ContractError> {
     let state = STATE.load(deps.storage)?;
     ensure!(info.sender == state.admin, ContractError::Unauthorized {});
-    let mut validators = VALIDATORS.load(deps.storage)?;
+    let mut validators = VALIDATORS
+        .load(deps.storage, chain_uid.clone())
+        .unwrap_or(vec![]);
     let index = validators
         .iter()
         .position(|v| v.address == validator.address);
@@ -193,6 +201,6 @@ pub fn execute_remove_validator(
     } else {
         return Err(ContractError::new("Validator does not exist"));
     }
-    VALIDATORS.save(deps.storage, &validators)?;
+    VALIDATORS.save(deps.storage, chain_uid, &validators)?;
     Ok(Response::new().add_attribute("validator_removed", validator.address.clone()))
 }

--- a/contracts/common/euclid-relayer/src/execute.rs
+++ b/contracts/common/euclid-relayer/src/execute.rs
@@ -101,7 +101,7 @@ pub fn execute_meta_transaction(
 
     let verified = verify_signature(
         deps.as_ref(),
-        &expiry_call_data(&msg.data, msg.expiry),
+        &expiry_call_data(&msg.data, msg.expiry, msg.chain_uid.as_str()),
         &msg.admin_signature,
         &state.message_signer.pubkey,
     )?;
@@ -122,7 +122,7 @@ pub fn execute_meta_transaction(
         }
         let verified = verify_signature(
             deps.as_ref(),
-            &expiry_call_data(&msg.data, signature.expiry),
+            &expiry_call_data(&msg.data, signature.expiry, msg.chain_uid.as_str()),
             &signature.signature,
             &signature.pubkey,
         )?;
@@ -157,8 +157,13 @@ pub fn execute_meta_transaction(
         .add_attribute("relayer_sender", info.sender.to_string()))
 }
 
-fn expiry_call_data(data: &str, expiry: u64) -> String {
-    let expiry_call_data = format!("{data},{expiry}", data = data, expiry = expiry);
+fn expiry_call_data(data: &str, expiry: u64, chain_uid: &str) -> String {
+    let expiry_call_data = format!(
+        "{data},{expiry},{chain_uid}",
+        data = data,
+        expiry = expiry,
+        chain_uid = chain_uid
+    );
     expiry_call_data
 }
 

--- a/contracts/common/euclid-relayer/src/execute.rs
+++ b/contracts/common/euclid-relayer/src/execute.rs
@@ -109,7 +109,7 @@ pub fn execute_meta_transaction(
     ensure!(verified, ContractError::new("Invalid admin signature"));
     let validators = VALIDATORS
         .load(deps.storage, msg.chain_uid.clone())
-        .unwrap_or(vec![]);
+        .map_err(|_| ContractError::new("Validators not found for chain"))?;
     let mut visited = vec![false; validators.len()];
     let mut valid_signatures = 0;
     for signature in msg.validator_signatures {

--- a/contracts/common/euclid-relayer/src/query.rs
+++ b/contracts/common/euclid-relayer/src/query.rs
@@ -1,6 +1,6 @@
-use cosmwasm_std::Deps;
+use cosmwasm_std::{Deps, Order};
 use euclid::error::ContractError;
-use relayer::{msgs::State, ValidatorsResponse};
+use relayer::{msgs::State, ValidatorsResponse, ValidatorsResponseItem};
 
 use crate::state::{NONCES, STATE, VALIDATORS};
 
@@ -14,6 +14,16 @@ pub fn nonce_relayed(deps: &Deps, nonce: String) -> Result<bool, ContractError> 
 }
 
 pub fn get_validators(deps: &Deps) -> Result<ValidatorsResponse, ContractError> {
-    let validators = VALIDATORS.load(deps.storage)?;
+    let mut validators = vec![];
+    let iter = VALIDATORS.range(deps.storage, None, None, Order::Ascending);
+    for v in iter {
+        let (chain_uid, chain_validators) = v?;
+        for validator in chain_validators.iter() {
+            validators.push(ValidatorsResponseItem {
+                validator: validator.clone(),
+                chain_uid: chain_uid.clone(),
+            });
+        }
+    }
     Ok(ValidatorsResponse { validators })
 }

--- a/contracts/common/euclid-relayer/src/state.rs
+++ b/contracts/common/euclid-relayer/src/state.rs
@@ -1,9 +1,10 @@
 use cosmwasm_std::Uint128;
 use cw_storage_plus::{Item, Map};
+use euclid::chain::ChainUid;
 use relayer::{msgs::State, Validator};
 
 pub const STATE: Item<State> = Item::new("state");
 
-pub const VALIDATORS: Item<Vec<Validator>> = Item::new("validators");
+pub const VALIDATORS: Map<ChainUid, Vec<Validator>> = Map::new("validators");
 // nonce -> block height when it was relayed
 pub const NONCES: Map<String, Uint128> = Map::new("nonces");

--- a/contracts/hub/router/src/execute/token.rs
+++ b/contracts/hub/router/src/execute/token.rs
@@ -5,7 +5,6 @@ use cosmwasm_std::{
 use euclid::{
     cross_chain_user::CrossChainUser,
     error::ContractError,
-    events::simple_event,
     limit::Limit,
     msgs::{cross_chain_config::CrossChainConfig, router::TokenDenom},
     recipient::Recipient,

--- a/contracts/liquidity/factory/src/contract.rs
+++ b/contracts/liquidity/factory/src/contract.rs
@@ -2,9 +2,7 @@ use std::collections::HashMap;
 
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::{
-    Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError, Uint128, Uint512,
-};
+use cosmwasm_std::{Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdError, Uint512};
 use cw2::set_contract_version;
 use euclid::cross_chain_user::CrossChainUser;
 use euclid::error::ContractError;

--- a/contracts/liquidity/factory/src/execute/relay.rs
+++ b/contracts/liquidity/factory/src/execute/relay.rs
@@ -22,7 +22,9 @@ use euclid_ibc::{
 
 use crate::{
     ibc::{ack_and_timeout, receive},
-    rate_limit::{calc_fee, USER_FREE_LIMIT, USER_PENDING_PACKETS_COUNT, USER_TOTAL_PACKETS_COUNT},
+    rate_limit::{
+        ensure_rate_limit_exceeded, USER_PENDING_PACKETS_COUNT, USER_TOTAL_PACKETS_COUNT,
+    },
     relay_state::{
         CROSS_CHAIN_LATEST_SEQUENCE_COUNT, CROSS_CHAIN_PENDING_PACKET_SENDER,
         CROSS_CHAIN_PENDING_SEND_PACKETS, CROSS_CHAIN_PROCESSED_RECEIVED_PACKETS,
@@ -54,15 +56,7 @@ pub fn execute_send_packet(
 
     let factory_state = STATE.load(deps.storage)?;
 
-    let user_pending_packets_count = USER_PENDING_PACKETS_COUNT
-        .load(deps.storage, sender.clone())
-        .unwrap_or(0);
-
-    let user_free_limit = USER_FREE_LIMIT.may_load(deps.storage, sender.clone())?;
-    let rate_limit_fee = calc_fee(&deps, user_pending_packets_count, user_free_limit)?;
-    if rate_limit_fee.gt(&Uint128::zero()) {
-        // TODO: Deduct rate limit credits from the user
-    }
+    ensure_rate_limit_exceeded(&deps, sender.clone())?;
 
     let sequence = CROSS_CHAIN_LATEST_SEQUENCE_COUNT
         .load(deps.storage)
@@ -79,6 +73,10 @@ pub fn execute_send_packet(
     )?;
     CROSS_CHAIN_PENDING_PACKET_SENDER.save(deps.storage, sequence, &sender)?;
     CROSS_CHAIN_LATEST_SEQUENCE_COUNT.save(deps.storage, &sequence.add(1))?;
+
+    let user_pending_packets_count = USER_PENDING_PACKETS_COUNT
+        .load(deps.storage, sender.clone())
+        .unwrap_or(0);
 
     // Update user pending packets count
     USER_PENDING_PACKETS_COUNT.save(

--- a/contracts/liquidity/factory/src/rate_limit.rs
+++ b/contracts/liquidity/factory/src/rate_limit.rs
@@ -22,7 +22,7 @@ pub const USER_TOTAL_PACKETS_COUNT: Map<Addr, u128> = Map::new("user_total_packe
 pub const USER_PENDING_PACKETS_COUNT: Map<Addr, u128> = Map::new("user_pending_packets_count");
 
 pub fn ensure_rate_limit_exceeded(deps: &DepsMut, sender: Addr) -> Result<(), ContractError> {
-    let state = RATE_LIMIT_STATE.load(deps.storage)?;
+    // User free limit provides custom rate limit for a user
     let user_free_limit = USER_FREE_LIMIT.may_load(deps.storage, sender.clone())?;
 
     let pending_count = USER_PENDING_PACKETS_COUNT
@@ -35,10 +35,114 @@ pub fn ensure_rate_limit_exceeded(deps: &DepsMut, sender: Addr) -> Result<(), Co
             ContractError::RateLimitExceeded {}
         );
     } else {
+        let state = RATE_LIMIT_STATE.load(deps.storage)?;
         ensure!(
             pending_count < state.free_limit,
             ContractError::RateLimitExceeded {}
         );
     }
     Ok(())
+}
+
+mod tests {
+    use cosmwasm_std::testing::mock_dependencies;
+
+    use super::*;
+
+    #[test]
+    fn test_ensure_rate_limit_pass() {
+        let mut deps = mock_dependencies();
+        let sender = Addr::unchecked("sender");
+        USER_FREE_LIMIT
+            .save(deps.as_mut().storage, sender.clone(), &100)
+            .unwrap();
+        USER_PENDING_PACKETS_COUNT
+            .save(deps.as_mut().storage, sender.clone(), &99)
+            .unwrap();
+        RATE_LIMIT_STATE
+            .save(
+                deps.as_mut().storage,
+                &RateLimitState {
+                    free_limit: 100,
+                    fee_brackets: vec![],
+                },
+            )
+            .unwrap();
+        assert!(
+            ensure_rate_limit_exceeded(&deps.as_mut(), sender).is_ok(),
+            "Rate limit should pass"
+        );
+    }
+
+    #[test]
+    fn test_ensure_rate_limit_exceeded() {
+        let mut deps = mock_dependencies();
+        let sender = Addr::unchecked("sender");
+        USER_FREE_LIMIT
+            .save(deps.as_mut().storage, sender.clone(), &100)
+            .unwrap();
+        USER_PENDING_PACKETS_COUNT
+            .save(deps.as_mut().storage, sender.clone(), &100)
+            .unwrap();
+        RATE_LIMIT_STATE
+            .save(
+                deps.as_mut().storage,
+                &RateLimitState {
+                    free_limit: 100,
+                    fee_brackets: vec![],
+                },
+            )
+            .unwrap();
+        assert!(
+            ensure_rate_limit_exceeded(&deps.as_mut(), sender).is_err(),
+            "Rate limit should be exceeded"
+        );
+    }
+
+    #[test]
+    fn test_ensure_rate_limit_exceeded_no_user_free_limit() {
+        let mut deps = mock_dependencies();
+        let sender = Addr::unchecked("sender");
+        USER_PENDING_PACKETS_COUNT
+            .save(deps.as_mut().storage, sender.clone(), &100)
+            .unwrap();
+        RATE_LIMIT_STATE
+            .save(
+                deps.as_mut().storage,
+                &RateLimitState {
+                    free_limit: 10,
+                    fee_brackets: vec![],
+                },
+            )
+            .unwrap();
+        assert!(
+            ensure_rate_limit_exceeded(&deps.as_mut(), sender).is_err(),
+            "Rate limit should be exceeded because free limit is 10 and pending count is 100"
+        );
+    }
+
+    #[test]
+    fn test_ensure_rate_limit_exceeded_both_free_limit_and_user_free_limit_are_set() {
+        let mut deps = mock_dependencies();
+        let sender = Addr::unchecked("sender");
+        USER_FREE_LIMIT
+            .save(deps.as_mut().storage, sender.clone(), &10)
+            .unwrap();
+        USER_PENDING_PACKETS_COUNT
+            .save(deps.as_mut().storage, sender.clone(), &50)
+            .unwrap();
+        RATE_LIMIT_STATE
+            .save(
+                deps.as_mut().storage,
+                &RateLimitState {
+                    free_limit: 100,
+                    fee_brackets: vec![],
+                },
+            )
+            .unwrap();
+        assert!(
+            ensure_rate_limit_exceeded(&deps.as_mut(), sender).is_err(),
+            "Rate limit should be exceeded even if free limit is more than user free limit"
+        );
+    }
 }

--- a/contracts/liquidity/factory/src/rate_limit.rs
+++ b/contracts/liquidity/factory/src/rate_limit.rs
@@ -32,13 +32,19 @@ pub fn ensure_rate_limit_exceeded(deps: &DepsMut, sender: Addr) -> Result<(), Co
     if let Some(user_free_limit) = user_free_limit {
         ensure!(
             pending_count < user_free_limit,
-            ContractError::RateLimitExceeded {}
+            ContractError::RateLimitExceeded {
+                limit: user_free_limit,
+                actual: pending_count,
+            }
         );
     } else {
         let state = RATE_LIMIT_STATE.load(deps.storage)?;
         ensure!(
             pending_count < state.free_limit,
-            ContractError::RateLimitExceeded {}
+            ContractError::RateLimitExceeded {
+                limit: state.free_limit,
+                actual: pending_count,
+            }
         );
     }
     Ok(())

--- a/contracts/liquidity/factory/src/rate_limit.rs
+++ b/contracts/liquidity/factory/src/rate_limit.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, DepsMut, Uint128};
+use cosmwasm_std::{ensure, Addr, DepsMut, Uint128};
 use cw_storage_plus::{Item, Map};
 use euclid::error::ContractError;
 
@@ -21,28 +21,24 @@ pub const USER_TOTAL_PACKETS_COUNT: Map<Addr, u128> = Map::new("user_total_packe
 
 pub const USER_PENDING_PACKETS_COUNT: Map<Addr, u128> = Map::new("user_pending_packets_count");
 
-pub fn calc_fee(
-    deps: &DepsMut,
-    count: u128,
-    free_limit: Option<u128>,
-) -> Result<Uint128, ContractError> {
+pub fn ensure_rate_limit_exceeded(deps: &DepsMut, sender: Addr) -> Result<(), ContractError> {
     let state = RATE_LIMIT_STATE.load(deps.storage)?;
-    let free_limit = free_limit.unwrap_or(state.free_limit);
+    let user_free_limit = USER_FREE_LIMIT.may_load(deps.storage, sender.clone())?;
 
-    // If count is less than or equal to free limit, return zero fee
-    if count.le(&free_limit) {
-        return Ok(Uint128::zero());
+    let pending_count = USER_PENDING_PACKETS_COUNT
+        .load(deps.storage, sender.clone())
+        .unwrap_or(0);
+
+    if let Some(user_free_limit) = user_free_limit {
+        ensure!(
+            pending_count < user_free_limit,
+            ContractError::RateLimitExceeded {}
+        );
+    } else {
+        ensure!(
+            pending_count < state.free_limit,
+            ContractError::RateLimitExceeded {}
+        );
     }
-
-    // If count is greater than free limit, calculate fee
-    let fee_brackets = state.fee_brackets;
-
-    // Loop from last to first fee bracket and return on the first that is less than count
-    for bracket in fee_brackets.iter().rev() {
-        if count >= bracket.threshold {
-            return Ok(bracket.fee);
-        }
-    }
-
-    Ok(Uint128::zero())
+    Ok(())
 }

--- a/contracts/liquidity/factory/src/rate_limit.rs
+++ b/contracts/liquidity/factory/src/rate_limit.rs
@@ -50,6 +50,7 @@ pub fn ensure_rate_limit_exceeded(deps: &DepsMut, sender: Addr) -> Result<(), Co
     Ok(())
 }
 
+#[cfg(test)]
 mod tests {
     use cosmwasm_std::testing::mock_dependencies;
 

--- a/packages/euclid/src/error.rs
+++ b/packages/euclid/src/error.rs
@@ -274,6 +274,9 @@ pub enum ContractError {
 
     #[error("Balance not found for key: {key}")]
     BalanceNotFound { key: String },
+
+    #[error("Rate limit exceeded")]
+    RateLimitExceeded {},
 }
 
 impl ContractError {

--- a/packages/euclid/src/error.rs
+++ b/packages/euclid/src/error.rs
@@ -275,8 +275,8 @@ pub enum ContractError {
     #[error("Balance not found for key: {key}")]
     BalanceNotFound { key: String },
 
-    #[error("Rate limit exceeded")]
-    RateLimitExceeded {},
+    #[error("Rate limit exceeded: limit {limit}, actual {actual}")]
+    RateLimitExceeded { limit: u128, actual: u128 },
 }
 
 impl ContractError {

--- a/packages/relayer/src/msgs.rs
+++ b/packages/relayer/src/msgs.rs
@@ -1,11 +1,11 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Binary};
+use euclid::chain::ChainUid;
 
 #[cw_serde]
 pub struct InstantiateMsg {
     pub message_signer: Validator,
     pub signature_threshold: u8,
-    pub validators: Vec<Validator>,
 }
 
 #[cw_serde]
@@ -14,8 +14,14 @@ pub enum ExecuteMsg {
     ExecuteMetaTransaction(MetaTransaction),
     UpdateState(UpdateStateMsg),
     UpdateAdmin(UpdateAdminMsg),
-    AddValidator { validator: Validator },
-    RemoveValidator { validator: Validator },
+    AddValidator {
+        validator: Validator,
+        chain_uid: ChainUid,
+    },
+    RemoveValidator {
+        validator: Validator,
+        chain_uid: ChainUid,
+    },
 }
 
 #[cw_serde]
@@ -57,6 +63,7 @@ pub struct MetaTransaction {
     pub expiry: u64,
     pub admin_signature: Binary,
     pub validator_signatures: Vec<ValidatorSignature>,
+    pub chain_uid: ChainUid,
 }
 
 #[cw_serde]
@@ -78,8 +85,14 @@ pub struct UpdateAdminMsg {
 }
 
 #[cw_serde]
+pub struct ValidatorsResponseItem {
+    pub validator: Validator,
+    pub chain_uid: ChainUid,
+}
+
+#[cw_serde]
 pub struct ValidatorsResponse {
-    pub validators: Vec<Validator>,
+    pub validators: Vec<ValidatorsResponseItem>,
 }
 
 #[cw_serde]

--- a/tests-integration/src/helpers/chains.rs
+++ b/tests-integration/src/helpers/chains.rs
@@ -20,6 +20,7 @@ use factory::FactoryContract;
 use lp_token::LpTokenContract;
 use meta_transaction::MetaTransactionContract;
 use relayer::verify::cosmos_address_from_pubkey;
+use relayer::ExecuteMsgFns as RelayerExecuteMsgFns;
 use relayer::Validator;
 use router::RouterContract;
 use stable_vlp::StableVlpContract;
@@ -84,7 +85,7 @@ fn setup_factory_inner(
     let factory = FactoryContract::new(chain.clone());
     let escrow = EscrowContract::new(chain.clone());
     let lp_token = LpTokenContract::new(chain.clone());
-    let relayer = setup_relayer(&chain)?;
+    let relayer = setup_relayer(&chain, vec![ChainUid::vsl_chain_uid().unwrap().as_str()])?;
 
     let string_length = factory_chain_id.len();
 
@@ -177,12 +178,15 @@ fn setup_factory_inner(
     Ok(factory)
 }
 
-pub fn setup_router(chain: &MockBase) -> Result<RouterContract<MockBase>, CwOrchError> {
+pub fn setup_router(
+    chain: &MockBase,
+    factory_chains: Vec<&str>,
+) -> Result<RouterContract<MockBase>, CwOrchError> {
     let router = RouterContract::new(chain.clone());
     let virtual_balance = VirtualBalanceContract::new(chain.clone());
     let vlp = VlpContract::new(chain.clone());
     let stable_vlp = StableVlpContract::new(chain.clone());
-    let relayer = setup_relayer(chain)?;
+    let relayer = setup_relayer(chain, factory_chains)?;
 
     router.upload().unwrap();
     virtual_balance.upload().unwrap();
@@ -210,7 +214,10 @@ pub fn setup_router(chain: &MockBase) -> Result<RouterContract<MockBase>, CwOrch
     Ok(router)
 }
 
-pub fn setup_relayer(chain: &MockBase) -> Result<RelayerContract<MockBase>, CwOrchError> {
+pub fn setup_relayer(
+    chain: &MockBase,
+    chain_uids: Vec<&str>,
+) -> Result<RelayerContract<MockBase>, CwOrchError> {
     let relayer = RelayerContract::new(chain.clone());
     let (_, pubkey_binary) = get_signer_key();
 
@@ -227,12 +234,17 @@ pub fn setup_relayer(chain: &MockBase) -> Result<RelayerContract<MockBase>, CwOr
         &relayer::msgs::InstantiateMsg {
             message_signer: validator.clone(),
             signature_threshold: 1,
-            validators: vec![validator],
         },
         Some(&chain.sender),
         &[],
     )?;
-
+    // Add validators to all chains
+    for chain_uid in chain_uids {
+        relayer.add_validator(
+            ChainUid::create(chain_uid.to_string()).unwrap(),
+            validator.clone(),
+        )?;
+    }
     Ok(relayer)
 }
 

--- a/tests-integration/src/helpers/relayer.rs
+++ b/tests-integration/src/helpers/relayer.rs
@@ -60,14 +60,16 @@ fn relay_factory_send_packet_inner(
             destination_port: packet.destination_port.clone(),
             timeout: None,
         };
+        let source_chain_uid = packet.source_port.split('.').next().unwrap();
         let signed_data = sign_relay_messsage(
             to_json_binary(&call_data).unwrap(),
             router.address().unwrap(),
             format!(
                 "{}-{}-{}-receive",
-                packet.source_port, packet.destination_port, packet.sequence
+                packet.source_port, packet.destination_port, packet.sequence,
             ),
             &router.environment().app.borrow(),
+            source_chain_uid,
         );
 
         let response = relayer.execute_meta_transaction(signed_data)?;
@@ -116,6 +118,7 @@ pub fn relay_router_send_packet(
             timeout: None,
         };
 
+        let source_chain_uid = packet.source_port.split('.').next().unwrap();
         let signed_data = sign_relay_messsage(
             to_json_binary(&call_data).unwrap(),
             factory.address().unwrap(),
@@ -124,6 +127,7 @@ pub fn relay_router_send_packet(
                 packet.source_port, packet.destination_port, packet.sequence
             ),
             &factory.environment().app.borrow(),
+            source_chain_uid,
         );
 
         let response = relayer.execute_meta_transaction(signed_data)?;
@@ -169,6 +173,7 @@ pub fn relay_factory_ack_packet(
             ack: packet.ack,
         };
 
+        let source_chain_uid = packet.source_port.split('.').next().unwrap();
         let signed_data = sign_relay_messsage(
             to_json_binary(&call_data).unwrap(),
             factory.address().unwrap(),
@@ -177,6 +182,7 @@ pub fn relay_factory_ack_packet(
                 packet.source_port, packet.destination_port, packet.sequence
             ),
             &factory.environment().app.borrow(),
+            source_chain_uid,
         );
 
         let response = relayer.execute_meta_transaction(signed_data)?;
@@ -211,6 +217,7 @@ pub fn relay_router_ack_packet(
             sequence: packet.sequence,
             ack: packet.ack,
         };
+        let source_chain_uid = packet.source_port.split('.').next().unwrap();
         let signed_data = sign_relay_messsage(
             to_json_binary(&call_data).unwrap(),
             router.address().unwrap(),
@@ -219,6 +226,7 @@ pub fn relay_router_ack_packet(
                 packet.source_port, packet.destination_port, packet.sequence
             ),
             &router.environment().app.borrow(),
+            source_chain_uid,
         );
 
         let response = relayer.execute_meta_transaction(signed_data);
@@ -264,12 +272,13 @@ pub fn ack_register_factory_evm(
         sequence,
         ack: ack_binary,
     };
-
+    let source_chain_uid = chain_uid.as_str();
     let signed_data = sign_relay_messsage(
         to_json_binary(&call_data).unwrap(),
         router.address().unwrap(),
         format!("{}-{}-{}-ack", evm_port, vsl_port, 0,),
         &router.environment().app.borrow(),
+        source_chain_uid,
     );
 
     let response = relayer.execute_meta_transaction(signed_data);
@@ -347,6 +356,7 @@ pub fn sign_relay_messsage(
     target: Addr,
     nonce: String,
     app: &App,
+    source_chain_uid: &str,
 ) -> RelayerMetaTransaction {
     let meta_tx_data = RelayerMetaTransactionData {
         call_data,
@@ -373,6 +383,7 @@ pub fn sign_relay_messsage(
             signature: admin_signature,
             expiry: app.block_info().time.plus_seconds(60).seconds(),
         }],
+        chain_uid: ChainUid::create(source_chain_uid.to_string()).unwrap(),
     }
 }
 

--- a/tests-integration/src/helpers/relayer.rs
+++ b/tests-integration/src/helpers/relayer.rs
@@ -365,7 +365,12 @@ pub fn sign_relay_messsage(
     };
     let expiry = app.block_info().time.plus_seconds(60).seconds();
     let msg = to_json_string(&meta_tx_data).unwrap();
-    let expiry_call_data = format!("{msg},{expiry}", msg = msg, expiry = expiry);
+    let expiry_call_data = format!(
+        "{msg},{expiry},{source_chain_uid}",
+        msg = msg,
+        expiry = expiry,
+        source_chain_uid = source_chain_uid
+    );
     let message_digest = Sha256::new().chain(expiry_call_data.as_bytes());
 
     let (secret_key, pubkey) = get_signer_key();

--- a/tests-integration/src/tests/claimer.rs
+++ b/tests-integration/src/tests/claimer.rs
@@ -43,7 +43,7 @@ fn setup_claimer_and_factory() -> (
     let interchain = MockInterchainEnv::new(vec![("osmosis", &sender), ("nibiru", &sender)]);
     let router_chain = interchain.get_chain("nibiru").unwrap();
 
-    let router = setup_router(&router_chain).unwrap();
+    let router = setup_router(&router_chain, vec!["osmosis", "nibiru"]).unwrap();
     let osmosis_factory = setup_factory(&interchain, "osmosis", "nibiru", &router).unwrap();
     let vcoin_address = get_virtual_balance(
         &router_chain,
@@ -60,7 +60,7 @@ fn test_proper_instantiation() {
     let _factory_chain = interchain.get_chain("osmosis").unwrap();
     let router_chain = interchain.get_chain("nibiru").unwrap();
 
-    let router = setup_router(&router_chain).unwrap();
+    let router = setup_router(&router_chain, vec!["osmosis", "nibiru"]).unwrap();
     let vcoin_address = get_virtual_balance(
         &router_chain,
         &router.get_state().unwrap().virtual_balance_address,

--- a/tests-integration/src/tests/factory.rs
+++ b/tests-integration/src/tests/factory.rs
@@ -150,7 +150,7 @@ fn run_create_pool_with_funds(router_chain_id: &str, factory_chain_id: &str) {
         )
         .unwrap();
 
-    let router_contract = setup_router(&router).unwrap();
+    let router_contract = setup_router(&router, vec![factory_chain_id]).unwrap();
     let router_state = router_contract.get_state().unwrap();
 
     let _virtual_balance_router =
@@ -477,7 +477,7 @@ fn run_add_liquidity(factory_chain_id: &str, router_chain_id: &str) {
         )
         .unwrap();
 
-    let router_contract = setup_router(&router_chain).unwrap();
+    let router_contract = setup_router(&router_chain, vec![factory_chain_id]).unwrap();
     let _router_state = router_contract.get_state().unwrap();
 
     let factory_chain_uid = ChainUid::create(factory_chain_id.to_string()).unwrap();
@@ -697,7 +697,7 @@ fn test_add_liquidity_fails_with_invalid_slippage_tolerance() {
     let _factory_chain = interchain.get_chain("osmosis").unwrap();
     let router_chain = interchain.get_chain("nibiru").unwrap();
 
-    let router = setup_router(&router_chain).unwrap();
+    let router = setup_router(&router_chain, vec!["osmosis", "nibiru"]).unwrap();
     let factory = setup_factory(&interchain, "osmosis", "nibiru", &router).unwrap();
 
     let pair_info = PairWithDenomAndAmount {
@@ -751,7 +751,7 @@ fn test_add_liquidity_fails_when_pool_does_not_exit() {
     let interchain = MockInterchainEnv::new(vec![("osmosis", &sender), ("nibiru", &sender)]);
     let router_chain = interchain.get_chain("nibiru").unwrap();
 
-    let router = setup_router(&router_chain).unwrap();
+    let router = setup_router(&router_chain, vec!["osmosis", "nibiru"]).unwrap();
     let factory = setup_factory(&interchain, "osmosis", "nibiru", &router).unwrap();
 
     let pair_info = PairWithDenomAndAmount {
@@ -806,7 +806,7 @@ fn test_add_liquidity_fails_with_zero_liquidity_amount() {
     let interchain = MockInterchainEnv::new(vec![("osmosis", &sender), ("nibiru", &sender)]);
     let router_chain = interchain.get_chain("nibiru").unwrap();
 
-    let router = setup_router(&router_chain).unwrap();
+    let router = setup_router(&router_chain, vec!["osmosis", "nibiru"]).unwrap();
     let factory = setup_factory(&interchain, "osmosis", "nibiru", &router).unwrap();
 
     let pair_info = PairWithDenomAndAmount {
@@ -869,7 +869,7 @@ fn test_add_liquidity_fails_with_insufficient_deposit() {
     let interchain = MockInterchainEnv::new(vec![("osmosis", &sender), ("nibiru", &sender)]);
     let router_chain = interchain.get_chain("nibiru").unwrap();
 
-    let router = setup_router(&router_chain).unwrap();
+    let router = setup_router(&router_chain, vec!["osmosis", "nibiru"]).unwrap();
     let factory = setup_factory(&interchain, "osmosis", "nibiru", &router).unwrap();
 
     let pair_info = PairWithDenomAndAmount {
@@ -917,7 +917,7 @@ fn test_add_liquidity_fails_with_unsupported_token_denomination() {
     let interchain = MockInterchainEnv::new(vec![("osmosis", &sender), ("nibiru", &sender)]);
     let router_chain = interchain.get_chain("nibiru").unwrap();
 
-    let router = setup_router(&router_chain).unwrap();
+    let router = setup_router(&router_chain, vec!["osmosis", "nibiru"]).unwrap();
     let factory = setup_factory(&interchain, "osmosis", "nibiru", &router).unwrap();
 
     let mut pair_info = PairWithDenomAndAmount {
@@ -985,7 +985,7 @@ fn test_add_liquidity_fails_with_extra_funds() {
     let interchain = MockInterchainEnv::new(vec![("osmosis", &sender), ("nibiru", &sender)]);
     let router_chain = interchain.get_chain("nibiru").unwrap();
 
-    let router = setup_router(&router_chain).unwrap();
+    let router = setup_router(&router_chain, vec!["osmosis", "nibiru"]).unwrap();
     let factory = setup_factory(&interchain, "osmosis", "nibiru", &router).unwrap();
 
     let pair_info = PairWithDenomAndAmount {
@@ -1098,7 +1098,7 @@ fn run_remove_liquidity(factory_chain_id: &str, router_chain_id: &str) {
         )
         .unwrap();
 
-    let router_contract = setup_router(&router_chain).unwrap();
+    let router_contract = setup_router(&router_chain, vec![factory_chain_id]).unwrap();
     let _router_state = router_contract.get_state().unwrap();
 
     let factory_chain_uid = ChainUid::create(factory_chain_id.to_string()).unwrap();
@@ -1378,7 +1378,7 @@ fn run_test_swap_request(factory_chain_id: &str, router_chain_id: &str) {
     }
     let interchain = MockInterchainEnv::new(chains);
     let router_chain = interchain.get_chain(router_chain_id).unwrap();
-    let router = setup_router(&router_chain).unwrap();
+    let router = setup_router(&router_chain, vec![factory_chain_id]).unwrap();
 
     let factory = setup_factory(&interchain, factory_chain_id, router_chain_id, &router).unwrap();
 
@@ -1541,7 +1541,7 @@ fn run_test_multi_hop_swap_request(factory_chain_id: &str, router_chain_id: &str
     let factory_chain = interchain.get_chain(factory_chain_id).unwrap();
     let factory_chain_uid = ChainUid::create(factory_chain_id.to_string()).unwrap();
     let router_chain = interchain.get_chain(router_chain_id).unwrap();
-    let router = setup_router(&router_chain).unwrap();
+    let router = setup_router(&router_chain, vec![factory_chain_id]).unwrap();
 
     let factory = setup_factory(&interchain, factory_chain_id, router_chain_id, &router).unwrap();
 
@@ -1702,7 +1702,7 @@ fn run_swap_request_with_valid_partner_fee(factory_chain_id: &str, router_chain_
     let interchain = MockInterchainEnv::new(chains);
     let router_chain = interchain.get_chain(router_chain_id).unwrap();
 
-    let router = setup_router(&router_chain).unwrap();
+    let router = setup_router(&router_chain, vec![factory_chain_id]).unwrap();
     let factory = setup_factory(&interchain, factory_chain_id, router_chain_id, &router).unwrap();
 
     let pair_info = PairWithDenomAndAmount {
@@ -1822,7 +1822,7 @@ fn test_swap_request_fails_with_invalid_partner_fee_bps() {
     let interchain = MockInterchainEnv::new(vec![("osmosis", &sender), ("nibiru", &sender)]);
     let router_chain = interchain.get_chain("nibiru").unwrap();
 
-    let router = setup_router(&router_chain).unwrap();
+    let router = setup_router(&router_chain, vec!["osmosis", "nibiru"]).unwrap();
     let factory = setup_factory(&interchain, "osmosis", "nibiru", &router).unwrap();
 
     let pair_info = PairWithDenomAndAmount {
@@ -1939,7 +1939,7 @@ fn test_swap_request_fails_for_unsupported_denomination_for_asset_in() {
     let interchain = MockInterchainEnv::new(vec![("osmosis", &sender), ("nibiru", &sender)]);
     let router_chain = interchain.get_chain("nibiru").unwrap();
 
-    let router = setup_router(&router_chain).unwrap();
+    let router = setup_router(&router_chain, vec!["osmosis", "nibiru"]).unwrap();
     let factory = setup_factory(&interchain, "osmosis", "nibiru", &router).unwrap();
 
     let pair_info = PairWithDenomAndAmount {
@@ -2052,7 +2052,7 @@ fn test_swap_request_fails_for_zero_min_amount_out() {
     let interchain = MockInterchainEnv::new(vec![("osmosis", &sender), ("nibiru", &sender)]);
     let router_chain = interchain.get_chain("nibiru").unwrap();
 
-    let router = setup_router(&router_chain).unwrap();
+    let router = setup_router(&router_chain, vec!["osmosis", "nibiru"]).unwrap();
     let factory = setup_factory(&interchain, "osmosis", "nibiru", &router).unwrap();
 
     let pair_info = PairWithDenomAndAmount {
@@ -2149,7 +2149,7 @@ fn test_swap_request_fails_for_invalid_swap_route() {
     let interchain = MockInterchainEnv::new(vec![("osmosis", &sender), ("nibiru", &sender)]);
     let router_chain = interchain.get_chain("nibiru").unwrap();
 
-    let router = setup_router(&router_chain).unwrap();
+    let router = setup_router(&router_chain, vec!["osmosis", "nibiru"]).unwrap();
     let factory = setup_factory(&interchain, "osmosis", "nibiru", &router).unwrap();
 
     let pair_info = PairWithDenomAndAmount {
@@ -2395,7 +2395,7 @@ fn run_test_stable_pool_swap_request(factory_chain_id: &str, router_chain_id: &s
     let factory_chain = interchain.get_chain(factory_chain_id).unwrap();
     let factory_chain_uid = ChainUid::create(factory_chain_id.to_string()).unwrap();
     let router_chain = interchain.get_chain(router_chain_id).unwrap();
-    let router = setup_router(&router_chain).unwrap();
+    let router = setup_router(&router_chain, vec![factory_chain_id]).unwrap();
 
     let factory = setup_factory(&interchain, factory_chain_id, router_chain_id, &router).unwrap();
 
@@ -2527,7 +2527,7 @@ fn test_deposit_and_withdraw() {
     let interchain = MockInterchainEnv::new(vec![("osmosis", &sender), ("nibiru", &sender)]);
     let router_chain = interchain.get_chain("nibiru").unwrap();
 
-    let router = setup_router(&router_chain).unwrap();
+    let router = setup_router(&router_chain, vec!["osmosis", "nibiru"]).unwrap();
     let factory_chain_uid = ChainUid::create("osmosis".to_string()).unwrap();
     let factory = setup_factory(&interchain, &factory_chain_uid, "nibiru", &router).unwrap();
 
@@ -2623,7 +2623,7 @@ fn test_deposit_and_withdraw_with_failure() {
         MockInterchainEnv::new(vec![("osmosis", &sender_label), ("nibiru", &sender_label)]);
     let router_chain = interchain.get_chain("nibiru").unwrap();
 
-    let router = setup_router(&router_chain).unwrap();
+    let router = setup_router(&router_chain, vec!["osmosis", "nibiru"]).unwrap();
     let factory_chain_uid = ChainUid::create("osmosis".to_string()).unwrap();
     let factory = setup_factory(&interchain, &factory_chain_uid, "nibiru", &router).unwrap();
 

--- a/tests-integration/src/tests/meta_transaction.rs
+++ b/tests-integration/src/tests/meta_transaction.rs
@@ -84,7 +84,7 @@ fn setup_meta_transaction_e2e() -> Result<
     ]);
     let router_chain = interchain.get_chain(router_chain_id).unwrap();
     // Set up router and factory using the helper functions
-    let router_contract = setup_router(&router_chain).unwrap();
+    let router_contract = setup_router(&router_chain, vec![factory_chain_id]).unwrap();
     let factory_contract = setup_factory(
         &interchain,
         factory_chain_id,
@@ -125,7 +125,11 @@ fn setup_meta_transaction_e2e_evm() -> Result<
     ]);
     let router_chain = interchain.get_chain(router_chain_id).unwrap();
     // Set up router and factory using the helper functions
-    let router_contract = setup_router(&router_chain).unwrap();
+    let router_contract = setup_router(
+        &router_chain,
+        vec![cosmos_factory_chain_id, evm_factory_chain_id],
+    )
+    .unwrap();
     let cosmos_factory_contract = setup_factory(
         &interchain,
         cosmos_factory_chain_id,
@@ -273,7 +277,7 @@ fn sign_meta_transaction_message_evm(
 #[test]
 fn test_meta_transaction_instantiation() {
     let chain = <MockBase>::new("nibiru");
-    let router = setup_router(&chain).unwrap();
+    let router = setup_router(&chain, vec!["nibiru"]).unwrap();
     let meta_tx_contract = setup_meta_transaction(&chain, router.address().unwrap()).unwrap();
 
     let state = meta_tx_contract.get_state().unwrap();
@@ -284,7 +288,7 @@ fn test_meta_transaction_instantiation() {
 #[test]
 fn test_update_admin() {
     let chain = <MockBase>::new("nibiru");
-    let router = setup_router(&chain).unwrap();
+    let router = setup_router(&chain, vec!["nibiru"]).unwrap();
     let meta_tx_contract = setup_meta_transaction(&chain, router.address().unwrap()).unwrap();
 
     let new_admin = chain.addr_make("new_admin");


### PR DESCRIPTION
# Pull Request

## Description

Added Rate Limit Exceed check for send packets.
Updated relayer to store validators based on chain_uid to allow flexibility and different validators per chain. This will mainly affect relayer on hub chain as factory will only receive messages from hub chain (vsl)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor/Chore

## Related Issue

[Link to related issue, if applicable]

## Testing

Steps to test:

1. [Step 1]
2. [Step 2]
3. [Step 3]

## Checklist

- [ ] Self-review completed
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated (if applicable)

## Screenshots (if applicable)

[Add screenshots here]

## Additional Notes

[Any additional information or context]