### PR TITLE
Fix: escrow ack, release to sender and release and burn msg execution order

### DIFF
--- a/contracts/hub/router/src/execute/token.rs
+++ b/contracts/hub/router/src/execute/token.rs
@@ -181,6 +181,10 @@ pub fn _transfer_voucher_as_voucher(
         Some(msg) => Some(Binary::from_base64(msg.as_str())?),
         None => None,
     };
+    // If sender is the same as recipient, we don't need to transfer the voucher but return the amount that would have been transferred if it was different so next recipient will be calculated accordingly.
+    if sender == recipient.recipient {
+        return Ok((vec![], amount));
+    }
     let transfer_voucher_msg = euclid::msgs::virtual_balance::msg::ExecuteMsg::Transfer(
         euclid::msgs::virtual_balance::msg::ExecuteTransfer {
             amount,
@@ -324,8 +328,9 @@ pub fn _release_voucher(
         &escrow_balance.checked_sub(release_amount_after_fee)?,
     )?;
 
+    // Order matters here because we want to burn the vouchers before releasing to prevent any reentrancy attacks.
     Ok((
-        vec![release_ibc_msg, SubMsg::new(burn_voucher_msg)],
+        vec![SubMsg::new(burn_voucher_msg), release_ibc_msg],
         release_amount,
     ))
 }

--- a/contracts/hub/router/src/ibc/ack_and_timeout.rs
+++ b/contracts/hub/router/src/ibc/ack_and_timeout.rs
@@ -111,11 +111,10 @@ pub fn ibc_ack_release_escrow(
     PENDING_RELEASE_VOUCHER.remove(deps.storage, tx_id);
     let virtual_balance_address = VIRTUAL_BALANCE_CONTRACT.load(deps.storage)?.to_string();
     match res {
-        AcknowledgementMsg::Ok(data) => {
+        AcknowledgementMsg::Ok(_data) => {
             let mut response = response
                 .add_attribute("method", "release_escrow_success")
-                .add_attribute("factory_chain", data.chain_id)
-                .add_attribute("factory_address", data.factory_address)
+                .add_attribute("amount", amount.to_string())
                 .add_attribute("chain_uid", sender.chain_uid.to_string());
 
             if !pending_release_voucher.release_fee_amount.is_zero() {

--- a/contracts/hub/router/src/ibc/ack_and_timeout.rs
+++ b/contracts/hub/router/src/ibc/ack_and_timeout.rs
@@ -111,10 +111,12 @@ pub fn ibc_ack_release_escrow(
     PENDING_RELEASE_VOUCHER.remove(deps.storage, tx_id);
     let virtual_balance_address = VIRTUAL_BALANCE_CONTRACT.load(deps.storage)?.to_string();
     match res {
-        AcknowledgementMsg::Ok(_data) => {
+        AcknowledgementMsg::Ok(data) => {
             let mut response = response
                 .add_attribute("method", "release_escrow_success")
                 .add_attribute("amount", amount.to_string())
+                .add_attribute("recipient", data.to_address)
+                .add_attribute("updated_escrow_balance", data.escrow_balance.to_string())
                 .add_attribute("chain_uid", sender.chain_uid.to_string());
 
             if !pending_release_voucher.release_fee_amount.is_zero() {

--- a/contracts/liquidity/escrow/src/execute.rs
+++ b/contracts/liquidity/escrow/src/execute.rs
@@ -271,12 +271,9 @@ pub fn execute_withdraw(
     )?;
 
     let ack_msg = ReleaseEscrowResponse {
-        factory_address: state.factory_address.to_string(),
-        chain_id: env.block.chain_id,
         amount,
-        token: state.token_id.clone(),
         to_address: recipient.to_string(),
-        denom,
+        escrow_balance: denom_balance,
     };
     let ack = to_json_binary(&AcknowledgementMsg::Ok(ack_msg))?;
 

--- a/packages/euclid/src/msgs/factory/msg.rs
+++ b/packages/euclid/src/msgs/factory/msg.rs
@@ -238,12 +238,9 @@ pub struct ReleaseEscrowDenomsResponse {
 
 #[cw_serde]
 pub struct ReleaseEscrowResponse {
-    pub factory_address: String,
-    pub chain_id: String,
     pub amount: Uint128,
-    pub token: Token,
     pub to_address: String,
-    pub denom: TokenType,
+    pub escrow_balance: Uint128,
 }
 
 #[cw_serde]


### PR DESCRIPTION
# Pull Request

## Description

- Fix escrow release ack to make it simple, similar update were made to solidity contract
- Release to recipient same as sender throws error but it caused issues with advance flow like release with limit. Added logic in router to allow it.
- Found and resolved issue with execution order of release and burn. Burn was triggered after release was executed which can cause significant attack using native factory

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor/Chore

## Related Issue

[Link to related issue, if applicable]

## Testing

Steps to test:

1. [Step 1]
2. [Step 2]
3. [Step 3]

## Checklist

- [x] Self-review completed
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated (if applicable)

## Screenshots (if applicable)

[Add screenshots here]

## Additional Notes

[Any additional information or context]