### PR TITLE
feat: auto-collect fees on full liquidity removal

### DIFF
--- a/contracts/hub/concentrated_vlp/src/contract.rs
+++ b/contracts/hub/concentrated_vlp/src/contract.rs
@@ -600,6 +600,21 @@ fn execute_remove_concentrated_liquidity(
         .liquidity
         .checked_sub(remove_liquidity_msg.liquidity_delta)?;
     let liquidity_after = position.liquidity;
+
+    // When fully removing liquidity, auto-collect any pending fees so the
+    // position can be deleted in a single transaction. Without this, users
+    // would need a separate collect_fees call to clear tokens_owed before
+    // the position is cleaned up from storage.
+    let (fee_0_collected, fee_1_collected) = if position.liquidity.is_zero() {
+        let f0 = position.tokens_owed_0;
+        let f1 = position.tokens_owed_1;
+        position.tokens_owed_0 = Uint128::zero();
+        position.tokens_owed_1 = Uint128::zero();
+        (f0, f1)
+    } else {
+        (Uint128::zero(), Uint128::zero())
+    };
+
     if position.liquidity.is_zero()
         && position.tokens_owed_0.is_zero()
         && position.tokens_owed_1.is_zero()
@@ -627,10 +642,13 @@ fn execute_remove_concentrated_liquidity(
         .checked_sub(remove_liquidity_msg.liquidity_delta)?;
     STATE.save(deps.storage, &state)?;
 
+    let total_0_out = amount_0_out.checked_add(fee_0_collected)?;
+    let total_1_out = amount_1_out.checked_add(fee_1_collected)?;
+
     let mut reserve_0 = BALANCES.load(deps.storage, state.pair.token_1.clone())?;
     let mut reserve_1 = BALANCES.load(deps.storage, state.pair.token_2.clone())?;
-    reserve_0 = reserve_0.checked_sub(amount_0_out)?;
-    reserve_1 = reserve_1.checked_sub(amount_1_out)?;
+    reserve_0 = reserve_0.checked_sub(total_0_out)?;
+    reserve_1 = reserve_1.checked_sub(total_1_out)?;
     BALANCES.save(deps.storage, state.pair.token_1.clone(), &reserve_0)?;
     BALANCES.save(deps.storage, state.pair.token_2.clone(), &reserve_1)?;
 
@@ -649,20 +667,20 @@ fn execute_remove_concentrated_liquidity(
     };
 
     let mut response = Response::new();
-    if !amount_0_out.is_zero() {
+    if !total_0_out.is_zero() {
         response = response.add_message(state.pair.token_1.create_voucher_transfer_msg(
             state.virtual_balance_contract.to_string(),
-            amount_0_out,
+            total_0_out,
             None,
             remove_liquidity_msg.sender.clone(),
             None,
             None,
         )?);
     }
-    if !amount_1_out.is_zero() {
+    if !total_1_out.is_zero() {
         response = response.add_message(state.pair.token_2.create_voucher_transfer_msg(
             state.virtual_balance_contract.to_string(),
-            amount_1_out,
+            total_1_out,
             None,
             remove_liquidity_msg.sender.clone(),
             None,

--- a/tests-integration/src/tests_reusable/concentrated_tick_boundary_regression.rs
+++ b/tests-integration/src/tests_reusable/concentrated_tick_boundary_regression.rs
@@ -19,6 +19,7 @@ use rstest::rstest;
 use crate::helpers::chains::get_concentrated_vlp;
 use crate::helpers::factory::{
     add_concentrated_liquidity, create_concentrated_pool, list_position_ids,
+    remove_concentrated_liquidity,
 };
 use crate::tests_reusable::concentrated_create_pool::{pair_with_amounts, setup_concentrated_env};
 use crate::tests_reusable::concentrated_swap::execute_concentrated_swap;
@@ -108,5 +109,80 @@ fn test_active_liquidity_consistent_after_boundary_crossings(
          by tick ({}, tick={}) or by price ({}, price_tick={})",
         slot0.liquidity, in_range_liquidity, slot0.tick,
         in_range_by_price, price_tick,
+    );
+}
+
+/// Full removal should auto-collect pending fees and delete the position
+/// in a single transaction. Before the fix, users needed a separate
+/// collect_fees call to clear tokens_owed.
+#[rstest]
+#[case(FactorySetupMode::Native, FACTORY_CHAIN_ID_LOCAL)]
+fn test_full_removal_auto_collects_fees(
+    #[case] mode: FactorySetupMode,
+    #[case] factory_chain_id: &str,
+) {
+    let (_interchain, factory, router, token_a, token_b) =
+        setup_concentrated_env(mode, factory_chain_id);
+
+    let pair = pair_with_amounts(&token_a, &token_b, 50_000, 50_000);
+    let pool_key = create_concentrated_pool(&factory, &router, pair, 500, 10, 100).unwrap();
+
+    let vlp_addr = Addr::unchecked(router.get_vlp_by_pool_key(pool_key.clone()).unwrap().vlp);
+    let vlp = get_concentrated_vlp(router.environment(), &vlp_addr);
+
+    // Add a position
+    let slot0: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+    let lower = ((slot0.tick - 100) / 10) * 10;
+    let upper = ((slot0.tick + 100) / 10) * 10;
+
+    let pair2 = pair_with_amounts(&token_a, &token_b, 20_000, 20_000);
+    add_concentrated_liquidity(
+        &factory, &router, pair2, pool_key.clone(),
+        lower, upper, None, 10_000,
+    )
+    .expect("add should succeed");
+
+    let position_id = {
+        let ids = list_position_ids(&factory).unwrap();
+        Uint128::new(ids.last().unwrap().parse::<u128>().unwrap())
+    };
+    let pos = vlp
+        .query::<PositionResponse>(&ConcentratedQueryMsg::Position { position_id })
+        .unwrap();
+    let liquidity = pos.liquidity;
+    assert!(!liquidity.is_zero(), "position should have liquidity");
+
+    // Swap to accrue fees
+    execute_concentrated_swap(
+        &factory, &router, pool_key.clone(),
+        token_b.clone(), token_a.token.clone(), Uint128::new(10_000),
+    );
+    execute_concentrated_swap(
+        &factory, &router, pool_key.clone(),
+        token_a.clone(), token_b.token.clone(), Uint128::new(10_000),
+    );
+
+    // Verify fees have accrued (fee_growth > 0)
+    let slot0: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+    assert!(
+        slot0.fee_growth_global_0_x128 > cosmwasm_std::Uint256::zero()
+            || slot0.fee_growth_global_1_x128 > cosmwasm_std::Uint256::zero(),
+        "fees should have accrued from swaps"
+    );
+
+    // Full removal — should auto-collect fees and delete position
+    remove_concentrated_liquidity(
+        &factory, &router, pool_key.clone(), position_id, liquidity,
+    )
+    .expect("full removal should succeed");
+
+    // Position should be fully deleted (not just zero liquidity)
+    let pos_result: Result<PositionResponse, _> =
+        vlp.query(&ConcentratedQueryMsg::Position { position_id });
+    assert!(
+        pos_result.is_err(),
+        "position should be deleted after full removal with auto-collect, \
+         but query succeeded with: {:?}",
+        pos_result.ok()
     );
 }


### PR DESCRIPTION
## Summary

When `remove_liquidity` fully drains a position (liquidity -> 0), automatically collect any pending `tokens_owed` and include them in the transfer. This allows positions to be fully closed in a single transaction instead of requiring a separate `collect_fees` call.

**Depends on:** #153 (tick boundary rounding fix)

## Problem

After a full removal, `settle_position_fees` computes pending fees into `tokens_owed`. The position is NOT deleted from storage because `tokens_owed > 0`, even though `liquidity == 0`. Users must make a separate `collect_fees` call to:
1. Clear `tokens_owed`
2. Delete the position from storage
3. Receive their accrued fees

This is an unnecessary extra transaction that costs gas and complicates client integrations.

## Fix

When `liquidity_after == 0` in `remove_liquidity`:
- Zero out `tokens_owed_0` and `tokens_owed_1`
- Add the owed amounts to the total transfer (`total_0_out = amount_0_out + fee_0_collected`)
- Position is deleted immediately (both liquidity and tokens_owed are zero)

`collect_fees` continues to work independently for partial removals or standalone fee collection.

## Test plan

- [x] `cargo test -p concentrated_vlp --lib` -- unit tests pass
- [x] `test_full_removal_auto_collects_fees` -- regression test verifies position is deleted after full removal
- [x] Fuzz endurance: drain completes in single pass (no collect/remove/collect lifecycle needed)

Generated with [Claude Code](https://claude.com/claude-code)