### PR TITLE
fix(pool): stable swap security fixes, checked arithmetic, and Uint128 API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1600,6 +1600,7 @@ dependencies = [
  "cw-utils 2.0.0",
  "euclid",
  "itertools 0.10.5",
+ "rstest",
  "thiserror 1.0.69",
 ]
 
@@ -3332,6 +3333,7 @@ dependencies = [
  "euclid-pool",
  "function_name",
  "mock",
+ "rstest",
  "schemars",
  "serde",
  "thiserror 1.0.69",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "cp_vlp"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "euclid-pool"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
@@ -3320,7 +3320,7 @@ dependencies = [
 
 [[package]]
 name = "stable_vlp"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",

--- a/contracts/hub/cp_vlp/Cargo.toml
+++ b/contracts/hub/cp_vlp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cp_vlp"
-version = "0.2.3"
+version = "0.2.4"
 authors = [
   "gachouchani1999 <georgeschouchani1@gmail.com>",
   "Anshudhar Kumar Singh <anshudhar2001@gmail.com>",

--- a/contracts/hub/stable_vlp/Cargo.toml
+++ b/contracts/hub/stable_vlp/Cargo.toml
@@ -49,3 +49,6 @@ function_name = { workspace = true }
 cw-orch = { workspace = true }
 cw-multi-test = { workspace = true }
 mock = { workspace = true }
+
+[dev-dependencies]
+rstest = "0.19.0"

--- a/contracts/hub/stable_vlp/Cargo.toml
+++ b/contracts/hub/stable_vlp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stable_vlp"
-version = "0.2.3"
+version = "0.2.4"
 authors = [
   "gachouchani1999 <georgeschouchani1@gmail.com>",
   "Anshudhar Kumar Singh <anshudhar2001@gmail.com>",

--- a/contracts/hub/stable_vlp/src/tests.rs
+++ b/contracts/hub/stable_vlp/src/tests.rs
@@ -23,6 +23,7 @@ mod tests {
         token::{Pair, Token},
     };
     use euclid_pool::stable_math::compute_stable_swap;
+    use rstest::rstest;
     use std::collections::HashMap;
 
     fn init(
@@ -209,97 +210,5 @@ mod tests {
             err,
             ContractError::new("Euclid Fee cannot exceed maximum limit")
         );
-    }
-
-    #[test]
-    fn test_compute_swap_equal_pools() {
-        // Test with equal pool sizes (1:1 ratio)
-        let offer_asset = Decimal256::from_ratio(100u128, 1u128);
-        let offer_pool = Decimal256::from_ratio(1000u128, 1u128);
-        let ask_pool = Decimal256::from_ratio(1000u128, 1u128);
-        println!("offer_asset in decimal: {:?}", offer_asset);
-        let result =
-            compute_stable_swap(&offer_asset, &offer_pool, &ask_pool, Uint64::new(1000)).unwrap();
-        println!("result: {:?}", result);
-
-        // For stable swap with equal pools, return amount should be very close to offer amount
-        // with minimal spread
-        assert_eq!(result.return_amount, Uint128::new(99)); // Allow for small rounding
-        assert_eq!(result.spread_amount, Uint128::new(1));
-    }
-
-    #[test]
-    fn test_compute_swap_imbalanced_pools() {
-        // Test with imbalanced pools (2:1 ratio)
-        let offer_asset = Decimal256::from_ratio(100u128, 1u128);
-        let offer_pool = Decimal256::from_ratio(2000u128, 1u128);
-        let ask_pool = Decimal256::from_ratio(1000u128, 1u128);
-
-        let result =
-            compute_stable_swap(&offer_asset, &offer_pool, &ask_pool, Uint64::new(100)).unwrap();
-
-        // When pools are imbalanced, spread should be higher
-        assert_eq!(result.return_amount, Uint128::new(67));
-        assert_eq!(result.spread_amount, Uint128::new(33));
-    }
-
-    #[test]
-    fn test_compute_swap_small_amount() {
-        // Test with very small swap amount
-        let offer_asset = Decimal256::from_ratio(1u128, 1u128);
-        let offer_pool = Decimal256::from_ratio(1000000u128, 1u128);
-        let ask_pool = Decimal256::from_ratio(1000000u128, 1u128);
-
-        let result =
-            compute_stable_swap(&offer_asset, &offer_pool, &ask_pool, Uint64::new(1000)).unwrap();
-
-        // Small amounts should have minimal spread
-        assert_eq!(result.return_amount, Uint128::new(1));
-        assert_eq!(result.spread_amount, Uint128::new(0));
-    }
-
-    #[test]
-    fn test_compute_swap_large_amount() {
-        // Test with large swap amount relative to pool size
-        let offer_asset = Decimal256::from_ratio(1000u128, 1u128);
-        let offer_pool = Decimal256::from_ratio(2000u128, 1u128);
-        let ask_pool = Decimal256::from_ratio(2000u128, 1u128);
-
-        let result =
-            compute_stable_swap(&offer_asset, &offer_pool, &ask_pool, Uint64::new(1000)).unwrap();
-
-        // Large swaps should have higher spread due to impact on pool balance
-        assert_eq!(result.return_amount, Uint128::new(946u128));
-        assert_eq!(result.spread_amount, Uint128::new(54u128));
-    }
-
-    #[test]
-    fn test_compute_swap_extreme_imbalance() {
-        // Test with extremely imbalanced pools
-        let offer_asset = Decimal256::from_ratio(100u128, 1u128);
-        let offer_pool = Decimal256::from_ratio(10000u128, 1u128);
-        let ask_pool = Decimal256::from_ratio(1000u128, 1u128);
-
-        let result =
-            compute_stable_swap(&offer_asset, &offer_pool, &ask_pool, Uint64::new(1000)).unwrap();
-
-        // Highly imbalanced pools should result in higher spread
-        assert_eq!(result.return_amount, Uint128::new(47u128));
-        assert_eq!(result.spread_amount, Uint128::new(53u128));
-    }
-
-    #[test]
-    fn test_compute_swap_large_values() {
-        // Test with extremely imbalanced pools
-        let offer_asset = Decimal256::from_ratio(1000000000000000000u128, 1u128);
-        let offer_pool = Decimal256::from_ratio(1000000000000000000u128, 1u128);
-        let ask_pool = Decimal256::from_ratio(1000000000000000000u128, 1u128);
-
-        let result =
-            compute_stable_swap(&offer_asset, &offer_pool, &ask_pool, Uint64::new(1000)).unwrap();
-
-        // Highly imbalanced pools should result in higher spread
-        assert_eq!(result.return_amount, Uint128::new(820871215252207999));
-        assert_eq!(result.spread_amount, Uint128::new(179128784747792001));
     }
 }

--- a/packages/euclid/src/utils/math.rs
+++ b/packages/euclid/src/utils/math.rs
@@ -10,7 +10,7 @@ pub trait Decimal256Ext {
 
     fn to_uint256_with_precision(&self, precision: impl Into<u32>) -> StdResult<Uint256>;
 
-    fn from_integer(i: impl Into<Uint256>) -> Self;
+    fn checked_from_integer(i: impl Into<Uint256>) -> StdResult<Decimal256>;
 
     fn checked_multiply_ratio(
         &self,
@@ -49,8 +49,8 @@ impl Decimal256Ext for Decimal256 {
             .map_err(|_| StdError::generic_err("DivideByZeroError"))
     }
 
-    fn from_integer(i: impl Into<Uint256>) -> Self {
-        Decimal256::from_ratio(i.into(), 1u8)
+    fn checked_from_integer(i: impl Into<Uint256>) -> StdResult<Decimal256> {
+        Decimal256::checked_from_ratio(i.into(), 1u8).map_err(|e| StdError::generic_err(e.to_string()))
     }
 
     fn checked_multiply_ratio(

--- a/packages/euclid/src/utils/math.rs
+++ b/packages/euclid/src/utils/math.rs
@@ -50,7 +50,8 @@ impl Decimal256Ext for Decimal256 {
     }
 
     fn checked_from_integer(i: impl Into<Uint256>) -> StdResult<Decimal256> {
-        Decimal256::checked_from_ratio(i.into(), 1u8).map_err(|e| StdError::generic_err(e.to_string()))
+        Decimal256::checked_from_ratio(i.into(), 1u8)
+            .map_err(|e| StdError::generic_err(e.to_string()))
     }
 
     fn checked_multiply_ratio(

--- a/packages/pool/Cargo.toml
+++ b/packages/pool/Cargo.toml
@@ -23,3 +23,6 @@ cosmwasm-schema = { workspace = true }
 cw-utils = { workspace = true }
 thiserror = { workspace = true }
 euclid = { workspace = true }
+
+[dev-dependencies]
+rstest = "0.19.0"

--- a/packages/pool/Cargo.toml
+++ b/packages/pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid-pool"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
     "Anshudhar Kumar Singh <anshudhar2001@gmail.com>",
     "Joe Monem <jmonem@icloud.com>",

--- a/packages/pool/src/AUDIT.md
+++ b/packages/pool/src/AUDIT.md
@@ -1,0 +1,315 @@
+# Stable Swap Math: Security Audit Report
+
+**Date:** 2026-03-25
+**Scope:** `packages/pool/src/stable_math.rs` and its integration via `pool_functions.rs`
+**Context:** Voucher balances are 24-decimal fixed-point values stored as `Uint128`. The stable swap math operates on `Decimal256` (18 internal decimal places). This report identifies vulnerabilities in the current implementation.
+
+## Summary
+
+| ID | Severity | Title | Status |
+|----|----------|-------|--------|
+| CRITICAL-1 | Critical | Overflow in `d^3` computation makes math unusable for 24-decimal tokens | Open |
+| CRITICAL-2 | Critical | Unchecked arithmetic in `compute_d` causes contract panic | Open |
+| CRITICAL-3 | Critical | `TOKEN_PRECISION = 1` is hardcoded and unrelated to token decimals | Open |
+| HIGH-1 | High | Inconsistent amp factor scaling between `compute_d` and `calc_y` | Open |
+| HIGH-2 | High | `saturating_sub` silently masks bugs in spread calculation | Open |
+| MEDIUM-1 | Medium | Fixed absolute tolerance is not scale-aware | Open |
+| MEDIUM-2 | Medium | No input validation on amp factor or pool amounts | Open |
+| LOW-1 | Low | Integer truncation in return_amount creates systematic user loss | Open |
+
+## Findings
+
+### CRITICAL-1: Overflow in `d.pow(3)` / `d.checked_pow(3)`
+
+**Location:** `stable_math.rs:93` (unchecked `d.pow(3)`), `stable_math.rs:125` (checked `d.checked_pow(3)`)
+
+**Description:**
+Both `compute_d` and `calc_y` compute `D^3` as part of the StableSwap formula. `Decimal256` stores values as `atomics = value * 10^18` in a `Uint256` (max ~ `1.158 * 10^77`). For any pool with integer values >= ~1e20, the intermediate `D^3` computation overflows `Uint256`.
+
+With 24-decimal tokens (where 1 token = `10^24` raw), even a single token per pool overflows.
+
+**Overflow boundary analysis:**
+
+| Pool Integer Value | d atomics | d^3 atomics | Overflows? | Behavior |
+|--------------------|-----------|-------------|------------|----------|
+| 1e3 (small) | 2e21 | 8e27 | No | Works |
+| 1e12 | 2e30 | 8e54 | No | Works |
+| 1e18 (current test max) | 2e36 | 8e72 | No | Works (ratio to max: 6.9e-5) |
+| **1e19** | **2e37** | **8e75** | **Yes** | Returns `Err` (overflow in `calc_y`'s `d^3 * amp_prec` step, since 8e75 * 100 > Uint256 max) |
+| **1e20** | **2e38** | **8e78** | **Yes** | **Panics** (overflow in `compute_d`'s unchecked `d.pow(3)`) |
+| **1e24 (1 token at 24 dec)** | **2e42** | **8e90** | **Yes** | **Panics** (even intermediate d*d overflows) |
+
+Note: At 1e19, `d.pow(3)` itself fits in Uint256, but `calc_y` then multiplies by `amp_prec = 100`, causing the overflow in a checked path that returns a clean `Err`. At 1e20+, `d.pow(3)` itself overflows and hits the unchecked code path in `compute_d`, causing a contract panic.
+
+Even the intermediate `d * d` overflows for 24-decimal values: `(2e42)^2 = 4e84 >> 1.158e77`.
+
+**Impact:** Complete inability to perform stable swaps with 24-decimal voucher tokens. In `compute_d`, the unchecked `d.pow(3)` will panic, halting the contract. In `calc_y`, the checked version returns an error, but the swap still fails.
+
+**Failing test:** `test_overflow_24_decimal_balanced_pools`, `test_overflow_24_decimal_small_pools`
+
+**Suggested fix:**
+Replace `d.pow(3) / (pool_a_scaled * pool_b_scaled)` with iterative computation that avoids the large intermediate:
+
+```rust
+// Instead of: d.pow(3) / (amount_a_times_coins * amount_b_times_coins)
+// Use iterative: d_product = d * d / pool_a_scaled * d / pool_b_scaled
+let mut d_product = d;
+for pool in [amount_a_times_coins, amount_b_times_coins] {
+    d_product = d_product.checked_mul(d)?.checked_div(pool)?;
+}
+```
+
+Similarly in `calc_y`, restructure `d.checked_pow(3)?.checked_mul(amp_prec)?` to avoid the `D^3` intermediate.
+
+---
+
+### CRITICAL-2: Unchecked arithmetic in `compute_d` causes contract panic
+
+**Location:** `stable_math.rs:80-93`
+
+**Description:**
+Several operations in `compute_d` use unchecked arithmetic that will panic on overflow instead of returning a recoverable error:
+
+```rust
+// Line 80: unchecked multiply
+let leverage = Decimal256::from_ratio(amp, AMP_PRECISION) * N_COINS;
+
+// Line 81-82: unchecked multiply
+let amount_a_times_coins = pools[0] * N_COINS;
+let amount_b_times_coins = pools[1] * N_COINS;
+
+// Line 93: unchecked pow, unchecked divide, unchecked multiply
+let d_product = d.pow(3) / (amount_a_times_coins * amount_b_times_coins);
+```
+
+**Impact:** A contract panic in CosmWasm is unrecoverable for that transaction. While it doesn't corrupt state (the transaction rolls back), it means users cannot perform swaps and receive an unhelpful generic error. Funds are not directly at risk but pool functionality is denied.
+
+**Failing test:** `test_compute_d_unchecked_panics`
+
+**Suggested fix:**
+Replace all unchecked operations with checked variants:
+
+```rust
+let leverage = Decimal256::from_ratio(amp, AMP_PRECISION).checked_mul(N_COINS)?;
+let amount_a_times_coins = pools[0].checked_mul(N_COINS)?;
+let amount_b_times_coins = pools[1].checked_mul(N_COINS)?;
+
+// In loop:
+let d_product = d.checked_pow(3)?
+    .checked_div(amount_a_times_coins.checked_mul(amount_b_times_coins)?)?;
+```
+
+---
+
+### CRITICAL-3: `TOKEN_PRECISION = 1` is hardcoded and unrelated to token decimals
+
+**Location:** `stable_math.rs:21`
+
+**Description:**
+`TOKEN_PRECISION` is a local constant set to `1` inside `compute_stable_swap`. It is used for:
+
+1. `ask_pool.to_uint128_with_precision(1)` — divides atomics by `10^17`, giving `value * 10`
+2. `calc_y(..., TOKEN_PRECISION)` — returns `y` with the same `10x` scaling
+3. `checked_div(Uint128::new(10))` — removes the `10x` scaling from the subtraction result
+4. `offer_asset.to_uint128_with_precision(0)` — gives the raw integer value
+
+The purpose is to preserve one extra decimal digit during the `ask_pool - new_ask_pool` subtraction to reduce rounding error. However:
+
+- This constant has no relationship to the actual decimal configuration of the tokens (6, 18, 24, etc.)
+- For 24-decimal tokens, the return amount is in raw 24-decimal units, and the extra digit of precision from TOKEN_PRECISION=1 is negligible relative to 24 decimal places
+- The spread calculation `offer_amount.saturating_sub(return_amount)` compares two values that were converted with different precisions (0 vs 1-then-divided-by-10), which are equivalent only because the math works out for integer inputs
+
+**Impact:** While the current implementation produces correct results for integer-valued inputs (the precision(1) and /10 cancel out), it does not account for fractional Decimal256 values or non-integer token amounts. Any refactoring that changes how amounts enter the function could silently break the precision math.
+
+**Failing test:** `test_precision_with_24_decimal_inputs`
+
+**Suggested fix:**
+Either:
+1. Accept token decimal configuration as a parameter and normalize amounts before computation
+2. Perform all math in Decimal256 and only convert to Uint128 at the final step
+3. At minimum, document why TOKEN_PRECISION=1 is correct and add assertions that inputs are integer-valued
+
+---
+
+### HIGH-1: Inconsistent amp factor scaling between `compute_d` and `calc_y`
+
+**Location:** `stable_math.rs:80` vs `stable_math.rs:122-123`
+
+**Description:**
+The two functions parameterize the amplification factor differently:
+
+```rust
+// compute_d (line 80):
+let leverage = Decimal256::from_ratio(amp, AMP_PRECISION) * N_COINS;
+// leverage = (amp / 100) * 2
+
+// calc_y (lines 122-123):
+let leverage = Decimal256::from_ratio(amp, 1u8) * N_COINS;
+let amp_prec = Decimal256::from_ratio(AMP_PRECISION, 1u8);
+// leverage = amp * 2, amp_prec = 100 (used separately in formulas)
+```
+
+These are mathematically equivalent: `calc_y` factors out `AMP_PRECISION` and applies it separately in the `c` and `b` formulas. However, the inconsistency is dangerous:
+
+- A developer modifying `compute_d` to change how `leverage` is computed would need to know that `calc_y` uses a different factoring
+- The relationship is not documented
+- Code review is harder because the two functions appear to use different amplification values
+
+**Verification:** The following identity holds:
+- `compute_d`: `Ann = (amp/100) * 2`
+- `calc_y`: `c = D^3 * 100 / (x * 4 * amp * 2) = D^3 / (x * 4 * (amp/100) * 2) = D^3 / (x * N_COINS^2 * Ann)` (correct)
+
+**Failing test:** `test_amp_factor_consistency`
+
+**Suggested fix:**
+Unify both functions to use the same leverage computation. The simplest approach is to have `calc_y` also use `Decimal256::from_ratio(amp, AMP_PRECISION) * N_COINS`.
+
+---
+
+### HIGH-2: `saturating_sub` silently masks bugs in spread calculation
+
+**Location:** `stable_math.rs:41`
+
+**Description:**
+```rust
+let spread_amount = offer_amount.saturating_sub(return_amount);
+```
+
+If `return_amount > offer_amount`, this silently returns `0` instead of signaling an invariant violation. In a correctly functioning StableSwap, the return amount should always be less than or equal to the offer amount (the pool takes a spread). If it's not, something is mathematically wrong.
+
+Using `saturating_sub` here means:
+- Arbitrage conditions where users get more than they put in would be hidden
+- Math bugs that produce inflated return amounts would go undetected
+- The spread amount reported to users would be incorrect (0 instead of an error)
+
+**Impact:** Could mask fund-draining bugs where the pool pays out more than it receives.
+
+**Failing test:** `test_spread_can_silently_be_zero`
+
+**Suggested fix:**
+```rust
+let spread_amount = offer_amount
+    .checked_sub(return_amount)
+    .map_err(|_| ContractError::new(
+        "Invariant violation: return_amount exceeds offer_amount"
+    ))?;
+```
+
+---
+
+### MEDIUM-1: Fixed absolute tolerance is not scale-aware
+
+**Location:** `stable_math.rs:12`
+
+**Description:**
+```rust
+pub const TOL: Decimal256 = Decimal256::raw(1000000000000); // 1e-6
+```
+
+This absolute tolerance of `1e-6` is used for convergence checks in both `compute_d` and `calc_y`:
+```rust
+if d.abs_diff(d_previous) <= TOL { return Ok(d); }
+```
+
+For large values (e.g., 24-decimal pools where D ~ 1e24), a tolerance of 1e-6 is `1e-30` relative to the value, meaning convergence happens very quickly but the last few iterations may be wasted or the result may lack precision in the least significant digits.
+
+For very small values (e.g., pools with 1 unit), `1e-6` relative to `1` means we stop iterating when within `0.0001%`, which may be acceptable but is not consistent with the large-value behavior.
+
+**Impact:** Potential precision loss for edge cases; not a correctness issue for typical values.
+
+**Note:** No dedicated test for this finding. The tolerance concern is theoretical for current usage (integer values << 1e18) but would become relevant if the overflow issues (CRITICAL-1) are fixed to support larger values.
+
+**Suggested fix:**
+Consider a relative tolerance:
+```rust
+if d.abs_diff(d_previous) <= TOL || d.abs_diff(d_previous) / d <= relative_tol {
+    return Ok(d);
+}
+```
+
+---
+
+### MEDIUM-2: No input validation on amp factor or pool amounts
+
+**Location:** `compute_stable_swap`, `compute_d`, `calc_y`
+
+**Description:**
+None of the math functions validate their inputs:
+
+- **Zero amp factor**: `amp = 0` causes `leverage = 0`. In `calculate_step`, the expression `leverage - Decimal256::one()` underflows (unsigned subtraction of 0 - 1), causing a **panic** instead of a clean error.
+- **Extremely large amp factor**: Could overflow the `leverage` multiplication
+- **Zero pool amounts**: `pools[0] = 0` with non-zero `pools[1]` causes division by zero in `d_product = d^3 / (amount_a * amount_b)` on line 93
+- **Pool array length**: `compute_d` directly indexes `pools[0]` and `pools[1]` without checking the array length (though this is somewhat mitigated by it being called only from trusted internal code)
+
+**Impact:** Unvalidated inputs cause panics or incorrect results instead of descriptive errors.
+
+**Failing test:** `test_zero_amp_factor_panics`, `test_extreme_amp_factor`, `test_zero_pool_reserve_panics`
+
+**Suggested fix:**
+Add input validation at the entry point (`compute_stable_swap`):
+```rust
+ensure!(amp_factor.u64() > 0, ContractError::new("Amp factor must be positive"));
+ensure!(amp_factor.u64() <= MAX_AMP, ContractError::new("Amp factor exceeds maximum"));
+ensure!(!offer_pool.is_zero() && !ask_pool.is_zero(), ContractError::new("Pool reserves must be non-zero"));
+```
+
+---
+
+### LOW-1: Integer truncation in return_amount creates systematic user loss
+
+**Location:** `stable_math.rs:35`
+
+**Description:**
+```rust
+let return_amount = ask_pool_amount
+    .checked_sub(new_ask_pool_amount)?
+    .checked_div(Uint128::new(10u128.pow(TOKEN_PRECISION as u32)))?;
+```
+
+The `checked_div(10)` performs floor division, always rounding down. This means:
+- A difference of `15` becomes `1` (user loses 5 units of the extra-precision digit)
+- A difference of `9` becomes `0` (user gets nothing for a valid but small swap)
+- Across many swaps, this creates a systematic leak of value away from users and into the pool
+
+For very small swaps (1-2 units in integer terms), the rounding error can be 50% or more of the swap value.
+
+**Impact:** Small but systematic value extraction from users. Accumulates over time and across all swaps.
+
+**Failing test:** `test_truncation_loss_small_swaps`, `test_truncation_loss_imbalanced_pools`
+
+**Suggested fix:**
+Use rounding division instead of floor division:
+```rust
+let divisor = Uint128::new(10u128.pow(TOKEN_PRECISION as u32));
+let return_amount = (diff + divisor / Uint128::new(2)) / divisor; // round to nearest
+```
+
+Or eliminate TOKEN_PRECISION entirely and perform the subtraction in Decimal256 before converting to Uint128 once.
+
+---
+
+## Recommendations
+
+### Immediate (before any production deployment with 24-decimal tokens)
+
+1. **Fix CRITICAL-1**: Replace `d.pow(3)` with iterative `d_product` computation to avoid Uint256 overflow. This is the single most important fix as it completely blocks functionality.
+
+2. **Fix CRITICAL-2**: Replace all unchecked arithmetic in `compute_d` with checked variants to prevent contract panics.
+
+3. **Fix CRITICAL-3**: Either normalize 24-decimal amounts down to a safe range before entering the math, or restructure the math to work with arbitrary decimal configurations.
+
+### Short-term
+
+4. **Fix HIGH-2**: Replace `saturating_sub` with `checked_sub` + error in the spread calculation to catch invariant violations.
+
+5. **Fix HIGH-1**: Unify amp factor parameterization between `compute_d` and `calc_y`.
+
+6. **Fix MEDIUM-2**: Add input validation for amp factor bounds and pool amounts.
+
+### Long-term
+
+7. Consider a comprehensive rewrite referencing the Curve/Astroport implementations that handle these edge cases.
+
+8. Add property-based fuzz testing (the `tests-fuzz` framework already exists in this repo) to verify invariants like: `return_amount <= offer_amount`, `D_after >= D_before` for deposits, and `no overflow for any valid input range`.
+
+9. Consider using `Uint512` or `checked_multiply_ratio` approaches to avoid intermediate overflow in the `D^3` computation.

--- a/packages/pool/src/AUDIT.md
+++ b/packages/pool/src/AUDIT.md
@@ -1,199 +1,123 @@
 # Stable Swap Math: Security Audit Report
 
-**Date:** 2026-03-25
+**Date:** 2026-03-25 (updated 2026-03-26)
 **Scope:** `packages/pool/src/stable_math.rs` and its integration via `pool_functions.rs`
-**Context:** Voucher balances are 24-decimal fixed-point values stored as `Uint128`. The stable swap math operates on `Decimal256` (18 internal decimal places). This report identifies vulnerabilities in the current implementation.
+**Context:** All stable swap inputs are `Uint128` integer amounts (range: 0 to ~3.4e38). The stable swap math operates on `Decimal256` (18 internal decimal places) internally. This report identifies vulnerabilities and tracks their resolution.
 
 ## Summary
 
 | ID | Severity | Title | Status |
 |----|----------|-------|--------|
-| CRITICAL-1 | Critical | Overflow in `d^3` computation makes math unusable for 24-decimal tokens | Open |
-| CRITICAL-2 | Critical | Unchecked arithmetic in `compute_d` causes contract panic | Open |
-| CRITICAL-3 | Critical | `TOKEN_PRECISION = 1` is hardcoded and unrelated to token decimals | Open |
-| HIGH-1 | High | Inconsistent amp factor scaling between `compute_d` and `calc_y` | Open |
-| HIGH-2 | High | `saturating_sub` silently masks bugs in spread calculation | Open |
+| CRITICAL-1 | Critical | Overflow in `d^3` computation makes math unusable for large tokens | **Fixed** |
+| CRITICAL-2 | Critical | Unchecked arithmetic causes contract panic | **Fixed** |
+| CRITICAL-3 | Critical | `TOKEN_PRECISION = 1` is hardcoded and unrelated to token decimals | **Fixed** |
+| HIGH-1 | High | Inconsistent amp factor scaling between `compute_d` and `calc_y` | **Fixed** |
+| HIGH-2 | High | `saturating_sub` silently masks bugs in spread calculation | **Fixed** |
 | MEDIUM-1 | Medium | Fixed absolute tolerance is not scale-aware | Open |
-| MEDIUM-2 | Medium | No input validation on amp factor or pool amounts | Open |
+| MEDIUM-2 | Medium | No input validation on amp factor or pool amounts | **Fixed** |
 | LOW-1 | Low | Integer truncation in return_amount creates systematic user loss | Open |
 
 ## Findings
 
-### CRITICAL-1: Overflow in `d.pow(3)` / `d.checked_pow(3)`
+### CRITICAL-1: Overflow in `d.pow(3)` / `d.checked_pow(3)` [FIXED]
 
-**Location:** `stable_math.rs:93` (unchecked `d.pow(3)`), `stable_math.rs:125` (checked `d.checked_pow(3)`)
+**Location:** `stable_math.rs` (compute_d, calc_y)
 
 **Description:**
 Both `compute_d` and `calc_y` compute `D^3` as part of the StableSwap formula. `Decimal256` stores values as `atomics = value * 10^18` in a `Uint256` (max ~ `1.158 * 10^77`). For any pool with integer values >= ~1e20, the intermediate `D^3` computation overflows `Uint256`.
 
-With 24-decimal tokens (where 1 token = `10^24` raw), even a single token per pool overflows.
+**Fix applied (two layers):**
 
-**Overflow boundary analysis:**
-
-| Pool Integer Value | d atomics | d^3 atomics | Overflows? | Behavior |
-|--------------------|-----------|-------------|------------|----------|
-| 1e3 (small) | 2e21 | 8e27 | No | Works |
-| 1e12 | 2e30 | 8e54 | No | Works |
-| 1e18 (current test max) | 2e36 | 8e72 | No | Works (ratio to max: 6.9e-5) |
-| **1e19** | **2e37** | **8e75** | **Yes** | Returns `Err` (overflow in `calc_y`'s `d^3 * amp_prec` step, since 8e75 * 100 > Uint256 max) |
-| **1e20** | **2e38** | **8e78** | **Yes** | **Panics** (overflow in `compute_d`'s unchecked `d.pow(3)`) |
-| **1e24 (1 token at 24 dec)** | **2e42** | **8e90** | **Yes** | **Panics** (even intermediate d*d overflows) |
-
-Note: At 1e19, `d.pow(3)` itself fits in Uint256, but `calc_y` then multiplies by `amp_prec = 100`, causing the overflow in a checked path that returns a clean `Err`. At 1e20+, `d.pow(3)` itself overflows and hits the unchecked code path in `compute_d`, causing a contract panic.
-
-Even the intermediate `d * d` overflows for 24-decimal values: `(2e42)^2 = 4e84 >> 1.158e77`.
-
-**Impact:** Complete inability to perform stable swaps with 24-decimal voucher tokens. In `compute_d`, the unchecked `d.pow(3)` will panic, halting the contract. In `calc_y`, the checked version returns an error, but the swap still fails.
-
-**Failing test:** `test_overflow_24_decimal_balanced_pools`, `test_overflow_24_decimal_small_pools`
-
-**Suggested fix:**
-Replace `d.pow(3) / (pool_a_scaled * pool_b_scaled)` with iterative computation that avoids the large intermediate:
+1. **compute_d**: Replaced `d.pow(3)` with iterative `checked_multiply_ratio` calls. `checked_multiply_ratio` performs `(a * b) / c` in `Uint512` intermediate space, avoiding overflow:
 
 ```rust
-// Instead of: d.pow(3) / (amount_a_times_coins * amount_b_times_coins)
-// Use iterative: d_product = d * d / pool_a_scaled * d / pool_b_scaled
-let mut d_product = d;
-for pool in [amount_a_times_coins, amount_b_times_coins] {
-    d_product = d_product.checked_mul(d)?.checked_div(pool)?;
-}
+let d_product = d
+    .checked_multiply_ratio(d, amount_a_times_coins)?
+    .checked_multiply_ratio(d, amount_b_times_coins)?;
 ```
 
-Similarly in `calc_y`, restructure `d.checked_pow(3)?.checked_mul(amp_prec)?` to avoid the `D^3` intermediate.
+2. **calc_y**: For pool values near Uint128::MAX, even the result of `c = D^3 / (x * N^2 * Ann)` exceeds Decimal256 range (~1.158e59). Fixed by computing `c/denom` directly in the Newton loop instead of computing `c` as a standalone value:
+
+```rust
+// Instead of precomputing c and then c/denom in the loop,
+// compute c/denom = D^3 / (x*N * N*leverage * denom) iteratively:
+let c_over_denom = d
+    .checked_multiply_ratio(d, new_amount_times_n)?
+    .checked_multiply_ratio(d, n_times_leverage.checked_mul(denom)?)?;
+```
+
+Each intermediate result stays within Decimal256 range because we divide by progressively larger denominators.
+
+**Verification tests:** `test_24_decimal_balanced_pools_now_works`, `test_1e20_pools_now_works`, `test_compute_d_24_decimal_pools`, `test_calc_y_large_pools_succeeds`, `test_uint128_max_pools_succeeds`
 
 ---
 
-### CRITICAL-2: Unchecked arithmetic in `compute_d` causes contract panic
+### CRITICAL-2: Unchecked arithmetic causes contract panic [FIXED]
 
-**Location:** `stable_math.rs:80-93`
+**Location:** `stable_math.rs` (compute_d, calc_y, calculate_step)
 
 **Description:**
-Several operations in `compute_d` use unchecked arithmetic that will panic on overflow instead of returning a recoverable error:
+Several operations used unchecked arithmetic that would panic on overflow instead of returning a recoverable error.
 
-```rust
-// Line 80: unchecked multiply
-let leverage = Decimal256::from_ratio(amp, AMP_PRECISION) * N_COINS;
+**Fix applied:**
+All arithmetic now uses checked variants throughout the entire math pipeline:
 
-// Line 81-82: unchecked multiply
-let amount_a_times_coins = pools[0] * N_COINS;
-let amount_b_times_coins = pools[1] * N_COINS;
+- `Decimal256::checked_mul` uses `full_mul` (Uint512 intermediate) internally in cosmwasm-std 2.2.2
+- `Decimal256Ext::checked_multiply_ratio` uses `Uint256::checked_multiply_ratio` (Uint512 intermediate)
+- `calculate_step` uses `checked_multiply_ratio(initial_d, r_val)` instead of `checked_mul(initial_d)` then `checked_div(r_val)`
+- Return amount computation uses `Uint128` for TOKEN_PRECISION scaling. Maximum supported pool value is `Uint128::MAX / 10` (~3.4e37) due to the x10 scaling. Pools exceeding this limit return a clean error.
 
-// Line 93: unchecked pow, unchecked divide, unchecked multiply
-let d_product = d.pow(3) / (amount_a_times_coins * amount_b_times_coins);
-```
+**Verification tests:** `test_compute_d_handles_extreme_values_without_panic`, `test_uint128_max_pools_returns_error`, `test_uint128_max_div_10_pools_succeeds`, `test_uint128_max_offer_no_panic`, `test_all_uint128_max_no_panic`
 
-**Impact:** A contract panic in CosmWasm is unrecoverable for that transaction. While it doesn't corrupt state (the transaction rolls back), it means users cannot perform swaps and receive an unhelpful generic error. Funds are not directly at risk but pool functionality is denied.
+---
 
-**Failing test:** `test_compute_d_unchecked_panics`
+### CRITICAL-3: `TOKEN_PRECISION = 1` is hardcoded and unrelated to token decimals [FIXED]
 
-**Suggested fix:**
-Replace all unchecked operations with checked variants:
+**Location:** `stable_math.rs:45`
 
+**Description:**
+`TOKEN_PRECISION` is set to `1` inside `compute_stable_swap`. It adds one extra decimal digit during the subtraction to reduce rounding error, then divides by 10. This is correct for integer inputs but was not explicit about that requirement. Additionally, the scaled values used `Uint128` which would overflow for pools near Uint128::MAX (3.4e38 × 10 > Uint128::MAX).
+
+**Fix applied:**
+1. Changed `compute_stable_swap` to accept explicit `Uint128` integer inputs instead of `Decimal256`, making the integer contract clear at the type level.
+2. TOKEN_PRECISION is kept as `1` with `Uint128` arithmetic. The `to_uint128_with_precision(1)` scaling multiplies values by 10, which means the maximum supported pool value is `Uint128::MAX / 10` (~3.4e37). Pools at `Uint128::MAX` will return a clean error. This is documented in the function's doc comment.
+
+**Verification tests:** `test_precision_with_integer_inputs`, `test_uint128_max_pools_returns_error`, `test_uint128_max_div_10_pools_succeeds`
+
+---
+
+### HIGH-1: Inconsistent amp factor scaling between `compute_d` and `calc_y` [FIXED]
+
+**Location:** `stable_math.rs` (compute_d vs calc_y)
+
+**Description:**
+`compute_d` used `leverage = (amp / AMP_PRECISION) * N_COINS` while `calc_y` used a different factoring with `amp * N_COINS` and `amp_prec` applied separately.
+
+**Fix applied:**
+Both functions now use identical leverage computation:
 ```rust
 let leverage = Decimal256::from_ratio(amp, AMP_PRECISION).checked_mul(N_COINS)?;
-let amount_a_times_coins = pools[0].checked_mul(N_COINS)?;
-let amount_b_times_coins = pools[1].checked_mul(N_COINS)?;
-
-// In loop:
-let d_product = d.checked_pow(3)?
-    .checked_div(amount_a_times_coins.checked_mul(amount_b_times_coins)?)?;
 ```
+
+**Verification tests:** `test_amp_factor_consistency`
 
 ---
 
-### CRITICAL-3: `TOKEN_PRECISION = 1` is hardcoded and unrelated to token decimals
+### HIGH-2: `saturating_sub` silently masks bugs in spread calculation [FIXED]
 
-**Location:** `stable_math.rs:21`
-
-**Description:**
-`TOKEN_PRECISION` is a local constant set to `1` inside `compute_stable_swap`. It is used for:
-
-1. `ask_pool.to_uint128_with_precision(1)` — divides atomics by `10^17`, giving `value * 10`
-2. `calc_y(..., TOKEN_PRECISION)` — returns `y` with the same `10x` scaling
-3. `checked_div(Uint128::new(10))` — removes the `10x` scaling from the subtraction result
-4. `offer_asset.to_uint128_with_precision(0)` — gives the raw integer value
-
-The purpose is to preserve one extra decimal digit during the `ask_pool - new_ask_pool` subtraction to reduce rounding error. However:
-
-- This constant has no relationship to the actual decimal configuration of the tokens (6, 18, 24, etc.)
-- For 24-decimal tokens, the return amount is in raw 24-decimal units, and the extra digit of precision from TOKEN_PRECISION=1 is negligible relative to 24 decimal places
-- The spread calculation `offer_amount.saturating_sub(return_amount)` compares two values that were converted with different precisions (0 vs 1-then-divided-by-10), which are equivalent only because the math works out for integer inputs
-
-**Impact:** While the current implementation produces correct results for integer-valued inputs (the precision(1) and /10 cancel out), it does not account for fractional Decimal256 values or non-integer token amounts. Any refactoring that changes how amounts enter the function could silently break the precision math.
-
-**Failing test:** `test_precision_with_24_decimal_inputs`
-
-**Suggested fix:**
-Either:
-1. Accept token decimal configuration as a parameter and normalize amounts before computation
-2. Perform all math in Decimal256 and only convert to Uint128 at the final step
-3. At minimum, document why TOKEN_PRECISION=1 is correct and add assertions that inputs are integer-valued
-
----
-
-### HIGH-1: Inconsistent amp factor scaling between `compute_d` and `calc_y`
-
-**Location:** `stable_math.rs:80` vs `stable_math.rs:122-123`
+**Location:** `stable_math.rs:68`
 
 **Description:**
-The two functions parameterize the amplification factor differently:
+Used `saturating_sub` which silently returns 0 if `return_amount > offer_amount`, hiding potential invariant violations.
 
+**Fix applied:**
 ```rust
-// compute_d (line 80):
-let leverage = Decimal256::from_ratio(amp, AMP_PRECISION) * N_COINS;
-// leverage = (amp / 100) * 2
-
-// calc_y (lines 122-123):
-let leverage = Decimal256::from_ratio(amp, 1u8) * N_COINS;
-let amp_prec = Decimal256::from_ratio(AMP_PRECISION, 1u8);
-// leverage = amp * 2, amp_prec = 100 (used separately in formulas)
+let spread_amount = offer_amount.checked_sub(return_amount).map_err(|_| {
+    ContractError::new("Invariant violation: return_amount exceeds offer_amount")
+})?;
 ```
 
-These are mathematically equivalent: `calc_y` factors out `AMP_PRECISION` and applies it separately in the `c` and `b` formulas. However, the inconsistency is dangerous:
-
-- A developer modifying `compute_d` to change how `leverage` is computed would need to know that `calc_y` uses a different factoring
-- The relationship is not documented
-- Code review is harder because the two functions appear to use different amplification values
-
-**Verification:** The following identity holds:
-- `compute_d`: `Ann = (amp/100) * 2`
-- `calc_y`: `c = D^3 * 100 / (x * 4 * amp * 2) = D^3 / (x * 4 * (amp/100) * 2) = D^3 / (x * N_COINS^2 * Ann)` (correct)
-
-**Failing test:** `test_amp_factor_consistency`
-
-**Suggested fix:**
-Unify both functions to use the same leverage computation. The simplest approach is to have `calc_y` also use `Decimal256::from_ratio(amp, AMP_PRECISION) * N_COINS`.
-
----
-
-### HIGH-2: `saturating_sub` silently masks bugs in spread calculation
-
-**Location:** `stable_math.rs:41`
-
-**Description:**
-```rust
-let spread_amount = offer_amount.saturating_sub(return_amount);
-```
-
-If `return_amount > offer_amount`, this silently returns `0` instead of signaling an invariant violation. In a correctly functioning StableSwap, the return amount should always be less than or equal to the offer amount (the pool takes a spread). If it's not, something is mathematically wrong.
-
-Using `saturating_sub` here means:
-- Arbitrage conditions where users get more than they put in would be hidden
-- Math bugs that produce inflated return amounts would go undetected
-- The spread amount reported to users would be incorrect (0 instead of an error)
-
-**Impact:** Could mask fund-draining bugs where the pool pays out more than it receives.
-
-**Failing test:** `test_spread_can_silently_be_zero`
-
-**Suggested fix:**
-```rust
-let spread_amount = offer_amount
-    .checked_sub(return_amount)
-    .map_err(|_| ContractError::new(
-        "Invariant violation: return_amount exceeds offer_amount"
-    ))?;
-```
+**Verification tests:** `test_spread_uses_checked_sub`
 
 ---
 
@@ -206,21 +130,12 @@ let spread_amount = offer_amount
 pub const TOL: Decimal256 = Decimal256::raw(1000000000000); // 1e-6
 ```
 
-This absolute tolerance of `1e-6` is used for convergence checks in both `compute_d` and `calc_y`:
-```rust
-if d.abs_diff(d_previous) <= TOL { return Ok(d); }
-```
+This absolute tolerance of `1e-6` is used for convergence checks. For large values (e.g., pools where D ~ 1e24), `1e-6` is negligible and convergence happens quickly. For very small values (pools with 1 unit), `1e-6` relative to `1` means we stop at `0.0001%` precision.
 
-For large values (e.g., 24-decimal pools where D ~ 1e24), a tolerance of 1e-6 is `1e-30` relative to the value, meaning convergence happens very quickly but the last few iterations may be wasted or the result may lack precision in the least significant digits.
-
-For very small values (e.g., pools with 1 unit), `1e-6` relative to `1` means we stop iterating when within `0.0001%`, which may be acceptable but is not consistent with the large-value behavior.
-
-**Impact:** Potential precision loss for edge cases; not a correctness issue for typical values.
-
-**Note:** No dedicated test for this finding. The tolerance concern is theoretical for current usage (integer values << 1e18) but would become relevant if the overflow issues (CRITICAL-1) are fixed to support larger values.
+**Impact:** Low. The tolerance works well across the Uint128 range in practice. Not a correctness issue for typical values.
 
 **Suggested fix:**
-Consider a relative tolerance:
+Consider adding a relative tolerance check:
 ```rust
 if d.abs_diff(d_previous) <= TOL || d.abs_diff(d_previous) / d <= relative_tol {
     return Ok(d);
@@ -229,87 +144,65 @@ if d.abs_diff(d_previous) <= TOL || d.abs_diff(d_previous) / d <= relative_tol {
 
 ---
 
-### MEDIUM-2: No input validation on amp factor or pool amounts
+### MEDIUM-2: No input validation on amp factor or pool amounts [FIXED]
 
-**Location:** `compute_stable_swap`, `compute_d`, `calc_y`
+**Location:** `stable_math.rs:26-34`
 
 **Description:**
-None of the math functions validate their inputs:
+None of the math functions validated their inputs. Zero amp factor caused panics, zero pool amounts caused division by zero.
 
-- **Zero amp factor**: `amp = 0` causes `leverage = 0`. In `calculate_step`, the expression `leverage - Decimal256::one()` underflows (unsigned subtraction of 0 - 1), causing a **panic** instead of a clean error.
-- **Extremely large amp factor**: Could overflow the `leverage` multiplication
-- **Zero pool amounts**: `pools[0] = 0` with non-zero `pools[1]` causes division by zero in `d_product = d^3 / (amount_a * amount_b)` on line 93
-- **Pool array length**: `compute_d` directly indexes `pools[0]` and `pools[1]` without checking the array length (though this is somewhat mitigated by it being called only from trusted internal code)
-
-**Impact:** Unvalidated inputs cause panics or incorrect results instead of descriptive errors.
-
-**Failing test:** `test_zero_amp_factor_panics`, `test_extreme_amp_factor`, `test_zero_pool_reserve_panics`
-
-**Suggested fix:**
-Add input validation at the entry point (`compute_stable_swap`):
+**Fix applied:**
+Input validation at the `compute_stable_swap` entry point:
 ```rust
-ensure!(amp_factor.u64() > 0, ContractError::new("Amp factor must be positive"));
-ensure!(amp_factor.u64() <= MAX_AMP, ContractError::new("Amp factor exceeds maximum"));
-ensure!(!offer_pool.is_zero() && !ask_pool.is_zero(), ContractError::new("Pool reserves must be non-zero"));
+if amp_factor.is_zero() {
+    return Err(ContractError::new("Amp factor must be greater than zero"));
+}
+if offer_pool.is_zero() || ask_pool.is_zero() {
+    return Err(ContractError::new("Pool reserves must be non-zero"));
+}
+if offer_asset.is_zero() {
+    return Err(ContractError::new("Offer amount must be non-zero"));
+}
 ```
+
+**Verification tests:** `test_zero_amp_factor_returns_error`, `test_extreme_amp_factor`, `test_zero_pool_reserve_returns_error`, `test_zero_offer_returns_error`, `test_uint128_min_boundaries`
 
 ---
 
 ### LOW-1: Integer truncation in return_amount creates systematic user loss
 
-**Location:** `stable_math.rs:35`
+**Location:** `stable_math.rs:62`
 
 **Description:**
-```rust
-let return_amount = ask_pool_amount
-    .checked_sub(new_ask_pool_amount)?
-    .checked_div(Uint128::new(10u128.pow(TOKEN_PRECISION as u32)))?;
-```
+The TOKEN_PRECISION floor division `checked_div(10)` always rounds down. For very small swaps (1 or 2 units), the rounding error can be significant.
 
-The `checked_div(10)` performs floor division, always rounding down. This means:
-- A difference of `15` becomes `1` (user loses 5 units of the extra-precision digit)
-- A difference of `9` becomes `0` (user gets nothing for a valid but small swap)
-- Across many swaps, this creates a systematic leak of value away from users and into the pool
-
-For very small swaps (1-2 units in integer terms), the rounding error can be 50% or more of the swap value.
-
-**Impact:** Small but systematic value extraction from users. Accumulates over time and across all swaps.
-
-**Failing test:** `test_truncation_loss_small_swaps`, `test_truncation_loss_imbalanced_pools`
+**Impact:** Small but systematic value extraction from users. Accumulates over time. The protocol benefits (value stays in the pool), so this is conservative behavior, not a vulnerability.
 
 **Suggested fix:**
 Use rounding division instead of floor division:
 ```rust
 let divisor = Uint128::new(10u128.pow(TOKEN_PRECISION as u32));
-let return_amount = (diff + divisor / Uint128::new(2)) / divisor; // round to nearest
+let return_amount = (diff + divisor / Uint128::new(2)) / divisor;
 ```
-
-Or eliminate TOKEN_PRECISION entirely and perform the subtraction in Decimal256 before converting to Uint128 once.
 
 ---
 
 ## Recommendations
 
-### Immediate (before any production deployment with 24-decimal tokens)
+### Completed
 
-1. **Fix CRITICAL-1**: Replace `d.pow(3)` with iterative `d_product` computation to avoid Uint256 overflow. This is the single most important fix as it completely blocks functionality.
+1. **CRITICAL-1**: Replaced `d.pow(3)` with iterative `checked_multiply_ratio` (Uint512 intermediate). Restructured `calc_y` to compute `c/denom` directly, avoiding `c` exceeding Decimal256 range for large pools.
+2. **CRITICAL-2**: All arithmetic is checked. `Decimal256::checked_mul` uses `full_mul` (Uint512). TOKEN_PRECISION scaling uses `Uint128`, limiting max pool value to `Uint128::MAX / 10`.
+3. **CRITICAL-3**: Changed API to accept explicit `Uint128` integer inputs. Maximum supported pool value is `Uint128::MAX / 10` (~3.4e37), documented in function doc comment.
+4. **HIGH-1**: Unified amp factor parameterization.
+5. **HIGH-2**: Replaced `saturating_sub` with `checked_sub` + error.
+6. **MEDIUM-2**: Added input validation for amp factor, pool amounts, and offer amount.
 
-2. **Fix CRITICAL-2**: Replace all unchecked arithmetic in `compute_d` with checked variants to prevent contract panics.
+### Open (low priority)
 
-3. **Fix CRITICAL-3**: Either normalize 24-decimal amounts down to a safe range before entering the math, or restructure the math to work with arbitrary decimal configurations.
+7. **MEDIUM-1**: Consider relative tolerance for Newton's method convergence.
+8. **LOW-1**: Consider rounding division instead of floor division for return_amount.
 
-### Short-term
+### Future considerations
 
-4. **Fix HIGH-2**: Replace `saturating_sub` with `checked_sub` + error in the spread calculation to catch invariant violations.
-
-5. **Fix HIGH-1**: Unify amp factor parameterization between `compute_d` and `calc_y`.
-
-6. **Fix MEDIUM-2**: Add input validation for amp factor bounds and pool amounts.
-
-### Long-term
-
-7. Consider a comprehensive rewrite referencing the Curve/Astroport implementations that handle these edge cases.
-
-8. Add property-based fuzz testing (the `tests-fuzz` framework already exists in this repo) to verify invariants like: `return_amount <= offer_amount`, `D_after >= D_before` for deposits, and `no overflow for any valid input range`.
-
-9. Consider using `Uint512` or `checked_multiply_ratio` approaches to avoid intermediate overflow in the `D^3` computation.
+9. Add property-based fuzz testing (the `tests-fuzz` framework exists in this repo) to verify invariants like: `return_amount <= offer_amount`, `D_after >= D_before`, and `no panic for any valid Uint128 input`.

--- a/packages/pool/src/README.md
+++ b/packages/pool/src/README.md
@@ -1,0 +1,130 @@
+# Stable Swap Math
+
+This module implements a Curve-style StableSwap automated market maker (AMM) for 2-coin pools. StableSwap provides low-slippage swaps for assets that are expected to trade near parity (e.g., stablecoin pairs, wrapped/unwrapped pairs).
+
+## Mathematical Foundation
+
+The StableSwap invariant combines constant-sum (zero slippage) and constant-product (infinite liquidity) behaviors, controlled by an amplification parameter `A`:
+
+```
+A * n^n * sum(x_i) + D = A * n^n * D + D^(n+1) / (n^n * prod(x_i))
+```
+
+Where:
+- `n` = number of coins (always 2 in this implementation)
+- `x_i` = pool balance of coin `i`
+- `D` = the invariant (total value of the pool when balanced)
+- `A` = amplification coefficient (higher = closer to constant-sum behavior)
+
+## Constants
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `N_COINS` | `2.0` (Decimal256) | Number of coins in the pool |
+| `AMP_PRECISION` | `100` | Divisor for the raw amplification parameter. Effective A = amp / 100. |
+| `ITERATIONS` | `64` | Maximum Newton's method iterations before returning an error |
+| `TOL` | `1e-6` (Decimal256) | Absolute convergence tolerance for Newton's method |
+| `TOKEN_PRECISION` | `1` (local to `compute_stable_swap`) | Extra decimal digit used during return amount subtraction to reduce rounding error |
+
+## Functions
+
+### `compute_stable_swap(offer_asset, offer_pool, ask_pool, amp_factor) -> SwapResult`
+
+**Entry point.** Computes how much the user receives for a given offer amount.
+
+**Flow:**
+1. Constructs pool array `xp = [offer_pool, ask_pool]`
+2. Calls `calc_y(amp_factor, offer_pool + offer_asset, xp, TOKEN_PRECISION)` to find the new ask pool balance
+3. Computes `return_amount = (ask_pool_scaled - new_ask_pool) / 10` (the `/10` reverses the TOKEN_PRECISION=1 scaling)
+4. Computes `spread_amount = offer_amount - return_amount` (the slippage/price impact)
+5. Returns `SwapResult { return_amount, spread_amount }`
+
+**Parameters:**
+- `offer_asset: &Decimal256` — amount the user is swapping in (post-fee)
+- `offer_pool: &Decimal256` — current reserve of the offer token
+- `ask_pool: &Decimal256` — current reserve of the ask token
+- `amp_factor: Uint64` — raw amplification parameter (divided by AMP_PRECISION internally)
+
+### `compute_d(amp, pools) -> Decimal256`
+
+Computes the StableSwap invariant `D` using Newton's method.
+
+**Algorithm:**
+1. Computes `leverage = (amp / AMP_PRECISION) * N_COINS`
+2. Initializes `d = sum(pools)` (sum of all pool balances)
+3. Iterates Newton's method via `calculate_step`:
+   ```
+   d_product = d^3 / (pool_a * N_COINS * pool_b * N_COINS)
+   d_new = (leverage * sum_x + d_product * n_coins) * d / ((leverage - 1) * d + (n_coins + 1) * d_product)
+   ```
+4. Converges when `|d_new - d_prev| <= TOL`
+
+### `calc_y(amp, new_amount, xp, target_precision) -> Uint128`
+
+Solves for the new balance of the ask token after a swap, given the new offer token balance.
+
+**Algorithm:**
+1. Computes `D` via `compute_d`
+2. Sets up the quadratic: `y^2 + b*y = c`
+   - `c = D^3 * AMP_PRECISION / (new_amount * N_COINS^2 * leverage)` where `leverage = amp * N_COINS`
+   - `b = new_amount + D * AMP_PRECISION / leverage`
+3. Iterates: `y_new = (y^2 + c) / (2y + b - D)`
+4. Returns `y` converted to `Uint128` with target precision
+
+**Note on amp factor parameterization:** `calc_y` uses `leverage = amp * N_COINS` (without dividing by AMP_PRECISION), then compensates by multiplying `c` by `amp_prec = 100`. This is mathematically equivalent to `compute_d`'s approach but uses a different factoring.
+
+### `calculate_step(initial_d, leverage, sum_x, d_product) -> Decimal256`
+
+Newton's method helper for `compute_d`. Computes one iteration step:
+
+```
+d_new = (leverage * sum_x + d_product * n_coins) * initial_d
+        / ((leverage - 1) * initial_d + (n_coins + 1) * d_product)
+```
+
+## Precision Handling
+
+### Decimal256 Internals
+- `Decimal256` has 18 internal decimal places, backed by `Uint256`
+- `atomics = integer_value * 10^18`
+- `Uint256` max ~ `1.158 * 10^77`
+
+### Decimal256Ext Methods (from `euclid::utils::math`)
+- `from_integer(x)`: Creates `Decimal256` with integer value `x` (atomics = x * 10^18)
+- `to_uint128_with_precision(p)`: Returns `atomics / 10^(18 - p)`
+- `with_precision(value, p)`: Creates `Decimal256` from atomics at given precision
+
+### How Precision Is Used in compute_stable_swap
+1. `ask_pool.to_uint128_with_precision(1)` gives `value * 10` (one extra digit)
+2. `calc_y` returns with the same precision(1) scaling
+3. The subtraction `ask_pool_scaled - new_ask_pool` preserves that extra digit
+4. Division by `10^TOKEN_PRECISION = 10` removes the extra digit, truncating
+5. `offer_asset.to_uint128_with_precision(0)` gives the raw integer value
+
+## Call Flow in the Swap Pipeline
+
+```
+User submits swap(amount_in, asset_in)
+    |
+    v
+pre_swap (pool_functions.rs:528)
+    |-- Calculate fees: lp_fee + euclid_fee
+    |-- swap_amount = amount_in - fees
+    |-- Convert to Decimal256: Decimal256::from_integer(swap_amount)
+    |-- Convert reserves: Decimal256::from_integer(token_in_reserve)
+    |
+    v
+compute_stable_swap (stable_math.rs:14)
+    |-- calc_y -> compute_d -> calculate_step (Newton's method)
+    |-- return SwapResult { return_amount, spread_amount }
+    |
+    v
+execute_swap (pool_functions.rs:589)
+    |-- Update reserves: in += swap_amount + lp_fee, out -= receive_amount
+    |-- Transfer euclid_fee to fee recipient
+    |-- Transfer receive_amount to user (or chain to next swap)
+```
+
+## Known Limitations
+
+See [AUDIT.md](./AUDIT.md) for a comprehensive security audit including critical overflow issues with large token decimal configurations and precision handling concerns.

--- a/packages/pool/src/README.md
+++ b/packages/pool/src/README.md
@@ -39,10 +39,12 @@ Where:
 4. Computes `spread_amount = offer_amount - return_amount` (the slippage/price impact)
 5. Returns `SwapResult { return_amount, spread_amount }`
 
+**Maximum supported pool value:** `Uint128::MAX / 10` (~3.4e37). The TOKEN_PRECISION=1 scaling multiplies pool values by 10 during the return amount computation, so pools at `Uint128::MAX` would overflow.
+
 **Parameters:**
-- `offer_asset: &Decimal256` — amount the user is swapping in (post-fee)
-- `offer_pool: &Decimal256` — current reserve of the offer token
-- `ask_pool: &Decimal256` — current reserve of the ask token
+- `offer_asset: Uint128` — amount the user is swapping in (post-fee)
+- `offer_pool: Uint128` — current reserve of the offer token
+- `ask_pool: Uint128` — current reserve of the ask token
 - `amp_factor: Uint64` — raw amplification parameter (divided by AMP_PRECISION internally)
 
 ### `compute_d(amp, pools) -> Decimal256`
@@ -66,12 +68,14 @@ Solves for the new balance of the ask token after a swap, given the new offer to
 **Algorithm:**
 1. Computes `D` via `compute_d`
 2. Sets up the quadratic: `y^2 + b*y = c`
-   - `c = D^3 * AMP_PRECISION / (new_amount * N_COINS^2 * leverage)` where `leverage = amp * N_COINS`
-   - `b = new_amount + D * AMP_PRECISION / leverage`
+   - `c = D^3 / (new_amount * N_COINS^2 * leverage)` where `leverage = (amp / AMP_PRECISION) * N_COINS`
+   - `b = new_amount + D / leverage`
 3. Iterates: `y_new = (y^2 + c) / (2y + b - D)`
 4. Returns `y` converted to `Uint128` with target precision
 
-**Note on amp factor parameterization:** `calc_y` uses `leverage = amp * N_COINS` (without dividing by AMP_PRECISION), then compensates by multiplying `c` by `amp_prec = 100`. This is mathematically equivalent to `compute_d`'s approach but uses a different factoring.
+**Overflow protection:** For large pool values, `c` itself can exceed Decimal256 range. Instead of computing `c` upfront, `c/denom` is computed directly in the Newton loop using iterative `checked_multiply_ratio` calls (Uint512 intermediate), keeping each step within Decimal256 range.
+
+**Amp factor parameterization:** Both `compute_d` and `calc_y` use identical leverage computation: `leverage = (amp / AMP_PRECISION) * N_COINS`.
 
 ### `calculate_step(initial_d, leverage, sum_x, d_product) -> Decimal256`
 
@@ -90,16 +94,17 @@ d_new = (leverage * sum_x + d_product * n_coins) * initial_d
 - `Uint256` max ~ `1.158 * 10^77`
 
 ### Decimal256Ext Methods (from `euclid::utils::math`)
-- `from_integer(x)`: Creates `Decimal256` with integer value `x` (atomics = x * 10^18)
+- `checked_from_integer(x)`: Creates `Decimal256` with integer value `x` (atomics = x * 10^18). Returns `StdResult`.
 - `to_uint128_with_precision(p)`: Returns `atomics / 10^(18 - p)`
+- `checked_multiply_ratio(num, den)`: Performs `(self * num) / den` using Uint512 intermediate to avoid overflow
 - `with_precision(value, p)`: Creates `Decimal256` from atomics at given precision
 
 ### How Precision Is Used in compute_stable_swap
-1. `ask_pool.to_uint128_with_precision(1)` gives `value * 10` (one extra digit)
-2. `calc_y` returns with the same precision(1) scaling
-3. The subtraction `ask_pool_scaled - new_ask_pool` preserves that extra digit
-4. Division by `10^TOKEN_PRECISION = 10` removes the extra digit, truncating
-5. `offer_asset.to_uint128_with_precision(0)` gives the raw integer value
+1. `ask_pool_dec.to_uint128_with_precision(1)` gives `value * 10` as Uint128 (one extra digit)
+2. `calc_y` returns a `Uint128` already scaled by `10^target_precision`
+3. The subtraction `ask_pool_scaled - new_ask_pool_scaled` preserves that extra digit
+4. Division by `10^TOKEN_PRECISION = 10` removes the extra digit, truncating to integer
+5. This limits maximum pool value to `Uint128::MAX / 10` (~3.4e37), since the x10 scaling must fit in Uint128
 
 ## Call Flow in the Swap Pipeline
 
@@ -110,13 +115,14 @@ User submits swap(amount_in, asset_in)
 pre_swap (pool_functions.rs:528)
     |-- Calculate fees: lp_fee + euclid_fee
     |-- swap_amount = amount_in - fees
-    |-- Convert to Decimal256: Decimal256::from_integer(swap_amount)
-    |-- Convert reserves: Decimal256::from_integer(token_in_reserve)
+    |-- Pass Uint128 directly to compute_stable_swap
     |
     v
-compute_stable_swap (stable_math.rs:14)
+compute_stable_swap (stable_math.rs:19)
+    |-- Convert Uint128 inputs to Decimal256 internally
     |-- calc_y -> compute_d -> calculate_step (Newton's method)
-    |-- return SwapResult { return_amount, spread_amount }
+    |-- Subtraction in Uint128 with TOKEN_PRECISION scaling
+    |-- return SwapResult { return_amount, spread_amount } as Uint128
     |
     v
 execute_swap (pool_functions.rs:589)
@@ -127,4 +133,5 @@ execute_swap (pool_functions.rs:589)
 
 ## Known Limitations
 
-See [AUDIT.md](./AUDIT.md) for a comprehensive security audit including critical overflow issues with large token decimal configurations and precision handling concerns.
+- **Maximum pool value:** `Uint128::MAX / 10` (~3.4e37) due to TOKEN_PRECISION x10 scaling. Pools exceeding this return a clean error.
+- See [AUDIT.md](./AUDIT.md) for the full security audit report.

--- a/packages/pool/src/pool_functions.rs
+++ b/packages/pool/src/pool_functions.rs
@@ -562,7 +562,7 @@ pub fn pre_swap(
     let (receive_amount, spread_amount) = match calculation_method {
         SwapCalculationMethod::Stable(amp_factor) => {
             let swap_result = compute_stable_swap(
-                &Decimal256::from_integer(amount_in),
+                &Decimal256::from_integer(swap_amount),
                 &Decimal256::from_integer(token_in_reserve),
                 &Decimal256::from_integer(token_out_reserve),
                 amp_factor,

--- a/packages/pool/src/pool_functions.rs
+++ b/packages/pool/src/pool_functions.rs
@@ -12,7 +12,7 @@ use euclid::{
     },
     swap::NextSwapVlp,
     token::{Pair, PairWithAmount, Token},
-    utils::math::Decimal256Ext,
+
 };
 
 use cosmwasm_schema::cw_serde;
@@ -562,9 +562,9 @@ pub fn pre_swap(
     let (receive_amount, spread_amount) = match calculation_method {
         SwapCalculationMethod::Stable(amp_factor) => {
             let swap_result = compute_stable_swap(
-                &Decimal256::from_integer(swap_amount),
-                &Decimal256::from_integer(token_in_reserve),
-                &Decimal256::from_integer(token_out_reserve),
+                swap_amount,
+                token_in_reserve,
+                token_out_reserve,
                 amp_factor,
             )?;
             (swap_result.return_amount, swap_result.spread_amount)

--- a/packages/pool/src/pool_functions.rs
+++ b/packages/pool/src/pool_functions.rs
@@ -12,7 +12,6 @@ use euclid::{
     },
     swap::NextSwapVlp,
     token::{Pair, PairWithAmount, Token},
-
 };
 
 use cosmwasm_schema::cw_serde;
@@ -561,12 +560,8 @@ pub fn pre_swap(
 
     let (receive_amount, spread_amount) = match calculation_method {
         SwapCalculationMethod::Stable(amp_factor) => {
-            let swap_result = compute_stable_swap(
-                swap_amount,
-                token_in_reserve,
-                token_out_reserve,
-                amp_factor,
-            )?;
+            let swap_result =
+                compute_stable_swap(swap_amount, token_in_reserve, token_out_reserve, amp_factor)?;
             (swap_result.return_amount, swap_result.spread_amount)
         }
         SwapCalculationMethod::Regular => {

--- a/packages/pool/src/stable_math.rs
+++ b/packages/pool/src/stable_math.rs
@@ -101,13 +101,10 @@ fn calculate_step(
     let d_p_mul = d_product.checked_mul(N_COINS)?;
 
     let numerator = leverage_mul.checked_add(d_p_mul)?;
-    let leverage_sub = initial_d.checked_mul(
-        leverage
-            .checked_sub(Decimal256::one())
-            .map_err(|e| StdError::generic_err(e.to_string()))?,
-    )?;
+    let leverage_sub_dec = leverage.checked_sub(Decimal256::one())?;
+    let leverage_sub = initial_d.checked_mul(leverage_sub_dec)?;
     let n_coins_sum = d_product.checked_mul(N_COINS.checked_add(Decimal256::one())?)?;
-
+    // (leverage - 1) * initial_d + (n_coins + 1) * d_product
     let r_val = leverage_sub.checked_add(n_coins_sum)?;
 
     numerator.checked_multiply_ratio(initial_d, r_val)

--- a/packages/pool/src/stable_math.rs
+++ b/packages/pool/src/stable_math.rs
@@ -11,10 +11,19 @@ const ITERATIONS: u8 = 64;
 /// 1e-6
 pub const TOL: Decimal256 = Decimal256::raw(1000000000000);
 
+/// Computes a stable swap result given integer token amounts.
+///
+/// All inputs are `Uint128` (integer amounts). The function converts to
+/// `Decimal256` internally for the math, then converts the result back
+/// to `Uint128`.
+///
+/// **Maximum supported pool value:** `Uint128::MAX / 10` (~3.4e37).
+/// The `TOKEN_PRECISION = 1` scaling multiplies pool values by 10 during
+/// the return amount computation, so pools at `Uint128::MAX` would overflow.
 pub fn compute_stable_swap(
-    offer_asset: &Decimal256,
-    offer_pool: &Decimal256,
-    ask_pool: &Decimal256,
+    offer_asset: Uint128,
+    offer_pool: Uint128,
+    ask_pool: Uint128,
     amp_factor: Uint64,
 ) -> Result<SwapResult, ContractError> {
     // Validate inputs
@@ -28,28 +37,38 @@ pub fn compute_stable_swap(
         return Err(ContractError::new("Offer amount must be non-zero"));
     }
 
-    // Extra decimal digit used during subtraction to reduce rounding error
+    // Convert Uint128 inputs to Decimal256 for internal math
+    let offer_asset_dec = Decimal256::checked_from_integer(offer_asset)?;
+    let offer_pool_dec = Decimal256::checked_from_integer(offer_pool)?;
+    let ask_pool_dec = Decimal256::checked_from_integer(ask_pool)?;
+
+    // Extra decimal digit used during subtraction to reduce rounding error.
+    // Both ask_pool and new_ask_pool are scaled by 10 (via to_uint128_with_precision(1)),
+    // subtracted as integers, then divided by 10. This preserves one extra digit
+    // of precision compared to truncating each value independently.
+    // NOTE: This limits max pool value to Uint128::MAX / 10, since the ×10 scaling
+    // must fit in Uint128.
     const TOKEN_PRECISION: u8 = 1;
 
     // Create array of pool amounts
-    let xp = [*offer_pool, *ask_pool];
+    let xp = [offer_pool_dec, ask_pool_dec];
 
     // Calculate new pool amount after swap
-    let new_offer_pool = offer_pool
-        .checked_add(*offer_asset)
+    let new_offer_pool = offer_pool_dec
+        .checked_add(offer_asset_dec)
         .map_err(|e| ContractError::new(&e.to_string()))?;
     let new_ask_pool = calc_y(amp_factor, new_offer_pool, &xp, TOKEN_PRECISION)?;
 
     // Calculate return amount (what user receives)
-    let ask_pool_amount = ask_pool.to_uint128_with_precision(TOKEN_PRECISION)?;
+    let ask_pool_amount = ask_pool_dec.to_uint128_with_precision(TOKEN_PRECISION)?;
     let new_ask_pool_amount = new_ask_pool;
     let return_amount = ask_pool_amount
         .checked_sub(new_ask_pool_amount)
         .map_err(|_| ContractError::new("Negative return amount"))?
         .checked_div(Uint128::new(10u128.pow(TOKEN_PRECISION as u32)))?;
 
-    // Calculate offer amount (what user provides)
-    let offer_amount = offer_asset.to_uint128_with_precision(0_u32)?;
+    // Calculate offer amount for spread calculation
+    let offer_amount = offer_asset_dec.to_uint128_with_precision(0_u32)?;
 
     // Calculate spread (difference between what user provides and receives)
     let spread_amount = offer_amount.checked_sub(return_amount).map_err(|_| {
@@ -81,7 +100,7 @@ fn calculate_step(
     let leverage_mul = leverage.checked_mul(sum_x)?;
     let d_p_mul = d_product.checked_mul(N_COINS)?;
 
-    let l_val = leverage_mul.checked_add(d_p_mul)?.checked_mul(initial_d)?;
+    let numerator = leverage_mul.checked_add(d_p_mul)?;
     let leverage_sub = initial_d.checked_mul(
         leverage
             .checked_sub(Decimal256::one())
@@ -91,9 +110,7 @@ fn calculate_step(
 
     let r_val = leverage_sub.checked_add(n_coins_sum)?;
 
-    l_val
-        .checked_div(r_val)
-        .map_err(|e| StdError::generic_err(e.to_string()))
+    numerator.checked_multiply_ratio(initial_d, r_val)
 }
 
 pub fn compute_d(amp: Uint64, pools: &[Decimal256]) -> StdResult<Decimal256> {
@@ -111,15 +128,11 @@ pub fn compute_d(amp: Uint64, pools: &[Decimal256]) -> StdResult<Decimal256> {
         // Newton's method to approximate D
         for _ in 0..ITERATIONS {
             // d_product = D^3 / (pool_a * n * pool_b * n)
-            // Computed iteratively to avoid D^3 intermediate overflow:
-            // (D * D / amount_a_times_coins) * D / amount_b_times_coins
+            // Computed iteratively via checked_multiply_ratio (uses Uint512 internally)
+            // to avoid D^3 intermediate overflow
             let d_product = d
-                .checked_mul(d)?
-                .checked_div(amount_a_times_coins)
-                .map_err(|e| StdError::generic_err(e.to_string()))?
-                .checked_mul(d)?
-                .checked_div(amount_b_times_coins)
-                .map_err(|e| StdError::generic_err(e.to_string()))?;
+                .checked_multiply_ratio(d, amount_a_times_coins)?
+                .checked_multiply_ratio(d, amount_b_times_coins)?;
             d_previous = d;
             d = calculate_step(d, leverage, sum_x, d_product)?;
             // Equality with the precision of 1e-6
@@ -151,16 +164,15 @@ pub(crate) fn calc_y(
     // Use same amp scaling as compute_d: leverage = (amp / AMP_PRECISION) * N_COINS
     let leverage = Decimal256::from_ratio(amp, AMP_PRECISION).checked_mul(N_COINS)?;
 
+    // Precompute denominators for c/denom factoring.
     // c = D^3 / (new_amount * N_COINS^2 * leverage)
-    // Computed iteratively to avoid D^3 intermediate overflow:
-    // (D * D / (new_amount * N)) * D / (N * leverage)
-    let c = d
-        .checked_mul(d)?
-        .checked_div(new_amount.checked_mul(N_COINS)?)
-        .map_err(|e| StdError::generic_err(e.to_string()))?
-        .checked_mul(d)?
-        .checked_div(N_COINS.checked_mul(leverage)?)
-        .map_err(|e| StdError::generic_err(e.to_string()))?;
+    // For large pool values, c itself can exceed Decimal256 range.
+    // Instead of computing c upfront, we compute c/denom directly in the loop:
+    //   c/denom = D * D / (new_amount * N) * D / (N * leverage * denom)
+    // Each checked_multiply_ratio uses Uint512 intermediate, and the per-step
+    // results stay within Decimal256 range.
+    let new_amount_times_n = new_amount.checked_mul(N_COINS)?;
+    let n_times_leverage = N_COINS.checked_mul(leverage)?;
 
     let b = new_amount.checked_add(
         d.checked_div(leverage)
@@ -172,11 +184,27 @@ pub(crate) fn calc_y(
     let mut y = d;
     for _ in 0..ITERATIONS {
         y_prev = y;
-        y = y
-            .checked_pow(2)?
-            .checked_add(c)?
-            .checked_div(y.checked_mul(N_COINS)?.checked_add(b)?.checked_sub(d)?)
+        // y_new = (y^2 + c) / denom = y^2/denom + c/denom
+        // where denom = 2y + b - d
+        let denom = y
+            .checked_mul(N_COINS)?
+            .checked_add(b)?
+            .checked_sub(d)
             .map_err(|e| StdError::generic_err(e.to_string()))?;
+
+        // y^2 / denom (Uint512 intermediate via checked_multiply_ratio)
+        let y_sq_over_denom = y.checked_multiply_ratio(y, denom)?;
+
+        // c/denom = D^3 / (new_amount * N * N * leverage * denom)
+        // Computed iteratively to keep each intermediate within Decimal256 range.
+        // Step 1: D^2 / (new_amount * N) — stays ~ O(D) for balanced pools
+        // Step 2: * D / (N * leverage * denom) — divides by large denom, result ~ O(y)
+        let c_over_denom = d
+            .checked_multiply_ratio(d, new_amount_times_n)?
+            .checked_multiply_ratio(d, n_times_leverage.checked_mul(denom)?)?;
+
+        y = y_sq_over_denom.checked_add(c_over_denom)?;
+
         if y.abs_diff(y_prev) <= TOL {
             return y.to_uint128_with_precision(target_precision);
         }

--- a/packages/pool/src/stable_math.rs
+++ b/packages/pool/src/stable_math.rs
@@ -77,9 +77,9 @@ fn calculate_step(
 }
 
 pub fn compute_d(amp: Uint64, pools: &[Decimal256]) -> StdResult<Decimal256> {
-    let leverage = Decimal256::from_ratio(amp, AMP_PRECISION) * N_COINS;
-    let amount_a_times_coins = pools[0] * N_COINS;
-    let amount_b_times_coins = pools[1] * N_COINS;
+    let leverage = Decimal256::from_ratio(amp, AMP_PRECISION).checked_mul(N_COINS)?;
+    let amount_a_times_coins = pools[0].checked_mul(N_COINS)?;
+    let amount_b_times_coins = pools[1].checked_mul(N_COINS)?;
 
     let sum_x = pools[0].checked_add(pools[1])?; // sum(x_i), a.k.a S
     if sum_x.is_zero() {
@@ -90,7 +90,16 @@ pub fn compute_d(amp: Uint64, pools: &[Decimal256]) -> StdResult<Decimal256> {
 
         // Newton's method to approximate D
         for _ in 0..ITERATIONS {
-            let d_product = d.pow(3) / (amount_a_times_coins * amount_b_times_coins);
+            // d_product = D^3 / (pool_a * n * pool_b * n)
+            // Computed iteratively to avoid D^3 intermediate overflow:
+            // (D * D / amount_a_times_coins) * D / amount_b_times_coins
+            let d_product = d
+                .checked_mul(d)?
+                .checked_div(amount_a_times_coins)
+                .map_err(|e| StdError::generic_err(e.to_string()))?
+                .checked_mul(d)?
+                .checked_div(amount_b_times_coins)
+                .map_err(|e| StdError::generic_err(e.to_string()))?;
             d_previous = d;
             d = calculate_step(d, leverage, sum_x, d_product)?;
             // Equality with the precision of 1e-6
@@ -119,13 +128,20 @@ pub(crate) fn calc_y(
     target_precision: u8,
 ) -> StdResult<Uint128> {
     let d = compute_d(amp, xp)?;
-    let leverage = Decimal256::from_ratio(amp, 1u8) * N_COINS;
+    let leverage = Decimal256::from_ratio(amp, 1u8).checked_mul(N_COINS)?;
     let amp_prec = Decimal256::from_ratio(AMP_PRECISION, 1u8);
 
-    let c = d.checked_pow(3)?.checked_mul(amp_prec)?
-        / new_amount
-            .checked_mul(N_COINS * N_COINS)?
-            .checked_mul(leverage)?;
+    // c = D^3 * amp_prec / (new_amount * N_COINS^2 * leverage)
+    // Computed iteratively to avoid D^3 intermediate overflow:
+    // (D * D / (new_amount * N)) * D * amp_prec / (N * leverage)
+    let c = d
+        .checked_mul(d)?
+        .checked_div(new_amount.checked_mul(N_COINS)?)
+        .map_err(|e| StdError::generic_err(e.to_string()))?
+        .checked_mul(d)?
+        .checked_mul(amp_prec)?
+        .checked_div(N_COINS.checked_mul(leverage)?)
+        .map_err(|e| StdError::generic_err(e.to_string()))?;
 
     let b = new_amount.checked_add(d.checked_mul(amp_prec)? / leverage)?;
 

--- a/packages/pool/src/stable_math.rs
+++ b/packages/pool/src/stable_math.rs
@@ -17,14 +17,28 @@ pub fn compute_stable_swap(
     ask_pool: &Decimal256,
     amp_factor: Uint64,
 ) -> Result<SwapResult, ContractError> {
-    // Use a constant for amplification factor instead of hardcoding
+    // Validate inputs
+    if amp_factor.is_zero() {
+        return Err(ContractError::new("Amp factor must be greater than zero"));
+    }
+    if offer_pool.is_zero() || ask_pool.is_zero() {
+        return Err(ContractError::new("Pool reserves must be non-zero"));
+    }
+    if offer_asset.is_zero() {
+        return Err(ContractError::new("Offer amount must be non-zero"));
+    }
+
+    // Extra decimal digit used during subtraction to reduce rounding error
     const TOKEN_PRECISION: u8 = 1;
 
     // Create array of pool amounts
     let xp = [*offer_pool, *ask_pool];
 
     // Calculate new pool amount after swap
-    let new_ask_pool = calc_y(amp_factor, offer_pool + offer_asset, &xp, TOKEN_PRECISION)?;
+    let new_offer_pool = offer_pool
+        .checked_add(*offer_asset)
+        .map_err(|e| ContractError::new(&e.to_string()))?;
+    let new_ask_pool = calc_y(amp_factor, new_offer_pool, &xp, TOKEN_PRECISION)?;
 
     // Calculate return amount (what user receives)
     let ask_pool_amount = ask_pool.to_uint128_with_precision(TOKEN_PRECISION)?;
@@ -38,7 +52,9 @@ pub fn compute_stable_swap(
     let offer_amount = offer_asset.to_uint128_with_precision(0_u32)?;
 
     // Calculate spread (difference between what user provides and receives)
-    let spread_amount = offer_amount.saturating_sub(return_amount);
+    let spread_amount = offer_amount.checked_sub(return_amount).map_err(|_| {
+        ContractError::new("Invariant violation: return_amount exceeds offer_amount")
+    })?;
 
     Ok(SwapResult {
         return_amount,
@@ -66,7 +82,11 @@ fn calculate_step(
     let d_p_mul = d_product.checked_mul(N_COINS)?;
 
     let l_val = leverage_mul.checked_add(d_p_mul)?.checked_mul(initial_d)?;
-    let leverage_sub = initial_d.checked_mul(leverage - Decimal256::one())?;
+    let leverage_sub = initial_d.checked_mul(
+        leverage
+            .checked_sub(Decimal256::one())
+            .map_err(|e| StdError::generic_err(e.to_string()))?,
+    )?;
     let n_coins_sum = d_product.checked_mul(N_COINS.checked_add(Decimal256::one())?)?;
 
     let r_val = leverage_sub.checked_add(n_coins_sum)?;
@@ -128,22 +148,24 @@ pub(crate) fn calc_y(
     target_precision: u8,
 ) -> StdResult<Uint128> {
     let d = compute_d(amp, xp)?;
-    let leverage = Decimal256::from_ratio(amp, 1u8).checked_mul(N_COINS)?;
-    let amp_prec = Decimal256::from_ratio(AMP_PRECISION, 1u8);
+    // Use same amp scaling as compute_d: leverage = (amp / AMP_PRECISION) * N_COINS
+    let leverage = Decimal256::from_ratio(amp, AMP_PRECISION).checked_mul(N_COINS)?;
 
-    // c = D^3 * amp_prec / (new_amount * N_COINS^2 * leverage)
+    // c = D^3 / (new_amount * N_COINS^2 * leverage)
     // Computed iteratively to avoid D^3 intermediate overflow:
-    // (D * D / (new_amount * N)) * D * amp_prec / (N * leverage)
+    // (D * D / (new_amount * N)) * D / (N * leverage)
     let c = d
         .checked_mul(d)?
         .checked_div(new_amount.checked_mul(N_COINS)?)
         .map_err(|e| StdError::generic_err(e.to_string()))?
         .checked_mul(d)?
-        .checked_mul(amp_prec)?
         .checked_div(N_COINS.checked_mul(leverage)?)
         .map_err(|e| StdError::generic_err(e.to_string()))?;
 
-    let b = new_amount.checked_add(d.checked_mul(amp_prec)? / leverage)?;
+    let b = new_amount.checked_add(
+        d.checked_div(leverage)
+            .map_err(|e| StdError::generic_err(e.to_string()))?,
+    )?;
 
     // Solve for y by approximating: y**2 + b*y = c
     let mut y_prev;

--- a/packages/pool/src/test.rs
+++ b/packages/pool/src/test.rs
@@ -187,8 +187,7 @@ mod tests {
         #[case] expected_return_amount: Uint128,
         #[case] expected_spread_amount: Uint128,
     ) {
-        let result =
-            compute_stable_swap(offer_asset, offer_pool, ask_pool, swap_amount).unwrap();
+        let result = compute_stable_swap(offer_asset, offer_pool, ask_pool, swap_amount).unwrap();
 
         assert_eq!(
             result.return_amount, expected_return_amount,
@@ -637,15 +636,17 @@ mod tests {
         #[test]
         fn test_uint128_max_div_10_pools_succeeds() {
             let max_pool = Uint128::MAX.checked_div(Uint128::new(10)).unwrap();
-            let result = compute_stable_swap(
-                Uint128::new(1000),
-                max_pool,
-                max_pool,
-                Uint64::new(1000),
-            );
+            let result =
+                compute_stable_swap(Uint128::new(1000), max_pool, max_pool, Uint64::new(1000));
             let swap = result.expect("Uint128::MAX/10 pools should succeed");
-            assert!(swap.return_amount <= Uint128::new(1000), "Return should not exceed offer");
-            assert!(swap.return_amount > Uint128::zero(), "Should return non-zero for balanced pools");
+            assert!(
+                swap.return_amount <= Uint128::new(1000),
+                "Return should not exceed offer"
+            );
+            assert!(
+                swap.return_amount > Uint128::zero(),
+                "Should return non-zero for balanced pools"
+            );
             assert_eq!(
                 swap.return_amount.u128() + swap.spread_amount.u128(),
                 1000,
@@ -657,12 +658,7 @@ mod tests {
         #[test]
         fn test_uint128_max_offer_no_panic() {
             let pool = Uint128::new(1_000_000_000_000_000_000); // 1e18
-            let result = compute_stable_swap(
-                Uint128::MAX,
-                pool,
-                pool,
-                Uint64::new(1000),
-            );
+            let result = compute_stable_swap(Uint128::MAX, pool, pool, Uint64::new(1000));
             // Must not panic
             match result {
                 Ok(_) | Err(_) => {} // Either is fine, no panic
@@ -692,10 +688,11 @@ mod tests {
                 1_000_000_000_000_000_000_000_000u128, // 1e24
                 1u128,
             );
-            let new_amount = pool + Decimal256::from_ratio(
-                100_000_000_000_000_000_000_000u128, // 1e23
-                1u128,
-            );
+            let new_amount = pool
+                + Decimal256::from_ratio(
+                    100_000_000_000_000_000_000_000u128, // 1e23
+                    1u128,
+                );
             let xp = [pool, pool];
 
             let result = calc_y(Uint64::new(1000), new_amount, &xp, 1);
@@ -735,8 +732,7 @@ mod tests {
             let pool = Uint128::new(10000);
             let offer = Uint128::new(100);
 
-            let result_low_amp =
-                compute_stable_swap(offer, pool, pool, Uint64::new(100)).unwrap();
+            let result_low_amp = compute_stable_swap(offer, pool, pool, Uint64::new(100)).unwrap();
             let result_high_amp =
                 compute_stable_swap(offer, pool, pool, Uint64::new(10000)).unwrap();
 
@@ -929,8 +925,7 @@ mod tests {
 
             // New pool state after swap
             let new_pool_a = pool_a + offer;
-            let new_pool_b =
-                pool_b - Decimal256::from_ratio(result.return_amount, 1u128);
+            let new_pool_b = pool_b - Decimal256::from_ratio(result.return_amount, 1u128);
 
             // Compute D after swap
             let d_after = compute_d(amp, &[new_pool_a, new_pool_b]).unwrap();
@@ -950,19 +945,34 @@ mod tests {
         fn test_uint128_min_boundaries() {
             // Zero offer
             assert!(compute_stable_swap(
-                Uint128::zero(), Uint128::new(1000), Uint128::new(1000), Uint64::new(1000)
-            ).is_err());
+                Uint128::zero(),
+                Uint128::new(1000),
+                Uint128::new(1000),
+                Uint64::new(1000)
+            )
+            .is_err());
             // Zero pool
             assert!(compute_stable_swap(
-                Uint128::new(100), Uint128::zero(), Uint128::new(1000), Uint64::new(1000)
-            ).is_err());
+                Uint128::new(100),
+                Uint128::zero(),
+                Uint128::new(1000),
+                Uint64::new(1000)
+            )
+            .is_err());
             // Zero ask pool
             assert!(compute_stable_swap(
-                Uint128::new(100), Uint128::new(1000), Uint128::zero(), Uint64::new(1000)
-            ).is_err());
+                Uint128::new(100),
+                Uint128::new(1000),
+                Uint128::zero(),
+                Uint64::new(1000)
+            )
+            .is_err());
             // Minimum valid: all 1
             let result = compute_stable_swap(
-                Uint128::new(1), Uint128::new(1), Uint128::new(1), Uint64::new(100)
+                Uint128::new(1),
+                Uint128::new(1),
+                Uint128::new(1),
+                Uint64::new(100),
             );
             // Should either succeed or return a clean error, never panic
             match result {

--- a/packages/pool/src/test.rs
+++ b/packages/pool/src/test.rs
@@ -547,13 +547,10 @@ mod tests {
         use super::*;
         use crate::stable_math::compute_d;
 
-        // CRITICAL-1: Overflow in d^3 computation for 24-decimal tokens
-        // With 24-decimal tokens, 1 token = 1e24 raw. Even 1 token per pool overflows.
-        // d ≈ 2e24, d_atomics = 2e42, d^3_atomics = 8e90 >> Uint256 max (1.158e77)
+        // CRITICAL-1 FIX VERIFICATION: 24-decimal pools now work with iterative d_product
+        // Previously panicked due to d.pow(3) overflow. Now uses D*D/pool_a * D/pool_b.
         #[test]
-        #[should_panic]
-        fn test_overflow_24_decimal_balanced_pools() {
-            // 1 token each at 24 decimals = 1e24 raw per pool
+        fn test_24_decimal_balanced_pools_now_works() {
             let one_token_24dec = Decimal256::from_ratio(
                 1_000_000_000_000_000_000_000_000u128, // 1e24
                 1u128,
@@ -562,69 +559,91 @@ mod tests {
                 100_000_000_000_000_000_000_000u128, // 0.1 token = 1e23
                 1u128,
             );
-            // This panics due to unchecked d.pow(3) overflow in compute_d
-            let _ = compute_stable_swap(&offer, &one_token_24dec, &one_token_24dec, Uint64::new(1000));
+            let result =
+                compute_stable_swap(&offer, &one_token_24dec, &one_token_24dec, Uint64::new(1000));
+            assert!(
+                result.is_ok(),
+                "24-decimal pools should now work after iterative d_product fix. Error: {:?}",
+                result.err()
+            );
+            let swap = result.unwrap();
+            // Return should be close to offer for balanced pools with high amp
+            assert!(
+                swap.return_amount > Uint128::zero(),
+                "Should return non-zero amount"
+            );
+            assert!(
+                swap.return_amount <= Uint128::new(100_000_000_000_000_000_000_000u128),
+                "Return should not exceed offer"
+            );
         }
 
-        // CRITICAL-1: Even 1e20 integer values overflow d^3
-        // d ≈ 2e20, d_atomics = 2e38, d^3_atomics = 8e78 > Uint256 max
+        // CRITICAL-1 FIX VERIFICATION: 1e20 pools now work
         #[test]
-        #[should_panic]
-        fn test_overflow_1e20_pools() {
+        fn test_1e20_pools_now_works() {
             let pool = Decimal256::from_ratio(100_000_000_000_000_000_000u128, 1u128); // 1e20
             let offer = Decimal256::from_ratio(1_000_000_000_000_000_000u128, 1u128); // 1e18
-            // Panics in compute_d line 93: d.pow(3)
-            let _ = compute_stable_swap(&offer, &pool, &pool, Uint64::new(1000));
+            let result = compute_stable_swap(&offer, &pool, &pool, Uint64::new(1000));
+            assert!(
+                result.is_ok(),
+                "1e20 pools should now work. Error: {:?}",
+                result.err()
+            );
         }
 
-        // CRITICAL-1: Even the intermediate d*d overflows for 24-decimal values
-        // d_atomics = 2e42, d*d raw = 4e84 >> Uint256 max
+        // CRITICAL-1 FIX VERIFICATION: compute_d works for 24-decimal pools
         #[test]
-        #[should_panic]
-        fn test_overflow_intermediate_d_squared() {
-            // compute_d with 24-decimal pools
+        fn test_compute_d_24_decimal_pools() {
             let pool_a = Decimal256::from_ratio(
                 1_000_000_000_000_000_000_000_000u128, // 1e24
                 1u128,
             );
             let pool_b = pool_a;
-            // This panics inside compute_d because d.pow(3) uses d*d as intermediate
-            let _ = compute_d(Uint64::new(1000), &[pool_a, pool_b]);
-        }
-
-        // CRITICAL-2: compute_d uses unchecked arithmetic that panics instead of returning error
-        // Line 93: d.pow(3) / (amount_a_times_coins * amount_b_times_coins) — all unchecked
-        #[test]
-        #[should_panic]
-        fn test_compute_d_unchecked_panics() {
-            // Values large enough to trigger overflow, proving panic vs error
-            let pool = Decimal256::from_ratio(
-                100_000_000_000_000_000_000u128, // 1e20
-                1u128,
+            let result = compute_d(Uint64::new(1000), &[pool_a, pool_b]);
+            assert!(
+                result.is_ok(),
+                "compute_d should work for 24-decimal pools. Error: {:?}",
+                result.err()
             );
-            // Should return Err, but panics instead due to unchecked ops
-            let _ = compute_d(Uint64::new(1000), &[pool, pool]);
+            let d = result.unwrap();
+            // D should be approximately 2e24 for balanced pools
+            assert!(d > Decimal256::zero(), "D should be positive");
         }
 
-        // CRITICAL-2: calc_y uses checked_pow(3) which returns Err (not panic)
-        // This proves the inconsistency: compute_d panics, calc_y returns error
+        // CRITICAL-2 FIX VERIFICATION: compute_d now returns error instead of panicking
+        // for values that overflow even the iterative approach
         #[test]
-        fn test_calc_y_checked_overflow_returns_error() {
+        fn test_compute_d_returns_error_not_panic_on_extreme_values() {
+            // Use an extremely large value that might still overflow the iterative path
+            // Uint128::MAX ≈ 3.4e38
+            let pool = Decimal256::from_ratio(Uint128::MAX, 1u128);
+            let result = compute_d(Uint64::new(1000), &[pool, pool]);
+            // Should return Err (checked arithmetic), not panic
+            assert!(
+                result.is_err(),
+                "Extreme values should return error, not panic"
+            );
+        }
+
+        // Verify calc_y succeeds for large pool values after fix
+        #[test]
+        fn test_calc_y_large_pools_succeeds() {
             use crate::stable_math::calc_y;
 
             let pool = Decimal256::from_ratio(
-                1_000_000_000_000_000u128, // 1e15 — small enough for compute_d to succeed
+                1_000_000_000_000_000_000_000_000u128, // 1e24
                 1u128,
             );
-            // For calc_y, new_amount after swap
-            let new_amount = pool + Decimal256::from_ratio(1000u128, 1u128);
+            let new_amount = pool + Decimal256::from_ratio(
+                100_000_000_000_000_000_000_000u128, // 1e23
+                1u128,
+            );
             let xp = [pool, pool];
 
-            // This should succeed at 1e15 because d^3 atomics ≈ 8e63 < Uint256 max
             let result = calc_y(Uint64::new(1000), new_amount, &xp, 1);
             assert!(
                 result.is_ok(),
-                "calc_y should succeed for pools at 1e15: {:?}",
+                "calc_y should succeed for 24-decimal pools after fix: {:?}",
                 result.err()
             );
         }
@@ -773,17 +792,9 @@ mod tests {
             );
         }
 
-        // Additional: The maximum safe pool size is ~1e18 as integer value.
-        // 1e19 already overflows due to intermediate multiplications in compute_d
-        // (pools[0] * N_COINS = 1e19 * 2, then d^3 / (2e19 * 2e19) requires d^3
-        // which at d ≈ 2e19 produces atomics ≈ 8e75, but the unchecked multiply
-        // (amount_a_times_coins * amount_b_times_coins) = 4e38 as Decimal256,
-        // with atomics = 4e56, and d.pow(3) atomics = 8e75 — the division
-        // d.pow(3) / product overflows during the pow step itself for 1e19).
-        // 1e19 pools overflow in the multiply step, returning an error (not panic)
-        // because the overflow occurs in a checked_mul path rather than unchecked pow
+        // After fix: 1e19 pools now work (previously returned overflow error)
         #[test]
-        fn test_1e19_pools_overflow_with_error() {
+        fn test_1e19_pools_now_works() {
             let pool = Decimal256::from_ratio(
                 10_000_000_000_000_000_000u128, // 1e19
                 1u128,
@@ -794,15 +805,15 @@ mod tests {
             );
             let result = compute_stable_swap(&offer, &pool, &pool, Uint64::new(1000));
             assert!(
-                result.is_err(),
-                "1e19 pools should fail with overflow. Got: {:?}",
-                result.unwrap()
+                result.is_ok(),
+                "1e19 pools should now work after fix. Error: {:?}",
+                result.err()
             );
         }
 
-        // The actual maximum safe pool size is ~1e18 (same as current test max)
+        // 1e18 pools still work (regression check)
         #[test]
-        fn test_maximum_safe_pool_size_is_1e18() {
+        fn test_1e18_pools_still_works() {
             let pool = Decimal256::from_ratio(
                 1_000_000_000_000_000_000u128, // 1e18
                 1u128,
@@ -817,20 +828,22 @@ mod tests {
             );
         }
 
-        // MEDIUM-2: Zero pool reserve causes panic (division by zero in d_product)
-        // compute_d line 93: d^3 / (amount_a_times_coins * amount_b_times_coins)
-        // If one pool is zero but the other isn't, sum_x != 0 so the early return
-        // is skipped, then the division by zero hits the unchecked / operator.
+        // MEDIUM-2: Zero pool reserve now returns error instead of panicking
+        // (fixed by CRITICAL-2: all arithmetic is now checked)
         #[test]
-        #[should_panic]
-        fn test_zero_pool_reserve_panics() {
+        fn test_zero_pool_reserve_returns_error() {
             let zero_pool = Decimal256::zero();
             let pool = Decimal256::from_ratio(1000u128, 1u128);
             let offer = Decimal256::from_ratio(100u128, 1u128);
 
             // One pool is zero, the other is not. sum_x != 0, so Newton's method runs.
-            // amount_b_times_coins = 0, causing division by zero in d_product.
-            let _ = compute_stable_swap(&offer, &pool, &zero_pool, Uint64::new(1000));
+            // amount_b_times_coins = 0, causing checked_div to return error.
+            let result = compute_stable_swap(&offer, &pool, &zero_pool, Uint64::new(1000));
+            assert!(
+                result.is_err(),
+                "Zero pool reserve should return error. Got: {:?}",
+                result.unwrap()
+            );
         }
 
         // LOW-1: Demonstrate actual truncation loss with imbalanced pools

--- a/packages/pool/src/test.rs
+++ b/packages/pool/src/test.rs
@@ -1,57 +1,41 @@
 #[cfg(test)]
 mod tests {
-    use crate::{calculate_amount_from_shares, calculate_lp_allocation};
-    use cosmwasm_std::Uint128;
+    use crate::{
+        calculate_amount_from_shares, calculate_cp_swap, calculate_lp_allocation, pre_swap,
+        stable_math::compute_stable_swap, SwapCalculationMethod,
+    };
+    use cosmwasm_std::testing::mock_dependencies;
+    use cosmwasm_std::{Addr, Decimal, Decimal256, Uint128, Uint64};
+    use rstest::rstest;
 
-    #[test]
-    fn test_calculate_lp_allocation() {
-        // Test initial liquidity provision (empty pool)
-        let token_1_amount = Uint128::new(1000);
-        let token_2_amount = Uint128::new(1000);
-        let total_liquidity_1 = Uint128::zero();
-        let total_liquidity_2 = Uint128::zero();
-        let total_lp_supply = Uint128::zero();
+    use cw_storage_plus::{Item, Map};
+    use euclid::{
+        chain::ChainUid,
+        cross_chain_user::CrossChainUser,
+        fee::{DenomFees, Fee, TotalFees},
+        msgs::vlp::base::State,
+        token::{Pair, Token},
+        utils::math::Decimal256Ext,
+    };
+    use std::collections::HashMap;
 
-        let lp_tokens = calculate_lp_allocation(
-            token_1_amount,
-            token_2_amount,
-            total_liquidity_1,
-            total_liquidity_2,
-            total_lp_supply,
-        )
-        .unwrap();
-
-        // For initial provision, LP tokens should be sqrt(token1 * token2) - MINIMUM_LIQUIDITY
-        assert_eq!(lp_tokens, Uint128::new(1000));
-
-        let amount_1 = calculate_amount_from_shares(
-            token_1_amount + total_liquidity_1,
-            lp_tokens,
-            total_lp_supply + lp_tokens,
-        )
-        .unwrap();
-        assert_eq!(
-            amount_1, token_1_amount,
-            "Token 1 amount from shares is not correct"
-        );
-
-        let amount_2 = calculate_amount_from_shares(
-            token_2_amount + total_liquidity_2,
-            lp_tokens,
-            total_lp_supply + lp_tokens,
-        )
-        .unwrap();
-        assert_eq!(
-            amount_2, token_2_amount,
-            "Token 2 amount from shares is not correct"
-        );
-
-        // Test subsequent liquidity provision
-        let token_1_amount = Uint128::new(100);
-        let token_2_amount = Uint128::new(100);
-        let total_liquidity_1 = Uint128::new(1000);
-        let total_liquidity_2 = Uint128::new(1000);
-        let total_lp_supply = Uint128::new(1000); // From previous provision
+    #[rstest]
+    #[case(1000u128, 1000u128, 0u128, 0u128, 0u128, 1000u128)]
+    #[case(100u128, 100u128, 1000u128, 1000u128, 1000u128, 100u128)]
+    #[case(200u128, 100u128, 2000u128, 1000u128, 1990u128, 199u128)]
+    fn test_calculate_lp_allocation(
+        #[case] token_1_amount: u128,
+        #[case] token_2_amount: u128,
+        #[case] total_liquidity_1: u128,
+        #[case] total_liquidity_2: u128,
+        #[case] total_lp_supply: u128,
+        #[case] expected_lp_tokens: u128,
+    ) {
+        let token_1_amount = Uint128::new(token_1_amount);
+        let token_2_amount = Uint128::new(token_2_amount);
+        let total_liquidity_1 = Uint128::new(total_liquidity_1);
+        let total_liquidity_2 = Uint128::new(total_liquidity_2);
+        let total_lp_supply = Uint128::new(total_lp_supply);
 
         let lp_tokens = calculate_lp_allocation(
             token_1_amount,
@@ -62,49 +46,7 @@ mod tests {
         )
         .unwrap();
 
-        // For subsequent provisions, LP tokens should be proportional to liquidity added
-        assert_eq!(lp_tokens, Uint128::new(100));
-
-        let amount_1 = calculate_amount_from_shares(
-            token_1_amount + total_liquidity_1,
-            lp_tokens,
-            total_lp_supply + lp_tokens,
-        )
-        .unwrap();
-
-        assert_eq!(
-            amount_1, token_1_amount,
-            "Token 1 amount from shares is not correct"
-        );
-        let amount_2 = calculate_amount_from_shares(
-            token_2_amount + total_liquidity_2,
-            lp_tokens,
-            total_lp_supply + lp_tokens,
-        )
-        .unwrap();
-        assert_eq!(
-            amount_2, token_2_amount,
-            "Token 2 amount from shares is not correct"
-        );
-
-        // Test uneven liquidity provision
-        let token_1_amount = Uint128::new(200);
-        let token_2_amount = Uint128::new(100);
-        let total_liquidity_1 = Uint128::new(2000);
-        let total_liquidity_2 = Uint128::new(1000);
-        let total_lp_supply = Uint128::new(1990);
-
-        let lp_tokens = calculate_lp_allocation(
-            token_1_amount,
-            token_2_amount,
-            total_liquidity_1,
-            total_liquidity_2,
-            total_lp_supply,
-        )
-        .unwrap();
-
-        // Should use the minimum ratio to prevent dilution
-        assert_eq!(lp_tokens, Uint128::new(199));
+        assert_eq!(lp_tokens, Uint128::new(expected_lp_tokens));
 
         let amount_1 = calculate_amount_from_shares(
             token_1_amount + total_liquidity_1,
@@ -129,14 +71,36 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_big_token_amount() {
-        // Test with large token amounts
-        let token_1_amount = Uint128::new(5_000_000_000_000_000_000_000_000);
-        let token_2_amount = Uint128::new(5_000_000_000_000_000_000_000_000);
-        let total_liquidity_1 = Uint128::new(0);
-        let total_liquidity_2 = Uint128::new(0);
-        let total_lp_supply = Uint128::new(0);
+    #[rstest]
+    #[case(
+        5_000_000_000_000_000_000_000_000u128,
+        5_000_000_000_000_000_000_000_000u128,
+        0u128,
+        0u128,
+        0u128,
+        5_000_000_000_000_000_000_000_000u128
+    )]
+    #[case(
+        5_000_000_000_000_000_000_000_000u128,
+        5_000_000_000_000_000_000_000_000u128,
+        5_000_000_000_000_000_000_000_000u128,
+        5_000_000_000_000_000_000_000_000u128,
+        5_000_000_000_000_000_000_000_000u128,
+        5_000_000_000_000_000_000_000_000u128
+    )]
+    fn test_big_token_amount(
+        #[case] token_1_amount: u128,
+        #[case] token_2_amount: u128,
+        #[case] total_liquidity_1: u128,
+        #[case] total_liquidity_2: u128,
+        #[case] total_lp_supply: u128,
+        #[case] expected_lp_tokens: u128,
+    ) {
+        let token_1_amount = Uint128::new(token_1_amount);
+        let token_2_amount = Uint128::new(token_2_amount);
+        let total_liquidity_1 = Uint128::new(total_liquidity_1);
+        let total_liquidity_2 = Uint128::new(total_liquidity_2);
+        let total_lp_supply = Uint128::new(total_lp_supply);
 
         let lp_tokens = calculate_lp_allocation(
             token_1_amount,
@@ -147,26 +111,431 @@ mod tests {
         )
         .unwrap();
 
-        // For initial provision with large amounts
-        assert_eq!(lp_tokens, Uint128::new(5_000_000_000_000_000_000_000_000));
+        assert_eq!(lp_tokens, Uint128::new(expected_lp_tokens));
+    }
 
-        // Test subsequent large liquidity provision
-        let token_1_amount = Uint128::new(5_000_000_000_000_000_000_000_000);
-        let token_2_amount = Uint128::new(5_000_000_000_000_000_000_000_000);
-        let total_liquidity_1 = Uint128::new(5_000_000_000_000_000_000_000_000);
-        let total_liquidity_2 = Uint128::new(5_000_000_000_000_000_000_000_000);
-        let total_lp_supply = Uint128::new(5_000_000_000_000_000_000_000_000);
+    #[rstest]
+    #[case(
+        "equal_pools",
+        Decimal256::from_ratio(100u128, 1u128),
+        Decimal256::from_ratio(1000u128, 1u128),
+        Decimal256::from_ratio(1000u128, 1u128),
+        Uint64::new(1000),
+        Uint128::new(99),
+        Uint128::new(1)
+    )]
+    #[case(
+        "imbalanced_pools",
+        Decimal256::from_ratio(100u128, 1u128),
+        Decimal256::from_ratio(2000u128, 1u128),
+        Decimal256::from_ratio(1000u128, 1u128),
+        Uint64::new(100),
+        Uint128::new(67),
+        Uint128::new(33)
+    )]
+    #[case(
+        "small_amount",
+        Decimal256::from_ratio(1u128, 1u128),
+        Decimal256::from_ratio(1000000u128, 1u128),
+        Decimal256::from_ratio(1000000u128, 1u128),
+        Uint64::new(1000),
+        Uint128::new(1),
+        Uint128::new(0)
+    )]
+    #[case(
+        "large_amount",
+        Decimal256::from_ratio(1000u128, 1u128),
+        Decimal256::from_ratio(2000u128, 1u128),
+        Decimal256::from_ratio(2000u128, 1u128),
+        Uint64::new(1000),
+        Uint128::new(946u128),
+        Uint128::new(54u128)
+    )]
+    #[case(
+        "extreme_imbalance",
+        Decimal256::from_ratio(100u128, 1u128),
+        Decimal256::from_ratio(10000u128, 1u128),
+        Decimal256::from_ratio(1000u128, 1u128),
+        Uint64::new(1000),
+        Uint128::new(47u128),
+        Uint128::new(53u128)
+    )]
+    #[case(
+        "large_values large spread",
+        Decimal256::from_ratio(1000000000000000000u128, 1u128),
+        Decimal256::from_ratio(1000000000000000000u128, 1u128),
+        Decimal256::from_ratio(1000000000000000000u128, 1u128),
+        Uint64::new(1000),
+        Uint128::new(820871215252207999),
+        Uint128::new(179128784747792001)
+    )]
+    #[case(
+        "large_values small spread",
+        Decimal256::from_ratio(1000u128, 1u128),
+        Decimal256::from_ratio(1000000000000000000u128, 1u128),
+        Decimal256::from_ratio(1000000000000000000u128, 1u128),
+        Uint64::new(1000),
+        Uint128::new(1000),
+        Uint128::new(0)
+    )]
+    fn test_compute_stable_swap(
+        #[case] case_name: &str,
+        #[case] offer_asset: Decimal256,
+        #[case] offer_pool: Decimal256,
+        #[case] ask_pool: Decimal256,
+        #[case] swap_amount: Uint64,
+        #[case] expected_return_amount: Uint128,
+        #[case] expected_spread_amount: Uint128,
+    ) {
+        let result =
+            compute_stable_swap(&offer_asset, &offer_pool, &ask_pool, swap_amount).unwrap();
 
-        let lp_tokens = calculate_lp_allocation(
-            token_1_amount,
-            token_2_amount,
-            total_liquidity_1,
-            total_liquidity_2,
-            total_lp_supply,
+        assert_eq!(
+            result.return_amount, expected_return_amount,
+            "case_name={case_name}"
+        );
+        assert_eq!(
+            result.spread_amount, expected_spread_amount,
+            "case_name={case_name}"
+        );
+    }
+
+    #[rstest]
+    #[case(true, 10000u128, 5000u128, 100u64, 50u64, 1000u128)]
+    #[case(false, 8000u128, 20000u128, 30u64, 20u64, 500u128)]
+    // Very small amount, very small spread
+    #[case(true, 1000u128, 1000u128, 10u64, 1u64, 1u128)]
+    // Very small amount, very large spread (high fee bps)
+    #[case(false, 1000u128, 1000u128, 9999u64, 0u64, 1u128)]
+    // Very large amount, very small spread
+    #[case(
+        true,
+        1000000000000000000u128,
+        1000000000000000000u128,
+        1u64,
+        1u64,
+        1000000000000000000u128
+    )]
+    // Very large amount, very large spread (high fee bps)
+    #[case(
+        false,
+        1000000000000000000u128,
+        1000000000000000000u128,
+        9999u64,
+        0u64,
+        1000000000000000000u128
+    )]
+
+    fn test_pre_swap_regular_calculates_fees_and_cp_swap(
+        #[case] asset_in_is_token_1: bool,
+        #[case] reserve_token_1: u128,
+        #[case] reserve_token_2: u128,
+        #[case] lp_fee_bps: u64,
+        #[case] euclid_fee_bps: u64,
+        #[case] amount_in: u128,
+    ) {
+        let mut deps = mock_dependencies();
+
+        let state_storage: Item<State> = Item::new("state");
+        let balances_storage: Map<Token, Uint128> = Map::new("balances");
+
+        let token_1 = Token::create("token1".to_string()).unwrap();
+        let token_2 = Token::create("token2".to_string()).unwrap();
+        let pair = Pair::new(token_1.clone(), token_2.clone()).unwrap();
+
+        let asset_in = if asset_in_is_token_1 {
+            token_1.clone()
+        } else {
+            token_2.clone()
+        };
+        let expected_asset_out = if asset_in_is_token_1 {
+            token_2.clone()
+        } else {
+            token_1.clone()
+        };
+
+        balances_storage
+            .save(
+                deps.as_mut().storage,
+                token_1.clone(),
+                &Uint128::new(reserve_token_1),
+            )
+            .unwrap();
+        balances_storage
+            .save(
+                deps.as_mut().storage,
+                token_2.clone(),
+                &Uint128::new(reserve_token_2),
+            )
+            .unwrap();
+
+        let fee = Fee::new(
+            lp_fee_bps,
+            euclid_fee_bps,
+            CrossChainUser::new(
+                ChainUid::create("1".to_string()).unwrap(),
+                "recipient".to_string(),
+            ),
+        );
+
+        let total_fees_collected = TotalFees {
+            lp_fees: DenomFees {
+                totals: HashMap::default(),
+            },
+            euclid_fees: DenomFees {
+                totals: HashMap::default(),
+            },
+        };
+
+        let state = State {
+            pair,
+            router: Addr::unchecked("router"),
+            virtual_balance_contract: Addr::unchecked("vbc"),
+            fee,
+            total_fees_collected,
+            last_updated: 0,
+            total_lp_tokens: Uint128::zero(),
+        };
+        state_storage.save(deps.as_mut().storage, &state).unwrap();
+
+        let amount_in = Uint128::new(amount_in);
+        let res = pre_swap(
+            &deps.as_ref(),
+            &state_storage,
+            &balances_storage,
+            &asset_in,
+            amount_in,
+            SwapCalculationMethod::Regular,
+            None,
         )
         .unwrap();
 
-        // For subsequent provisions with large amounts
-        assert_eq!(lp_tokens, Uint128::new(5_000_000_000_000_000_000_000_000));
+        let expected_lp_fee = amount_in
+            .checked_mul_floor(Decimal::bps(lp_fee_bps))
+            .unwrap();
+        let expected_euclid_fee = amount_in
+            .checked_mul_floor(Decimal::bps(euclid_fee_bps))
+            .unwrap();
+        let expected_swap_amount = amount_in
+            .checked_sub(expected_lp_fee.checked_add(expected_euclid_fee).unwrap())
+            .unwrap();
+
+        let (reserve_in, reserve_out) = if asset_in_is_token_1 {
+            (Uint128::new(reserve_token_1), Uint128::new(reserve_token_2))
+        } else {
+            (Uint128::new(reserve_token_2), Uint128::new(reserve_token_1))
+        };
+
+        let expected_swap =
+            calculate_cp_swap(expected_swap_amount, reserve_in, reserve_out).unwrap();
+
+        assert_eq!(
+            res.asset_out, expected_asset_out,
+            "Expected asset out is not correct"
+        );
+        assert_eq!(
+            res.lp_fee, expected_lp_fee,
+            "Expected lp fee is not correct"
+        );
+        assert_eq!(
+            res.euclid_fee, expected_euclid_fee,
+            "Expected euclid fee is not correct"
+        );
+        assert_eq!(
+            res.swap_amount, expected_swap_amount,
+            "Expected swap amount is not correct"
+        );
+        assert_eq!(
+            res.receive_amount, expected_swap.return_amount,
+            "Expected receive amount is not correct"
+        );
+        assert_eq!(
+            res.spread_amount, expected_swap.spread_amount,
+            "Expected spread amount is not correct"
+        );
+    }
+
+    #[rstest]
+    #[case(true, 10000u128, 5000u128, 100u64, 50u64, 1000u64, 1000u128)]
+    #[case(false, 8000u128, 20000u128, 30u64, 20u64, 1000u64, 500u128)]
+    // Very small amount, very small spread
+    #[case(true, 1000u128, 1000u128, 10u64, 1u64, 1000u64, 1u128)]
+    // Very small amount, very large spread (high fee bps)
+    #[case(false, 1000u128, 1000u128, 9999u64, 0u64, 1000u64, 1u128)]
+    // Very large amount, very small spread
+    #[case(
+        true,
+        1000000000000000000u128,
+        1000000000000000000u128,
+        1u64,
+        1u64,
+        1000u64,
+        1000000000000000000u128
+    )]
+    // Very large amount, very large spread (high fee bps)
+    #[case(
+        false,
+        1000000000000000000u128,
+        1000000000000000000u128,
+        9999u64,
+        0u64,
+        1000u64,
+        1000000000000000000u128
+    )]
+
+    fn test_pre_swap_stable_calculates_fees_and_stable_swap(
+        #[case] asset_in_is_token_1: bool,
+        #[case] reserve_token_1: u128,
+        #[case] reserve_token_2: u128,
+        #[case] lp_fee_bps: u64,
+        #[case] euclid_fee_bps: u64,
+        #[case] amp_factor: u64,
+        #[case] amount_in: u128,
+    ) {
+        let mut deps = mock_dependencies();
+
+        let state_storage: Item<State> = Item::new("state");
+        let balances_storage: Map<Token, Uint128> = Map::new("balances");
+
+        let token_1 = Token::create("token1".to_string()).unwrap();
+        let token_2 = Token::create("token2".to_string()).unwrap();
+        let pair = Pair::new(token_1.clone(), token_2.clone()).unwrap();
+
+        let asset_in = if asset_in_is_token_1 {
+            token_1.clone()
+        } else {
+            token_2.clone()
+        };
+        let expected_asset_out = if asset_in_is_token_1 {
+            token_2.clone()
+        } else {
+            token_1.clone()
+        };
+
+        balances_storage
+            .save(
+                deps.as_mut().storage,
+                token_1.clone(),
+                &Uint128::new(reserve_token_1),
+            )
+            .unwrap();
+        balances_storage
+            .save(
+                deps.as_mut().storage,
+                token_2.clone(),
+                &Uint128::new(reserve_token_2),
+            )
+            .unwrap();
+
+        let fee = Fee::new(
+            lp_fee_bps,
+            euclid_fee_bps,
+            CrossChainUser::new(
+                ChainUid::create("1".to_string()).unwrap(),
+                "recipient".to_string(),
+            ),
+        );
+
+        let total_fees_collected = TotalFees {
+            lp_fees: DenomFees {
+                totals: HashMap::default(),
+            },
+            euclid_fees: DenomFees {
+                totals: HashMap::default(),
+            },
+        };
+
+        let state = State {
+            pair,
+            router: Addr::unchecked("router"),
+            virtual_balance_contract: Addr::unchecked("vbc"),
+            fee,
+            total_fees_collected,
+            last_updated: 0,
+            total_lp_tokens: Uint128::zero(),
+        };
+        state_storage.save(deps.as_mut().storage, &state).unwrap();
+
+        let amount_in = Uint128::new(amount_in);
+        let res = pre_swap(
+            &deps.as_ref(),
+            &state_storage,
+            &balances_storage,
+            &asset_in,
+            amount_in,
+            SwapCalculationMethod::Stable(Uint64::from(amp_factor)),
+            None,
+        )
+        .unwrap();
+
+        let expected_lp_fee = amount_in
+            .checked_mul_floor(Decimal::bps(lp_fee_bps))
+            .unwrap();
+        let expected_euclid_fee = amount_in
+            .checked_mul_floor(Decimal::bps(euclid_fee_bps))
+            .unwrap();
+        let expected_swap_amount = amount_in
+            .checked_sub(expected_lp_fee.checked_add(expected_euclid_fee).unwrap())
+            .unwrap();
+
+        let (reserve_in, reserve_out) = if asset_in_is_token_1 {
+            (Uint128::new(reserve_token_1), Uint128::new(reserve_token_2))
+        } else {
+            (Uint128::new(reserve_token_2), Uint128::new(reserve_token_1))
+        };
+
+        let expected_swap = compute_stable_swap(
+            // `pre_swap` stable branch uses the original `amount_in` (pre-fee),
+            // while `swap_amount` returned in the response is fee-adjusted.
+            &Decimal256::from_integer(expected_swap_amount),
+            &Decimal256::from_integer(reserve_in),
+            &Decimal256::from_integer(reserve_out),
+            Uint64::from(amp_factor),
+        )
+        .unwrap();
+
+        assert_eq!(
+            res.asset_out, expected_asset_out,
+            "Expected asset out is not correct"
+        );
+        assert_eq!(
+            res.lp_fee,
+            expected_lp_fee,
+            "Expected lp fee is not correct. Percentage deviation: {}",
+            percentage_deviation(res.lp_fee, expected_lp_fee)
+        );
+        assert_eq!(
+            res.euclid_fee,
+            expected_euclid_fee,
+            "Expected euclid fee is not correct. Percentage deviation: {}",
+            percentage_deviation(res.euclid_fee, expected_euclid_fee)
+        );
+        assert_eq!(
+            res.swap_amount,
+            expected_swap_amount,
+            "Expected swap amount is not correct. Percentage deviation: {}",
+            percentage_deviation(res.swap_amount, expected_swap_amount)
+        );
+        assert_eq!(
+            res.receive_amount,
+            expected_swap.return_amount,
+            "Expected receive amount is not correct. Percentage deviation: {}",
+            percentage_deviation(res.receive_amount, expected_swap.return_amount)
+        );
+        assert_eq!(
+            res.spread_amount,
+            expected_swap.spread_amount,
+            "Expected spread amount is not correct. Percentage deviation: {}",
+            percentage_deviation(res.spread_amount, expected_swap.spread_amount)
+        );
+    }
+
+    fn percentage_deviation(actual: Uint128, expected: Uint128) -> Decimal256 {
+        let actual = Decimal256::from_integer(actual);
+        let expected = Decimal256::from_integer(expected);
+        let deviation = actual.abs_diff(expected) / expected;
+        deviation
+            .checked_mul(Decimal256::from_integer(100u64))
+            .unwrap()
     }
 }

--- a/packages/pool/src/test.rs
+++ b/packages/pool/src/test.rs
@@ -538,4 +538,380 @@ mod tests {
             .checked_mul(Decimal256::from_integer(100u64))
             .unwrap()
     }
+
+    // ========================================================================
+    // AUDIT TESTS: Proving vulnerabilities documented in AUDIT.md
+    // ========================================================================
+
+    mod audit_tests {
+        use super::*;
+        use crate::stable_math::compute_d;
+
+        // CRITICAL-1: Overflow in d^3 computation for 24-decimal tokens
+        // With 24-decimal tokens, 1 token = 1e24 raw. Even 1 token per pool overflows.
+        // d ≈ 2e24, d_atomics = 2e42, d^3_atomics = 8e90 >> Uint256 max (1.158e77)
+        #[test]
+        #[should_panic]
+        fn test_overflow_24_decimal_balanced_pools() {
+            // 1 token each at 24 decimals = 1e24 raw per pool
+            let one_token_24dec = Decimal256::from_ratio(
+                1_000_000_000_000_000_000_000_000u128, // 1e24
+                1u128,
+            );
+            let offer = Decimal256::from_ratio(
+                100_000_000_000_000_000_000_000u128, // 0.1 token = 1e23
+                1u128,
+            );
+            // This panics due to unchecked d.pow(3) overflow in compute_d
+            let _ = compute_stable_swap(&offer, &one_token_24dec, &one_token_24dec, Uint64::new(1000));
+        }
+
+        // CRITICAL-1: Even 1e20 integer values overflow d^3
+        // d ≈ 2e20, d_atomics = 2e38, d^3_atomics = 8e78 > Uint256 max
+        #[test]
+        #[should_panic]
+        fn test_overflow_1e20_pools() {
+            let pool = Decimal256::from_ratio(100_000_000_000_000_000_000u128, 1u128); // 1e20
+            let offer = Decimal256::from_ratio(1_000_000_000_000_000_000u128, 1u128); // 1e18
+            // Panics in compute_d line 93: d.pow(3)
+            let _ = compute_stable_swap(&offer, &pool, &pool, Uint64::new(1000));
+        }
+
+        // CRITICAL-1: Even the intermediate d*d overflows for 24-decimal values
+        // d_atomics = 2e42, d*d raw = 4e84 >> Uint256 max
+        #[test]
+        #[should_panic]
+        fn test_overflow_intermediate_d_squared() {
+            // compute_d with 24-decimal pools
+            let pool_a = Decimal256::from_ratio(
+                1_000_000_000_000_000_000_000_000u128, // 1e24
+                1u128,
+            );
+            let pool_b = pool_a;
+            // This panics inside compute_d because d.pow(3) uses d*d as intermediate
+            let _ = compute_d(Uint64::new(1000), &[pool_a, pool_b]);
+        }
+
+        // CRITICAL-2: compute_d uses unchecked arithmetic that panics instead of returning error
+        // Line 93: d.pow(3) / (amount_a_times_coins * amount_b_times_coins) — all unchecked
+        #[test]
+        #[should_panic]
+        fn test_compute_d_unchecked_panics() {
+            // Values large enough to trigger overflow, proving panic vs error
+            let pool = Decimal256::from_ratio(
+                100_000_000_000_000_000_000u128, // 1e20
+                1u128,
+            );
+            // Should return Err, but panics instead due to unchecked ops
+            let _ = compute_d(Uint64::new(1000), &[pool, pool]);
+        }
+
+        // CRITICAL-2: calc_y uses checked_pow(3) which returns Err (not panic)
+        // This proves the inconsistency: compute_d panics, calc_y returns error
+        #[test]
+        fn test_calc_y_checked_overflow_returns_error() {
+            use crate::stable_math::calc_y;
+
+            let pool = Decimal256::from_ratio(
+                1_000_000_000_000_000u128, // 1e15 — small enough for compute_d to succeed
+                1u128,
+            );
+            // For calc_y, new_amount after swap
+            let new_amount = pool + Decimal256::from_ratio(1000u128, 1u128);
+            let xp = [pool, pool];
+
+            // This should succeed at 1e15 because d^3 atomics ≈ 8e63 < Uint256 max
+            let result = calc_y(Uint64::new(1000), new_amount, &xp, 1);
+            assert!(
+                result.is_ok(),
+                "calc_y should succeed for pools at 1e15: {:?}",
+                result.err()
+            );
+        }
+
+        // CRITICAL-3: TOKEN_PRECISION=1 is arbitrary — demonstrate it works only because
+        // the to_uint128_with_precision(1) and /10 cancel out for integer inputs
+        #[test]
+        fn test_precision_with_24_decimal_inputs() {
+            // With 24-decimal tokens, we'd pass raw values like 1e24.
+            // But first, the overflow issue (CRITICAL-1) blocks this entirely.
+            // To isolate the precision concern, use smaller 6-decimal tokens.
+            // 1000 tokens at 6 decimals = 1_000_000_000 raw
+            let pool = Decimal256::from_ratio(1_000_000_000u128, 1u128);
+            let offer = Decimal256::from_ratio(1_000_000u128, 1u128); // 1 token
+
+            let result = compute_stable_swap(&offer, &pool, &pool, Uint64::new(1000)).unwrap();
+
+            // The return_amount is in the same raw units as input (integer scale)
+            // TOKEN_PRECISION=1 adds/removes one digit — this doesn't relate to
+            // the 6-decimal structure of the token at all.
+            // The result treats 1_000_000 as "one million integer units", not "1 token with 6 decimals"
+            assert!(
+                result.return_amount <= Uint128::new(1_000_000),
+                "Return should not exceed offer for stable swap. Got: {}",
+                result.return_amount
+            );
+            // Spread should be very small for equal balanced pools with high amp
+            assert!(
+                result.spread_amount < Uint128::new(10_000),
+                "Spread too high for balanced stable pool. Got: {}",
+                result.spread_amount
+            );
+        }
+
+        // HIGH-1: Verify amp factor consistency between compute_d and calc_y
+        #[test]
+        fn test_amp_factor_consistency() {
+            // Test that different amp factors produce monotonically decreasing spread
+            // (higher amp = more stable = less slippage)
+            let pool = Decimal256::from_ratio(10000u128, 1u128);
+            let offer = Decimal256::from_ratio(100u128, 1u128);
+
+            let result_low_amp =
+                compute_stable_swap(&offer, &pool, &pool, Uint64::new(100)).unwrap();
+            let result_high_amp =
+                compute_stable_swap(&offer, &pool, &pool, Uint64::new(10000)).unwrap();
+
+            // Higher amp should give higher return (less slippage)
+            assert!(
+                result_high_amp.return_amount >= result_low_amp.return_amount,
+                "Higher amp should give better rate. Low amp return: {}, High amp return: {}",
+                result_low_amp.return_amount,
+                result_high_amp.return_amount
+            );
+
+            // Higher amp should give lower spread
+            assert!(
+                result_high_amp.spread_amount <= result_low_amp.spread_amount,
+                "Higher amp should give lower spread. Low amp spread: {}, High amp spread: {}",
+                result_low_amp.spread_amount,
+                result_high_amp.spread_amount
+            );
+        }
+
+        // HIGH-2: saturating_sub silently masks bugs in spread calculation
+        // This test demonstrates that if a math bug caused return > offer,
+        // the spread would silently be 0 instead of an error
+        #[test]
+        fn test_spread_uses_saturating_sub() {
+            // For stable swap with balanced pools and small offer, return ≈ offer
+            // and spread ≈ 0. The saturating_sub makes this safe for valid cases.
+            let pool = Decimal256::from_ratio(1_000_000u128, 1u128);
+            let offer = Decimal256::from_ratio(1u128, 1u128);
+
+            let result = compute_stable_swap(&offer, &pool, &pool, Uint64::new(10000)).unwrap();
+
+            // For a 1-unit swap in a 1M pool with high amp, return should equal offer
+            // spread is 0 via saturating_sub — correct here, but the same mechanism
+            // would hide a bug where return_amount > offer_amount
+            assert_eq!(
+                result.spread_amount,
+                Uint128::zero(),
+                "Spread is zero via saturating_sub"
+            );
+        }
+
+        // MEDIUM-2: Zero amp factor causes panic (not a clean error)
+        // This proves the lack of input validation: amp=0 causes leverage=0,
+        // then (leverage - 1) underflows Decimal256 (unsigned), causing a panic
+        // instead of a descriptive error.
+        #[test]
+        #[should_panic]
+        fn test_zero_amp_factor_panics() {
+            let pool = Decimal256::from_ratio(1000u128, 1u128);
+            let offer = Decimal256::from_ratio(100u128, 1u128);
+
+            // This panics due to unsigned subtraction underflow in calculate_step
+            // (leverage - Decimal256::one()) where leverage = 0
+            let _ = compute_stable_swap(&offer, &pool, &pool, Uint64::new(0));
+        }
+
+        // MEDIUM-2: Extremely large amp factor
+        #[test]
+        fn test_extreme_amp_factor() {
+            let pool = Decimal256::from_ratio(1000u128, 1u128);
+            let offer = Decimal256::from_ratio(100u128, 1u128);
+
+            // Very large amp — at the extreme, stable swap approaches constant-sum
+            let result = compute_stable_swap(&offer, &pool, &pool, Uint64::new(u64::MAX));
+
+            // Should either succeed (with return ≈ offer) or return a clean error
+            match result {
+                Ok(swap) => {
+                    // With extreme amp, return should be very close to offer
+                    assert!(
+                        swap.return_amount <= Uint128::new(100),
+                        "Return should not exceed offer"
+                    );
+                }
+                Err(_) => {
+                    // An error is acceptable — overflow in leverage is expected
+                }
+            }
+        }
+
+        // LOW-1: Integer truncation creates systematic loss for users
+        #[test]
+        fn test_truncation_loss_small_swaps() {
+            // Swap 1 unit at a time in a balanced pool. Each swap loses up to 0.9
+            // units due to floor division by 10 (TOKEN_PRECISION).
+            let pool = Decimal256::from_ratio(1_000_000u128, 1u128);
+            let one_unit = Decimal256::from_ratio(1u128, 1u128);
+
+            let result = compute_stable_swap(&one_unit, &pool, &pool, Uint64::new(10000)).unwrap();
+
+            // With TOKEN_PRECISION=1: the subtraction happens at 10x scale,
+            // then divides by 10. For a 1-unit swap in a huge pool:
+            // ask_pool_at_precision_1 - new_ask_pool_at_precision_1 ≈ 10
+            // return_amount = 10 / 10 = 1 (no loss in this case)
+            // But with offer=3 in certain pool ratios, the result could be
+            // (31 - 1) / 10 = 3 instead of 3.1 -> truncation loss
+            assert_eq!(
+                result.return_amount,
+                Uint128::new(1),
+                "1-unit swap should return 1 in balanced pool"
+            );
+        }
+
+        // Additional: The maximum safe pool size is ~1e18 as integer value.
+        // 1e19 already overflows due to intermediate multiplications in compute_d
+        // (pools[0] * N_COINS = 1e19 * 2, then d^3 / (2e19 * 2e19) requires d^3
+        // which at d ≈ 2e19 produces atomics ≈ 8e75, but the unchecked multiply
+        // (amount_a_times_coins * amount_b_times_coins) = 4e38 as Decimal256,
+        // with atomics = 4e56, and d.pow(3) atomics = 8e75 — the division
+        // d.pow(3) / product overflows during the pow step itself for 1e19).
+        // 1e19 pools overflow in the multiply step, returning an error (not panic)
+        // because the overflow occurs in a checked_mul path rather than unchecked pow
+        #[test]
+        fn test_1e19_pools_overflow_with_error() {
+            let pool = Decimal256::from_ratio(
+                10_000_000_000_000_000_000u128, // 1e19
+                1u128,
+            );
+            let offer = Decimal256::from_ratio(
+                1_000_000_000_000_000_000u128, // 1e18
+                1u128,
+            );
+            let result = compute_stable_swap(&offer, &pool, &pool, Uint64::new(1000));
+            assert!(
+                result.is_err(),
+                "1e19 pools should fail with overflow. Got: {:?}",
+                result.unwrap()
+            );
+        }
+
+        // The actual maximum safe pool size is ~1e18 (same as current test max)
+        #[test]
+        fn test_maximum_safe_pool_size_is_1e18() {
+            let pool = Decimal256::from_ratio(
+                1_000_000_000_000_000_000u128, // 1e18
+                1u128,
+            );
+            let offer = Decimal256::from_ratio(1000u128, 1u128);
+
+            let result = compute_stable_swap(&offer, &pool, &pool, Uint64::new(1000));
+            assert!(
+                result.is_ok(),
+                "1e18 pools should work. Error: {:?}",
+                result.err()
+            );
+        }
+
+        // MEDIUM-2: Zero pool reserve causes panic (division by zero in d_product)
+        // compute_d line 93: d^3 / (amount_a_times_coins * amount_b_times_coins)
+        // If one pool is zero but the other isn't, sum_x != 0 so the early return
+        // is skipped, then the division by zero hits the unchecked / operator.
+        #[test]
+        #[should_panic]
+        fn test_zero_pool_reserve_panics() {
+            let zero_pool = Decimal256::zero();
+            let pool = Decimal256::from_ratio(1000u128, 1u128);
+            let offer = Decimal256::from_ratio(100u128, 1u128);
+
+            // One pool is zero, the other is not. sum_x != 0, so Newton's method runs.
+            // amount_b_times_coins = 0, causing division by zero in d_product.
+            let _ = compute_stable_swap(&offer, &pool, &zero_pool, Uint64::new(1000));
+        }
+
+        // LOW-1: Demonstrate actual truncation loss with imbalanced pools
+        // The floor division by 10 (TOKEN_PRECISION=1) loses fractional units
+        #[test]
+        fn test_truncation_loss_imbalanced_pools() {
+            // With imbalanced pools, the scaled difference may not be divisible by 10,
+            // causing truncation loss.
+            let offer_pool = Decimal256::from_ratio(2000u128, 1u128);
+            let ask_pool = Decimal256::from_ratio(1000u128, 1u128);
+            let offer = Decimal256::from_ratio(100u128, 1u128);
+
+            let result =
+                compute_stable_swap(&offer, &offer_pool, &ask_pool, Uint64::new(100)).unwrap();
+
+            // Compute what the "true" return would be without truncation:
+            // The spread + return should equal the offer amount.
+            // But due to truncation: return_amount + spread_amount may not equal offer_amount.
+            let reconstructed = result
+                .return_amount
+                .checked_add(result.spread_amount)
+                .unwrap();
+            let offer_uint = Uint128::new(100);
+
+            // If there's no truncation loss, return + spread == offer.
+            // With truncation, return is rounded down, so spread is inflated,
+            // meaning return + spread could differ from offer.
+            // The key insight: spread = offer - return (via saturating_sub),
+            // so return + spread always == offer by construction.
+            // The REAL loss is that return_amount is lower than the true mathematical value.
+            // We can detect this by checking: for a balanced stable pool with high amp,
+            // the return should be very close to the offer. Any shortfall beyond the
+            // mathematical spread is truncation loss.
+            assert_eq!(
+                reconstructed, offer_uint,
+                "return + spread should always equal offer by construction"
+            );
+
+            // The actual truncation shows up as reduced return_amount.
+            // With amp=100 and 2:1 pool ratio, 100 offer should return ~67
+            assert!(
+                result.return_amount > Uint128::zero(),
+                "Should get a non-zero return"
+            );
+        }
+
+        // Verify the StableSwap invariant holds before and after a swap:
+        // A * n^n * S + D = A * n^n * D + D^(n+1) / (n^n * prod(x_i))
+        #[test]
+        fn test_stableswap_invariant_preserved() {
+            let pool_a = Decimal256::from_ratio(10000u128, 1u128);
+            let pool_b = Decimal256::from_ratio(10000u128, 1u128);
+            let offer = Decimal256::from_ratio(500u128, 1u128);
+            let amp = Uint64::new(1000);
+
+            // Compute D before swap
+            let d_before = compute_d(amp, &[pool_a, pool_b]).unwrap();
+
+            // Perform swap
+            let result = compute_stable_swap(&offer, &pool_a, &pool_b, amp).unwrap();
+
+            // New pool state after swap
+            let new_pool_a = pool_a + offer;
+            let new_pool_b =
+                pool_b - Decimal256::from_ratio(result.return_amount, 1u128);
+
+            // Compute D after swap
+            let d_after = compute_d(amp, &[new_pool_a, new_pool_b]).unwrap();
+
+            // D should be approximately preserved (within tolerance)
+            // Note: due to integer truncation in return_amount, the actual output is
+            // slightly less than the mathematical output, which means more value stays
+            // in the pool, so D_after >= D_before (approximately).
+            let diff = d_after.abs_diff(d_before);
+            let relative_diff = diff / d_before;
+
+            assert!(
+                relative_diff < Decimal256::from_ratio(1u128, 1000u128), // < 0.1% deviation
+                "Invariant D should be approximately preserved. D_before: {}, D_after: {}, relative_diff: {}",
+                d_before, d_after, relative_diff
+            );
+        }
+    }
 }

--- a/packages/pool/src/test.rs
+++ b/packages/pool/src/test.rs
@@ -708,41 +708,38 @@ mod tests {
             );
         }
 
-        // HIGH-2: saturating_sub silently masks bugs in spread calculation
-        // This test demonstrates that if a math bug caused return > offer,
-        // the spread would silently be 0 instead of an error
+        // HIGH-2 FIX VERIFICATION: spread now uses checked_sub instead of saturating_sub.
+        // For valid swaps, spread should be non-negative. If return > offer due to a bug,
+        // checked_sub would return an error instead of silently returning 0.
         #[test]
-        fn test_spread_uses_saturating_sub() {
+        fn test_spread_uses_checked_sub() {
             // For stable swap with balanced pools and small offer, return ≈ offer
-            // and spread ≈ 0. The saturating_sub makes this safe for valid cases.
+            // and spread ≈ 0. checked_sub handles this correctly.
             let pool = Decimal256::from_ratio(1_000_000u128, 1u128);
             let offer = Decimal256::from_ratio(1u128, 1u128);
 
             let result = compute_stable_swap(&offer, &pool, &pool, Uint64::new(10000)).unwrap();
 
-            // For a 1-unit swap in a 1M pool with high amp, return should equal offer
-            // spread is 0 via saturating_sub — correct here, but the same mechanism
-            // would hide a bug where return_amount > offer_amount
             assert_eq!(
                 result.spread_amount,
                 Uint128::zero(),
-                "Spread is zero via saturating_sub"
+                "Spread should be zero for tiny swap in large balanced pool"
             );
         }
 
-        // MEDIUM-2: Zero amp factor causes panic (not a clean error)
-        // This proves the lack of input validation: amp=0 causes leverage=0,
-        // then (leverage - 1) underflows Decimal256 (unsigned), causing a panic
-        // instead of a descriptive error.
+        // MEDIUM-2 FIX VERIFICATION: Zero amp factor now returns a clean error
+        // (input validation catches it before reaching calculate_step)
         #[test]
-        #[should_panic]
-        fn test_zero_amp_factor_panics() {
+        fn test_zero_amp_factor_returns_error() {
             let pool = Decimal256::from_ratio(1000u128, 1u128);
             let offer = Decimal256::from_ratio(100u128, 1u128);
 
-            // This panics due to unsigned subtraction underflow in calculate_step
-            // (leverage - Decimal256::one()) where leverage = 0
-            let _ = compute_stable_swap(&offer, &pool, &pool, Uint64::new(0));
+            let result = compute_stable_swap(&offer, &pool, &pool, Uint64::new(0));
+            assert!(
+                result.is_err(),
+                "Zero amp factor should return error. Got: {:?}",
+                result.unwrap()
+            );
         }
 
         // MEDIUM-2: Extremely large amp factor

--- a/packages/pool/src/test.rs
+++ b/packages/pool/src/test.rs
@@ -117,78 +117,78 @@ mod tests {
     #[rstest]
     #[case(
         "equal_pools",
-        Decimal256::from_ratio(100u128, 1u128),
-        Decimal256::from_ratio(1000u128, 1u128),
-        Decimal256::from_ratio(1000u128, 1u128),
+        Uint128::new(100),
+        Uint128::new(1000),
+        Uint128::new(1000),
         Uint64::new(1000),
         Uint128::new(99),
         Uint128::new(1)
     )]
     #[case(
         "imbalanced_pools",
-        Decimal256::from_ratio(100u128, 1u128),
-        Decimal256::from_ratio(2000u128, 1u128),
-        Decimal256::from_ratio(1000u128, 1u128),
+        Uint128::new(100),
+        Uint128::new(2000),
+        Uint128::new(1000),
         Uint64::new(100),
         Uint128::new(67),
         Uint128::new(33)
     )]
     #[case(
         "small_amount",
-        Decimal256::from_ratio(1u128, 1u128),
-        Decimal256::from_ratio(1000000u128, 1u128),
-        Decimal256::from_ratio(1000000u128, 1u128),
+        Uint128::new(1),
+        Uint128::new(1000000),
+        Uint128::new(1000000),
         Uint64::new(1000),
         Uint128::new(1),
         Uint128::new(0)
     )]
     #[case(
         "large_amount",
-        Decimal256::from_ratio(1000u128, 1u128),
-        Decimal256::from_ratio(2000u128, 1u128),
-        Decimal256::from_ratio(2000u128, 1u128),
+        Uint128::new(1000),
+        Uint128::new(2000),
+        Uint128::new(2000),
         Uint64::new(1000),
-        Uint128::new(946u128),
-        Uint128::new(54u128)
+        Uint128::new(946),
+        Uint128::new(54)
     )]
     #[case(
         "extreme_imbalance",
-        Decimal256::from_ratio(100u128, 1u128),
-        Decimal256::from_ratio(10000u128, 1u128),
-        Decimal256::from_ratio(1000u128, 1u128),
+        Uint128::new(100),
+        Uint128::new(10000),
+        Uint128::new(1000),
         Uint64::new(1000),
-        Uint128::new(47u128),
-        Uint128::new(53u128)
+        Uint128::new(47),
+        Uint128::new(53)
     )]
     #[case(
         "large_values large spread",
-        Decimal256::from_ratio(1000000000000000000u128, 1u128),
-        Decimal256::from_ratio(1000000000000000000u128, 1u128),
-        Decimal256::from_ratio(1000000000000000000u128, 1u128),
+        Uint128::new(1000000000000000000),
+        Uint128::new(1000000000000000000),
+        Uint128::new(1000000000000000000),
         Uint64::new(1000),
         Uint128::new(820871215252207999),
         Uint128::new(179128784747792001)
     )]
     #[case(
         "large_values small spread",
-        Decimal256::from_ratio(1000u128, 1u128),
-        Decimal256::from_ratio(1000000000000000000u128, 1u128),
-        Decimal256::from_ratio(1000000000000000000u128, 1u128),
+        Uint128::new(1000),
+        Uint128::new(1000000000000000000),
+        Uint128::new(1000000000000000000),
         Uint64::new(1000),
         Uint128::new(1000),
         Uint128::new(0)
     )]
     fn test_compute_stable_swap(
         #[case] case_name: &str,
-        #[case] offer_asset: Decimal256,
-        #[case] offer_pool: Decimal256,
-        #[case] ask_pool: Decimal256,
+        #[case] offer_asset: Uint128,
+        #[case] offer_pool: Uint128,
+        #[case] ask_pool: Uint128,
         #[case] swap_amount: Uint64,
         #[case] expected_return_amount: Uint128,
         #[case] expected_spread_amount: Uint128,
     ) {
         let result =
-            compute_stable_swap(&offer_asset, &offer_pool, &ask_pool, swap_amount).unwrap();
+            compute_stable_swap(offer_asset, offer_pool, ask_pool, swap_amount).unwrap();
 
         assert_eq!(
             result.return_amount, expected_return_amount,
@@ -485,11 +485,9 @@ mod tests {
         };
 
         let expected_swap = compute_stable_swap(
-            // `pre_swap` stable branch uses the original `amount_in` (pre-fee),
-            // while `swap_amount` returned in the response is fee-adjusted.
-            &Decimal256::from_integer(expected_swap_amount),
-            &Decimal256::from_integer(reserve_in),
-            &Decimal256::from_integer(reserve_out),
+            expected_swap_amount,
+            reserve_in,
+            reserve_out,
             Uint64::from(amp_factor),
         )
         .unwrap();
@@ -531,11 +529,11 @@ mod tests {
     }
 
     fn percentage_deviation(actual: Uint128, expected: Uint128) -> Decimal256 {
-        let actual = Decimal256::from_integer(actual);
-        let expected = Decimal256::from_integer(expected);
+        let actual = Decimal256::checked_from_integer(actual).unwrap();
+        let expected = Decimal256::checked_from_integer(expected).unwrap();
         let deviation = actual.abs_diff(expected) / expected;
         deviation
-            .checked_mul(Decimal256::from_integer(100u64))
+            .checked_mul(Decimal256::checked_from_integer(100u64).unwrap())
             .unwrap()
     }
 
@@ -547,33 +545,27 @@ mod tests {
         use super::*;
         use crate::stable_math::compute_d;
 
-        // CRITICAL-1 FIX VERIFICATION: 24-decimal pools now work with iterative d_product
-        // Previously panicked due to d.pow(3) overflow. Now uses D*D/pool_a * D/pool_b.
+        // CRITICAL-1 FIX VERIFICATION: 24-decimal pools now work with checked_multiply_ratio
+        // Previously panicked due to d.pow(3) overflow. Now uses Uint512 intermediate.
         #[test]
         fn test_24_decimal_balanced_pools_now_works() {
-            let one_token_24dec = Decimal256::from_ratio(
-                1_000_000_000_000_000_000_000_000u128, // 1e24
-                1u128,
-            );
-            let offer = Decimal256::from_ratio(
-                100_000_000_000_000_000_000_000u128, // 0.1 token = 1e23
-                1u128,
-            );
+            let one_token_24dec = Uint128::new(1_000_000_000_000_000_000_000_000); // 1e24
+            let offer = Uint128::new(100_000_000_000_000_000_000_000); // 1e23
+
             let result =
-                compute_stable_swap(&offer, &one_token_24dec, &one_token_24dec, Uint64::new(1000));
+                compute_stable_swap(offer, one_token_24dec, one_token_24dec, Uint64::new(1000));
             assert!(
                 result.is_ok(),
-                "24-decimal pools should now work after iterative d_product fix. Error: {:?}",
+                "24-decimal pools should now work after checked_multiply_ratio fix. Error: {:?}",
                 result.err()
             );
             let swap = result.unwrap();
-            // Return should be close to offer for balanced pools with high amp
             assert!(
                 swap.return_amount > Uint128::zero(),
                 "Should return non-zero amount"
             );
             assert!(
-                swap.return_amount <= Uint128::new(100_000_000_000_000_000_000_000u128),
+                swap.return_amount <= offer,
                 "Return should not exceed offer"
             );
         }
@@ -581,9 +573,9 @@ mod tests {
         // CRITICAL-1 FIX VERIFICATION: 1e20 pools now work
         #[test]
         fn test_1e20_pools_now_works() {
-            let pool = Decimal256::from_ratio(100_000_000_000_000_000_000u128, 1u128); // 1e20
-            let offer = Decimal256::from_ratio(1_000_000_000_000_000_000u128, 1u128); // 1e18
-            let result = compute_stable_swap(&offer, &pool, &pool, Uint64::new(1000));
+            let pool = Uint128::new(100_000_000_000_000_000_000); // 1e20
+            let offer = Uint128::new(1_000_000_000_000_000_000); // 1e18
+            let result = compute_stable_swap(offer, pool, pool, Uint64::new(1000));
             assert!(
                 result.is_ok(),
                 "1e20 pools should now work. Error: {:?}",
@@ -606,23 +598,89 @@ mod tests {
                 result.err()
             );
             let d = result.unwrap();
-            // D should be approximately 2e24 for balanced pools
             assert!(d > Decimal256::zero(), "D should be positive");
         }
 
-        // CRITICAL-2 FIX VERIFICATION: compute_d now returns error instead of panicking
-        // for values that overflow even the iterative approach
+        // CRITICAL-2 FIX VERIFICATION: compute_d handles Uint128::MAX without panic.
+        // With checked_multiply_ratio (Uint512 intermediate), this may succeed or
+        // return a clean error, but must never panic.
         #[test]
-        fn test_compute_d_returns_error_not_panic_on_extreme_values() {
-            // Use an extremely large value that might still overflow the iterative path
-            // Uint128::MAX ≈ 3.4e38
+        fn test_compute_d_handles_extreme_values_without_panic() {
             let pool = Decimal256::from_ratio(Uint128::MAX, 1u128);
             let result = compute_d(Uint64::new(1000), &[pool, pool]);
-            // Should return Err (checked arithmetic), not panic
+            // Either Ok or Err is acceptable; the key is no panic
+            match result {
+                Ok(d) => assert!(d > Decimal256::zero(), "D should be positive if Ok"),
+                Err(_) => {} // Clean error is fine
+            }
+        }
+
+        // CRITICAL-2 FIX VERIFICATION: Uint128::MAX pools return a clean error
+        // (not a panic). TOKEN_PRECISION=1 scales values by 10, so max supported
+        // pool value is Uint128::MAX / 10.
+        #[test]
+        fn test_uint128_max_pools_returns_error() {
+            let result = compute_stable_swap(
+                Uint128::new(1000),
+                Uint128::MAX,
+                Uint128::MAX,
+                Uint64::new(1000),
+            );
             assert!(
                 result.is_err(),
-                "Extreme values should return error, not panic"
+                "Uint128::MAX pools should return error (TOKEN_PRECISION overflow), not panic"
             );
+        }
+
+        // CRITICAL-2 FIX VERIFICATION: Uint128::MAX / 10 pools succeed.
+        // This is the maximum supported pool value given TOKEN_PRECISION=1.
+        #[test]
+        fn test_uint128_max_div_10_pools_succeeds() {
+            let max_pool = Uint128::MAX.checked_div(Uint128::new(10)).unwrap();
+            let result = compute_stable_swap(
+                Uint128::new(1000),
+                max_pool,
+                max_pool,
+                Uint64::new(1000),
+            );
+            let swap = result.expect("Uint128::MAX/10 pools should succeed");
+            assert!(swap.return_amount <= Uint128::new(1000), "Return should not exceed offer");
+            assert!(swap.return_amount > Uint128::zero(), "Should return non-zero for balanced pools");
+            assert_eq!(
+                swap.return_amount.u128() + swap.spread_amount.u128(),
+                1000,
+                "return + spread should equal offer"
+            );
+        }
+
+        // CRITICAL-2 FIX VERIFICATION: Uint128::MAX as offer must not panic
+        #[test]
+        fn test_uint128_max_offer_no_panic() {
+            let pool = Uint128::new(1_000_000_000_000_000_000); // 1e18
+            let result = compute_stable_swap(
+                Uint128::MAX,
+                pool,
+                pool,
+                Uint64::new(1000),
+            );
+            // Must not panic
+            match result {
+                Ok(_) | Err(_) => {} // Either is fine, no panic
+            }
+        }
+
+        // CRITICAL-2 FIX VERIFICATION: All Uint128::MAX inputs must not panic
+        #[test]
+        fn test_all_uint128_max_no_panic() {
+            let result = compute_stable_swap(
+                Uint128::MAX,
+                Uint128::MAX,
+                Uint128::MAX,
+                Uint64::new(u64::MAX),
+            );
+            match result {
+                Ok(_) | Err(_) => {} // Either is fine, no panic
+            }
         }
 
         // Verify calc_y succeeds for large pool values after fix
@@ -648,29 +706,20 @@ mod tests {
             );
         }
 
-        // CRITICAL-3: TOKEN_PRECISION=1 is arbitrary — demonstrate it works only because
-        // the to_uint128_with_precision(1) and /10 cancel out for integer inputs
+        // CRITICAL-3 FIX VERIFICATION: inputs are now explicit Uint128 integer types.
+        // TOKEN_PRECISION=1 correctly adds/removes one decimal digit for integer inputs.
         #[test]
-        fn test_precision_with_24_decimal_inputs() {
-            // With 24-decimal tokens, we'd pass raw values like 1e24.
-            // But first, the overflow issue (CRITICAL-1) blocks this entirely.
-            // To isolate the precision concern, use smaller 6-decimal tokens.
-            // 1000 tokens at 6 decimals = 1_000_000_000 raw
-            let pool = Decimal256::from_ratio(1_000_000_000u128, 1u128);
-            let offer = Decimal256::from_ratio(1_000_000u128, 1u128); // 1 token
+        fn test_precision_with_integer_inputs() {
+            let pool = Uint128::new(1_000_000_000);
+            let offer = Uint128::new(1_000_000); // 1 token at 6 decimals
 
-            let result = compute_stable_swap(&offer, &pool, &pool, Uint64::new(1000)).unwrap();
+            let result = compute_stable_swap(offer, pool, pool, Uint64::new(1000)).unwrap();
 
-            // The return_amount is in the same raw units as input (integer scale)
-            // TOKEN_PRECISION=1 adds/removes one digit — this doesn't relate to
-            // the 6-decimal structure of the token at all.
-            // The result treats 1_000_000 as "one million integer units", not "1 token with 6 decimals"
             assert!(
-                result.return_amount <= Uint128::new(1_000_000),
+                result.return_amount <= offer,
                 "Return should not exceed offer for stable swap. Got: {}",
                 result.return_amount
             );
-            // Spread should be very small for equal balanced pools with high amp
             assert!(
                 result.spread_amount < Uint128::new(10_000),
                 "Spread too high for balanced stable pool. Got: {}",
@@ -678,28 +727,25 @@ mod tests {
             );
         }
 
-        // HIGH-1: Verify amp factor consistency between compute_d and calc_y
+        // HIGH-1 FIX VERIFICATION: amp factor consistency between compute_d and calc_y
+        // Both now use Decimal256::from_ratio(amp, AMP_PRECISION).checked_mul(N_COINS)
         #[test]
         fn test_amp_factor_consistency() {
-            // Test that different amp factors produce monotonically decreasing spread
-            // (higher amp = more stable = less slippage)
-            let pool = Decimal256::from_ratio(10000u128, 1u128);
-            let offer = Decimal256::from_ratio(100u128, 1u128);
+            // Higher amp = more stable = less slippage
+            let pool = Uint128::new(10000);
+            let offer = Uint128::new(100);
 
             let result_low_amp =
-                compute_stable_swap(&offer, &pool, &pool, Uint64::new(100)).unwrap();
+                compute_stable_swap(offer, pool, pool, Uint64::new(100)).unwrap();
             let result_high_amp =
-                compute_stable_swap(&offer, &pool, &pool, Uint64::new(10000)).unwrap();
+                compute_stable_swap(offer, pool, pool, Uint64::new(10000)).unwrap();
 
-            // Higher amp should give higher return (less slippage)
             assert!(
                 result_high_amp.return_amount >= result_low_amp.return_amount,
                 "Higher amp should give better rate. Low amp return: {}, High amp return: {}",
                 result_low_amp.return_amount,
                 result_high_amp.return_amount
             );
-
-            // Higher amp should give lower spread
             assert!(
                 result_high_amp.spread_amount <= result_low_amp.spread_amount,
                 "Higher amp should give lower spread. Low amp spread: {}, High amp spread: {}",
@@ -708,17 +754,13 @@ mod tests {
             );
         }
 
-        // HIGH-2 FIX VERIFICATION: spread now uses checked_sub instead of saturating_sub.
-        // For valid swaps, spread should be non-negative. If return > offer due to a bug,
-        // checked_sub would return an error instead of silently returning 0.
+        // HIGH-2 FIX VERIFICATION: spread uses checked_sub (not saturating_sub)
         #[test]
         fn test_spread_uses_checked_sub() {
-            // For stable swap with balanced pools and small offer, return ≈ offer
-            // and spread ≈ 0. checked_sub handles this correctly.
-            let pool = Decimal256::from_ratio(1_000_000u128, 1u128);
-            let offer = Decimal256::from_ratio(1u128, 1u128);
+            let pool = Uint128::new(1_000_000);
+            let offer = Uint128::new(1);
 
-            let result = compute_stable_swap(&offer, &pool, &pool, Uint64::new(10000)).unwrap();
+            let result = compute_stable_swap(offer, pool, pool, Uint64::new(10000)).unwrap();
 
             assert_eq!(
                 result.spread_amount,
@@ -727,14 +769,15 @@ mod tests {
             );
         }
 
-        // MEDIUM-2 FIX VERIFICATION: Zero amp factor now returns a clean error
-        // (input validation catches it before reaching calculate_step)
+        // MEDIUM-2 FIX VERIFICATION: Zero amp factor returns clean error
         #[test]
         fn test_zero_amp_factor_returns_error() {
-            let pool = Decimal256::from_ratio(1000u128, 1u128);
-            let offer = Decimal256::from_ratio(100u128, 1u128);
-
-            let result = compute_stable_swap(&offer, &pool, &pool, Uint64::new(0));
+            let result = compute_stable_swap(
+                Uint128::new(100),
+                Uint128::new(1000),
+                Uint128::new(1000),
+                Uint64::new(0),
+            );
             assert!(
                 result.is_err(),
                 "Zero amp factor should return error. Got: {:?}",
@@ -742,46 +785,70 @@ mod tests {
             );
         }
 
-        // MEDIUM-2: Extremely large amp factor
+        // MEDIUM-2 FIX VERIFICATION: Extremely large amp factor
         #[test]
         fn test_extreme_amp_factor() {
-            let pool = Decimal256::from_ratio(1000u128, 1u128);
-            let offer = Decimal256::from_ratio(100u128, 1u128);
-
-            // Very large amp — at the extreme, stable swap approaches constant-sum
-            let result = compute_stable_swap(&offer, &pool, &pool, Uint64::new(u64::MAX));
-
-            // Should either succeed (with return ≈ offer) or return a clean error
+            let result = compute_stable_swap(
+                Uint128::new(100),
+                Uint128::new(1000),
+                Uint128::new(1000),
+                Uint64::new(u64::MAX),
+            );
+            // Should either succeed or return a clean error
             match result {
                 Ok(swap) => {
-                    // With extreme amp, return should be very close to offer
                     assert!(
                         swap.return_amount <= Uint128::new(100),
                         "Return should not exceed offer"
                     );
                 }
-                Err(_) => {
-                    // An error is acceptable — overflow in leverage is expected
-                }
+                Err(_) => {} // Overflow in leverage is acceptable
             }
+        }
+
+        // MEDIUM-2 FIX VERIFICATION: Zero pool reserve returns error
+        #[test]
+        fn test_zero_pool_reserve_returns_error() {
+            let result = compute_stable_swap(
+                Uint128::new(100),
+                Uint128::new(1000),
+                Uint128::zero(),
+                Uint64::new(1000),
+            );
+            assert!(
+                result.is_err(),
+                "Zero pool reserve should return error. Got: {:?}",
+                result.unwrap()
+            );
+        }
+
+        // MEDIUM-2 FIX VERIFICATION: Zero offer returns error
+        #[test]
+        fn test_zero_offer_returns_error() {
+            let result = compute_stable_swap(
+                Uint128::zero(),
+                Uint128::new(1000),
+                Uint128::new(1000),
+                Uint64::new(1000),
+            );
+            assert!(
+                result.is_err(),
+                "Zero offer should return error. Got: {:?}",
+                result.unwrap()
+            );
         }
 
         // LOW-1: Integer truncation creates systematic loss for users
         #[test]
         fn test_truncation_loss_small_swaps() {
-            // Swap 1 unit at a time in a balanced pool. Each swap loses up to 0.9
-            // units due to floor division by 10 (TOKEN_PRECISION).
-            let pool = Decimal256::from_ratio(1_000_000u128, 1u128);
-            let one_unit = Decimal256::from_ratio(1u128, 1u128);
+            let result = compute_stable_swap(
+                Uint128::new(1),
+                Uint128::new(1_000_000),
+                Uint128::new(1_000_000),
+                Uint64::new(10000),
+            )
+            .unwrap();
 
-            let result = compute_stable_swap(&one_unit, &pool, &pool, Uint64::new(10000)).unwrap();
-
-            // With TOKEN_PRECISION=1: the subtraction happens at 10x scale,
-            // then divides by 10. For a 1-unit swap in a huge pool:
-            // ask_pool_at_precision_1 - new_ask_pool_at_precision_1 ≈ 10
-            // return_amount = 10 / 10 = 1 (no loss in this case)
-            // But with offer=3 in certain pool ratios, the result could be
-            // (31 - 1) / 10 = 3 instead of 3.1 -> truncation loss
             assert_eq!(
                 result.return_amount,
                 Uint128::new(1),
@@ -789,18 +856,12 @@ mod tests {
             );
         }
 
-        // After fix: 1e19 pools now work (previously returned overflow error)
+        // After fix: 1e19 pools now work
         #[test]
         fn test_1e19_pools_now_works() {
-            let pool = Decimal256::from_ratio(
-                10_000_000_000_000_000_000u128, // 1e19
-                1u128,
-            );
-            let offer = Decimal256::from_ratio(
-                1_000_000_000_000_000_000u128, // 1e18
-                1u128,
-            );
-            let result = compute_stable_swap(&offer, &pool, &pool, Uint64::new(1000));
+            let pool = Uint128::new(10_000_000_000_000_000_000); // 1e19
+            let offer = Uint128::new(1_000_000_000_000_000_000); // 1e18
+            let result = compute_stable_swap(offer, pool, pool, Uint64::new(1000));
             assert!(
                 result.is_ok(),
                 "1e19 pools should now work after fix. Error: {:?}",
@@ -811,13 +872,9 @@ mod tests {
         // 1e18 pools still work (regression check)
         #[test]
         fn test_1e18_pools_still_works() {
-            let pool = Decimal256::from_ratio(
-                1_000_000_000_000_000_000u128, // 1e18
-                1u128,
-            );
-            let offer = Decimal256::from_ratio(1000u128, 1u128);
-
-            let result = compute_stable_swap(&offer, &pool, &pool, Uint64::new(1000));
+            let pool = Uint128::new(1_000_000_000_000_000_000); // 1e18
+            let offer = Uint128::new(1000);
+            let result = compute_stable_swap(offer, pool, pool, Uint64::new(1000));
             assert!(
                 result.is_ok(),
                 "1e18 pools should work. Error: {:?}",
@@ -825,82 +882,50 @@ mod tests {
             );
         }
 
-        // MEDIUM-2: Zero pool reserve now returns error instead of panicking
-        // (fixed by CRITICAL-2: all arithmetic is now checked)
-        #[test]
-        fn test_zero_pool_reserve_returns_error() {
-            let zero_pool = Decimal256::zero();
-            let pool = Decimal256::from_ratio(1000u128, 1u128);
-            let offer = Decimal256::from_ratio(100u128, 1u128);
-
-            // One pool is zero, the other is not. sum_x != 0, so Newton's method runs.
-            // amount_b_times_coins = 0, causing checked_div to return error.
-            let result = compute_stable_swap(&offer, &pool, &zero_pool, Uint64::new(1000));
-            assert!(
-                result.is_err(),
-                "Zero pool reserve should return error. Got: {:?}",
-                result.unwrap()
-            );
-        }
-
         // LOW-1: Demonstrate actual truncation loss with imbalanced pools
-        // The floor division by 10 (TOKEN_PRECISION=1) loses fractional units
         #[test]
         fn test_truncation_loss_imbalanced_pools() {
-            // With imbalanced pools, the scaled difference may not be divisible by 10,
-            // causing truncation loss.
-            let offer_pool = Decimal256::from_ratio(2000u128, 1u128);
-            let ask_pool = Decimal256::from_ratio(1000u128, 1u128);
-            let offer = Decimal256::from_ratio(100u128, 1u128);
+            let result = compute_stable_swap(
+                Uint128::new(100),
+                Uint128::new(2000),
+                Uint128::new(1000),
+                Uint64::new(100),
+            )
+            .unwrap();
 
-            let result =
-                compute_stable_swap(&offer, &offer_pool, &ask_pool, Uint64::new(100)).unwrap();
-
-            // Compute what the "true" return would be without truncation:
-            // The spread + return should equal the offer amount.
-            // But due to truncation: return_amount + spread_amount may not equal offer_amount.
             let reconstructed = result
                 .return_amount
                 .checked_add(result.spread_amount)
                 .unwrap();
-            let offer_uint = Uint128::new(100);
 
-            // If there's no truncation loss, return + spread == offer.
-            // With truncation, return is rounded down, so spread is inflated,
-            // meaning return + spread could differ from offer.
-            // The key insight: spread = offer - return (via saturating_sub),
-            // so return + spread always == offer by construction.
-            // The REAL loss is that return_amount is lower than the true mathematical value.
-            // We can detect this by checking: for a balanced stable pool with high amp,
-            // the return should be very close to the offer. Any shortfall beyond the
-            // mathematical spread is truncation loss.
             assert_eq!(
-                reconstructed, offer_uint,
+                reconstructed,
+                Uint128::new(100),
                 "return + spread should always equal offer by construction"
             );
-
-            // The actual truncation shows up as reduced return_amount.
-            // With amp=100 and 2:1 pool ratio, 100 offer should return ~67
             assert!(
                 result.return_amount > Uint128::zero(),
                 "Should get a non-zero return"
             );
         }
 
-        // Verify the StableSwap invariant holds before and after a swap:
-        // A * n^n * S + D = A * n^n * D + D^(n+1) / (n^n * prod(x_i))
+        // Verify the StableSwap invariant holds before and after a swap
         #[test]
         fn test_stableswap_invariant_preserved() {
-            let pool_a = Decimal256::from_ratio(10000u128, 1u128);
-            let pool_b = Decimal256::from_ratio(10000u128, 1u128);
-            let offer = Decimal256::from_ratio(500u128, 1u128);
+            let pool_a_uint = Uint128::new(10000);
+            let pool_b_uint = Uint128::new(10000);
+            let offer_uint = Uint128::new(500);
             let amp = Uint64::new(1000);
+
+            let pool_a = Decimal256::from_ratio(pool_a_uint, 1u128);
+            let pool_b = Decimal256::from_ratio(pool_b_uint, 1u128);
+            let offer = Decimal256::from_ratio(offer_uint, 1u128);
 
             // Compute D before swap
             let d_before = compute_d(amp, &[pool_a, pool_b]).unwrap();
 
             // Perform swap
-            let result = compute_stable_swap(&offer, &pool_a, &pool_b, amp).unwrap();
+            let result = compute_stable_swap(offer_uint, pool_a_uint, pool_b_uint, amp).unwrap();
 
             // New pool state after swap
             let new_pool_a = pool_a + offer;
@@ -910,10 +935,6 @@ mod tests {
             // Compute D after swap
             let d_after = compute_d(amp, &[new_pool_a, new_pool_b]).unwrap();
 
-            // D should be approximately preserved (within tolerance)
-            // Note: due to integer truncation in return_amount, the actual output is
-            // slightly less than the mathematical output, which means more value stays
-            // in the pool, so D_after >= D_before (approximately).
             let diff = d_after.abs_diff(d_before);
             let relative_diff = diff / d_before;
 
@@ -922,6 +943,31 @@ mod tests {
                 "Invariant D should be approximately preserved. D_before: {}, D_after: {}, relative_diff: {}",
                 d_before, d_after, relative_diff
             );
+        }
+
+        // Uint128::MIN (zero) boundary: all zero inputs should return clean errors
+        #[test]
+        fn test_uint128_min_boundaries() {
+            // Zero offer
+            assert!(compute_stable_swap(
+                Uint128::zero(), Uint128::new(1000), Uint128::new(1000), Uint64::new(1000)
+            ).is_err());
+            // Zero pool
+            assert!(compute_stable_swap(
+                Uint128::new(100), Uint128::zero(), Uint128::new(1000), Uint64::new(1000)
+            ).is_err());
+            // Zero ask pool
+            assert!(compute_stable_swap(
+                Uint128::new(100), Uint128::new(1000), Uint128::zero(), Uint64::new(1000)
+            ).is_err());
+            // Minimum valid: all 1
+            let result = compute_stable_swap(
+                Uint128::new(1), Uint128::new(1), Uint128::new(1), Uint64::new(100)
+            );
+            // Should either succeed or return a clean error, never panic
+            match result {
+                Ok(_) | Err(_) => {}
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- Fix `pre_swap` calculation for stable pools to use fee-adjusted `swap_amount` instead of total input
- Change `compute_stable_swap` API from `Decimal256` inputs to explicit `Uint128` inputs
- Replace `d.pow(3)` with iterative `checked_multiply_ratio` (Uint512 intermediate) in `compute_d` and `calc_y` to prevent overflow for large pools
- Restructure `calc_y` to compute `c/denom` directly in Newton loop, avoiding standalone `c` exceeding Decimal256 range
- Unify amp factor parameterization across `compute_d` and `calc_y`
- Replace `saturating_sub` with `checked_sub` + error in spread calculation
- Add input validation for amp factor, pool reserves, and offer amount
- Document maximum supported pool value as `Uint128::MAX / 10` (~3.4e37)
- Add 22 audit verification tests (46 total), security audit report (AUDIT.md), and math documentation (README.md)

## Type of Change

- [x] Bug fix
- [x] Documentation update
- [x] Refactor/Chore

## Related Issue

N/A

## Testing

```bash
cargo test -p euclid-pool    # 46 tests pass
cargo test -p stable-vlp     # compiles clean
```

## Checklist

- [x] Self-review completed
- [x] Tests added/updated
- [x] Documentation updated (AUDIT.md, README.md)