### PR TITLE
fix: CLP audit findings (H-01, H-02, M-01, M-02, M-03, M-09, L-02)

### DIFF
--- a/contracts/hub/concentrated_vlp/src/contract.rs
+++ b/contracts/hub/concentrated_vlp/src/contract.rs
@@ -303,11 +303,11 @@ pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractE
     }
 }
 
-fn uint256_to_uint128(value: Uint256) -> Result<Uint128, ContractError> {
+pub(crate) fn uint256_to_uint128(value: Uint256) -> Result<Uint128, ContractError> {
     Uint128::try_from(value).map_err(|_| ContractError::new("uint128 overflow"))
 }
 
-fn amounts_for_position_liquidity_with_bound(
+pub(crate) fn amounts_for_position_liquidity_with_bound(
     sqrt_price_x96: Uint256,
     sqrt_lower_x96: Uint256,
     sqrt_upper_x96: Uint256,

--- a/contracts/hub/concentrated_vlp/src/contract.rs
+++ b/contracts/hub/concentrated_vlp/src/contract.rs
@@ -61,7 +61,6 @@ use crate::{
 const CONTRACT_NAME: &str = "crates.io:concentrated_vlp";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 const MAX_SWAP_STEPS: u32 = 4096;
-const MAX_LIQUIDITY_ADJUSTMENT_STEPS: u32 = 1024;
 
 #[derive(Clone)]
 struct CrossedTickUpdate {
@@ -312,31 +311,46 @@ fn amounts_for_position_liquidity_with_bound(
     sqrt_price_x96: Uint256,
     sqrt_lower_x96: Uint256,
     sqrt_upper_x96: Uint256,
-    mut liquidity_delta: Uint128,
+    liquidity_delta: Uint128,
     max_amount_0: Uint128,
     max_amount_1: Uint128,
 ) -> Result<(Uint128, Uint128, Uint128), ContractError> {
-    for _ in 0..MAX_LIQUIDITY_ADJUSTMENT_STEPS {
-        let (amount_0_u256, amount_1_u256) = get_amounts_for_liquidity(
-            sqrt_price_x96,
-            sqrt_lower_x96,
-            sqrt_upper_x96,
-            liquidity_delta,
-            true,
-        )?;
-        let amount_0 = uint256_to_uint128(amount_0_u256)?;
-        let amount_1 = uint256_to_uint128(amount_1_u256)?;
-        if amount_0 <= max_amount_0 && amount_1 <= max_amount_1 {
-            return Ok((liquidity_delta, amount_0, amount_1));
+    let fits = |liq: Uint128| -> Result<Option<(Uint128, Uint128)>, ContractError> {
+        let (a0_u256, a1_u256) =
+            get_amounts_for_liquidity(sqrt_price_x96, sqrt_lower_x96, sqrt_upper_x96, liq, true)?;
+        let a0 = uint256_to_uint128(a0_u256)?;
+        let a1 = uint256_to_uint128(a1_u256)?;
+        if a0 <= max_amount_0 && a1 <= max_amount_1 {
+            Ok(Some((a0, a1)))
+        } else {
+            Ok(None)
         }
-        liquidity_delta = liquidity_delta
-            .checked_sub(Uint128::new(1))
-            .map_err(|_| ContractError::new("insufficient liquidity amount after rounding"))?;
+    };
+
+    if let Some((a0, a1)) = fits(liquidity_delta)? {
+        return Ok((liquidity_delta, a0, a1));
     }
 
-    Err(ContractError::new(
-        "failed to fit liquidity amounts within provided amounts",
-    ))
+    let mut lo = Uint128::zero();
+    let mut hi = liquidity_delta;
+    let mut best: Option<(Uint128, Uint128, Uint128)> = None;
+
+    for _ in 0..128u32 {
+        if lo >= hi {
+            break;
+        }
+        let mid = lo.checked_add(hi.checked_sub(lo)? / Uint128::new(2))?;
+        if let Some((a0, a1)) = fits(mid)? {
+            best = Some((mid, a0, a1));
+            lo = mid.checked_add(Uint128::new(1))?;
+        } else {
+            hi = mid;
+        }
+    }
+
+    best.ok_or_else(|| {
+        ContractError::new("failed to fit liquidity amounts within provided amounts")
+    })
 }
 
 fn assert_unused_within_slippage(

--- a/contracts/hub/concentrated_vlp/src/contract.rs
+++ b/contracts/hub/concentrated_vlp/src/contract.rs
@@ -531,6 +531,12 @@ fn execute_add_concentrated_liquidity(
     state.total_lp_tokens = state.total_lp_tokens.checked_add(liquidity_delta)?;
     STATE.save(deps.storage, &state)?;
 
+    // Update oracle so seconds_per_liquidity_cumulative stays accurate
+    // across periods with only liquidity changes and no swaps (I-06).
+    let slot0 = SLOT0.load(deps.storage)?;
+    let active_liq = ACTIVE_LIQUIDITY.load(deps.storage)?;
+    write_observation(deps.storage, env.block.time.seconds(), slot0.tick, active_liq)?;
+
     let mut reserve_0 = BALANCES.load(deps.storage, state.pair.token_1.clone())?;
     let mut reserve_1 = BALANCES.load(deps.storage, state.pair.token_2.clone())?;
     reserve_0 = reserve_0.checked_add(amount_0_used)?;
@@ -697,6 +703,11 @@ fn execute_remove_concentrated_liquidity(
         .total_lp_tokens
         .checked_sub(remove_liquidity_msg.liquidity_delta)?;
     STATE.save(deps.storage, &state)?;
+
+    // Update oracle so seconds_per_liquidity_cumulative stays accurate (I-06).
+    let slot0 = SLOT0.load(deps.storage)?;
+    let active_liq = ACTIVE_LIQUIDITY.load(deps.storage)?;
+    write_observation(deps.storage, env.block.time.seconds(), slot0.tick, active_liq)?;
 
     let total_0_out = amount_0_out.checked_add(fee_0_collected)?;
     let total_1_out = amount_1_out.checked_add(fee_1_collected)?;
@@ -942,11 +953,12 @@ fn run_swap_simulation(
     deps: Deps,
     asset_in: Token,
     amount_in: Uint128,
-    test_fail: Option<bool>,
+    _test_fail: Option<bool>,
     sqrt_price_limit_x96: Option<Uint256>,
 ) -> Result<SwapSimulation, ContractError> {
+    #[cfg(test)]
     ensure!(
-        !test_fail.unwrap_or(false),
+        !_test_fail.unwrap_or(false),
         ContractError::new("Force fail flag")
     );
     ensure!(!amount_in.is_zero(), ContractError::ZeroAssetAmount {});
@@ -1073,6 +1085,10 @@ fn run_swap_simulation(
         amount_remaining = amount_remaining.checked_sub(consumed)?;
         amount_out_total = amount_out_total.checked_add(step.amount_out)?;
 
+        // Protocol fee truncates down; the remainder accrues to LPs.
+        // A second truncation in fee_growth accumulation (fee * 2^128 / liquidity)
+        // means a small amount of dust per swap step is unclaimable by either party
+        // and remains locked in reserves. This matches Uniswap V3 behavior.
         let protocol_fee_step = step
             .fee_amount
             .checked_mul(Uint256::from(protocol_cut_bps as u128))?

--- a/contracts/hub/concentrated_vlp/src/contract.rs
+++ b/contracts/hub/concentrated_vlp/src/contract.rs
@@ -51,7 +51,7 @@ use crate::{
     reply,
     state::{
         initialize_position_nonce, next_position_id, ConcentratedPosition, MigrationMetadata,
-        Slot0, TickInfo, ACTIVE_LIQUIDITY, ADMIN, BALANCES, CHAIN_LP_TOKENS, COLLATERAL_LP_TOKENS,
+        Slot0, TickInfo, ACTIVE_LIQUIDITY, ADMIN, BALANCES, CHAIN_LP_TOKENS,
         FEE_GROWTH_GLOBAL_0_X128, FEE_GROWTH_GLOBAL_1_X128, MAX_TICK, MIGRATION_METADATA,
         MIGRATION_REVISION, MIN_TICK, POOL_KEY, POSITIONS, PROTOCOL_FEES_0, PROTOCOL_FEES_1, SLOT0,
         STATE, TICKS,
@@ -119,8 +119,6 @@ pub fn instantiate(
 
     BALANCES.save(deps.storage, state.pair.token_1.clone(), &Uint128::zero())?;
     BALANCES.save(deps.storage, state.pair.token_2.clone(), &Uint128::zero())?;
-    COLLATERAL_LP_TOKENS.save(deps.storage, &Uint128::zero())?;
-
     POOL_KEY.save(
         deps.storage,
         &euclid::msgs::vlp::base::PoolKey {
@@ -140,7 +138,6 @@ pub fn instantiate(
             observation_index: 0,
             observation_cardinality: 1,
             observation_cardinality_next: 1,
-            unlocked: true,
         },
     )?;
     ACTIVE_LIQUIDITY.save(deps.storage, &Uint128::zero())?;
@@ -385,6 +382,16 @@ fn execute_add_concentrated_liquidity(
     let tx_id = add_liquidity_msg.tx_id.clone();
     let lower_tick_index = add_liquidity_msg.lower_tick_index;
     let upper_tick_index = add_liquidity_msg.upper_tick_index;
+    if let Some(explicit_id) = add_liquidity_msg.position_id {
+        ensure!(
+            POSITIONS
+                .may_load(deps.storage, explicit_id.u128())?
+                .is_some(),
+            ContractError::new(
+                "explicit position_id does not exist; new positions must omit position_id"
+            )
+        );
+    }
     let position_id = add_liquidity_msg
         .position_id
         .unwrap_or(next_position_id(deps.storage)?);
@@ -396,7 +403,7 @@ fn execute_add_concentrated_liquidity(
     );
     let (provided_0, provided_1) = extract_token_amount(&add_liquidity_msg.liquidity, &state.pair);
     ensure!(
-        !provided_0.is_zero() && !provided_1.is_zero(),
+        !provided_0.is_zero() || !provided_1.is_zero(),
         ContractError::ZeroAssetAmount {}
     );
 
@@ -496,7 +503,14 @@ fn execute_add_concentrated_liquidity(
     position.liquidity = position.liquidity.checked_add(liquidity_delta)?;
     POSITIONS.save(deps.storage, position_id.u128(), &position)?;
 
-    let mut chain_lp_tokens = CHAIN_LP_TOKENS.load(deps.storage, sender.chain_uid.clone())?;
+    let mut chain_lp_tokens = CHAIN_LP_TOKENS
+        .may_load(deps.storage, sender.chain_uid.clone())?
+        .ok_or(ContractError::Generic {
+            err: format!(
+                "chain {:?} is not registered for this pool",
+                sender.chain_uid
+            ),
+        })?;
     chain_lp_tokens = chain_lp_tokens.checked_add(liquidity_delta)?;
     CHAIN_LP_TOKENS.save(deps.storage, sender.chain_uid.clone(), &chain_lp_tokens)?;
 
@@ -650,8 +664,14 @@ fn execute_remove_concentrated_liquidity(
         )?;
     }
 
-    let mut chain_lp_tokens =
-        CHAIN_LP_TOKENS.load(deps.storage, remove_liquidity_msg.sender.chain_uid.clone())?;
+    let mut chain_lp_tokens = CHAIN_LP_TOKENS
+        .may_load(deps.storage, remove_liquidity_msg.sender.chain_uid.clone())?
+        .ok_or(ContractError::Generic {
+            err: format!(
+                "chain {:?} is not registered for this pool",
+                remove_liquidity_msg.sender.chain_uid
+            ),
+        })?;
     chain_lp_tokens = chain_lp_tokens.checked_sub(remove_liquidity_msg.liquidity_delta)?;
     CHAIN_LP_TOKENS.save(
         deps.storage,
@@ -1535,7 +1555,6 @@ fn query_slot0(deps: Deps) -> Result<Slot0Response, ContractError> {
         observation_index: slot0.observation_index,
         observation_cardinality: slot0.observation_cardinality,
         observation_cardinality_next: slot0.observation_cardinality_next,
-        unlocked: slot0.unlocked,
         liquidity: ACTIVE_LIQUIDITY.load(deps.storage)?,
         fee_growth_global_0_x128: FEE_GROWTH_GLOBAL_0_X128.load(deps.storage)?,
         fee_growth_global_1_x128: FEE_GROWTH_GLOBAL_1_X128.load(deps.storage)?,
@@ -1729,7 +1748,6 @@ mod tests {
             observation_index: 0,
             observation_cardinality: 1,
             observation_cardinality_next: 1,
-            unlocked: true,
         };
         SLOT0
             .save(deps.as_mut().storage, &slot0)
@@ -2245,7 +2263,7 @@ mod tests {
             liquidity: wrong_pair,
             lower_tick_index: -600,
             upper_tick_index: 600,
-            position_id: Some(Uint128::new(1)),
+            position_id: None,
             slippage_tolerance_bps: 100,
         };
 

--- a/contracts/hub/concentrated_vlp/src/math/oracle.rs
+++ b/contracts/hub/concentrated_vlp/src/math/oracle.rs
@@ -484,7 +484,6 @@ mod tests {
                     observation_index: index,
                     observation_cardinality: cardinality,
                     observation_cardinality_next: cardinality,
-                    unlocked: true,
                 },
             )
             .expect("save slot0");
@@ -643,7 +642,6 @@ mod tests {
                     observation_index: 0,
                     observation_cardinality: 1,
                     observation_cardinality_next: cardinality,
-                    unlocked: true,
                 },
             )
             .expect("save slot0");

--- a/contracts/hub/concentrated_vlp/src/math/oracle.rs
+++ b/contracts/hub/concentrated_vlp/src/math/oracle.rs
@@ -108,12 +108,16 @@ pub fn write_observation(
     Ok(())
 }
 
-fn interpolate(left: &Observation, right: &Observation, target: u64) -> Observation {
+fn interpolate(
+    left: &Observation,
+    right: &Observation,
+    target: u64,
+) -> Result<Observation, ContractError> {
     if left.block_timestamp == right.block_timestamp || target <= left.block_timestamp {
-        return left.clone();
+        return Ok(left.clone());
     }
     if target >= right.block_timestamp {
-        return right.clone();
+        return Ok(right.clone());
     }
     let total = right.block_timestamp - left.block_timestamp;
     let elapsed = target - left.block_timestamp;
@@ -127,20 +131,21 @@ fn interpolate(left: &Observation, right: &Observation, target: u64) -> Observat
     let spl_delta = right
         .seconds_per_liquidity_cumulative_x128
         .wrapping_sub(left.seconds_per_liquidity_cumulative_x128);
+    let spl_product = spl_delta
+        .checked_mul(Uint256::from(elapsed as u128))
+        .map_err(|_| ContractError::new("oracle interpolation overflow in spl_delta * elapsed"))?;
     let spl_interp = left.seconds_per_liquidity_cumulative_x128.wrapping_add(
-        spl_delta
-            .checked_mul(Uint256::from(elapsed as u128))
-            .unwrap_or_default()
+        spl_product
             .checked_div(Uint256::from(total as u128))
-            .unwrap_or_default(),
+            .map_err(|_| ContractError::new("oracle interpolation division by zero"))?,
     );
 
-    Observation {
+    Ok(Observation {
         block_timestamp: target,
         tick_cumulative: tick_interp,
         seconds_per_liquidity_cumulative_x128: spl_interp,
         initialized: true,
-    }
+    })
 }
 
 pub fn observe(
@@ -208,7 +213,7 @@ pub fn observe(
                 let left = &window[0];
                 let right = &window[1];
                 if left.block_timestamp <= target && target <= right.block_timestamp {
-                    resolved = interpolate(left, right, target);
+                    resolved = interpolate(left, right, target)?;
                     break;
                 }
             }
@@ -456,7 +461,7 @@ mod tests {
         ];
 
         for case in cases {
-            let result = interpolate(&case.left, &case.right, case.target);
+            let result = interpolate(&case.left, &case.right, case.target).unwrap();
             assert_eq!(
                 result.tick_cumulative, case.expected_tick,
                 "FAILED tick: {}",

--- a/contracts/hub/concentrated_vlp/src/math/position_math.rs
+++ b/contracts/hub/concentrated_vlp/src/math/position_math.rs
@@ -107,6 +107,8 @@ pub fn accumulate_fee_growth(
         return Ok(fee_growth_global_x128);
     }
     // Step 1: fee_growth_delta = lp_fee * 2^128 / active_liquidity
+    // (L-10) Integer division truncates; the remainder (<1 unit per swap step)
+    // is unclaimable by either LPs or the protocol and stays locked in reserves.
     let fee_growth_delta = lp_fee
         .checked_mul(q128())?
         .checked_div(Uint256::from(active_liquidity.u128()))?;

--- a/contracts/hub/concentrated_vlp/src/migrate.rs
+++ b/contracts/hub/concentrated_vlp/src/migrate.rs
@@ -353,7 +353,7 @@ fn validate_position(
     Ok(())
 }
 
-fn fit_liquidity_with_bound(
+pub(crate) fn fit_liquidity_with_bound(
     sqrt_price_x96: Uint256,
     sqrt_lower_x96: Uint256,
     sqrt_upper_x96: Uint256,

--- a/contracts/hub/concentrated_vlp/src/migrate.rs
+++ b/contracts/hub/concentrated_vlp/src/migrate.rs
@@ -91,7 +91,6 @@ pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> Result<Response, Con
     slot0.observation_index = 0;
     slot0.observation_cardinality = 1;
     slot0.observation_cardinality_next = 1;
-    slot0.unlocked = true;
 
     let positions: Vec<(u128, ConcentratedPosition)> = POSITIONS
         .range(deps.storage, None, None, Order::Ascending)
@@ -315,7 +314,6 @@ fn resolve_slot0(
             observation_index: 0,
             observation_cardinality: 1,
             observation_cardinality_next: 1,
-            unlocked: true,
         })
     };
 

--- a/contracts/hub/concentrated_vlp/src/migrate.rs
+++ b/contracts/hub/concentrated_vlp/src/migrate.rs
@@ -25,7 +25,6 @@ use crate::{
 const CONTRACT_NAME: &str = "crates.io:concentrated_vlp";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 const TARGET_MIGRATION_REVISION: u16 = 2;
-const MAX_LIQUIDITY_ADJUSTMENT_STEPS: u32 = 1024;
 const SUPPORTED_SOURCE_VERSIONS: [&str; 2] = ["0.0.1", "0.1.0"];
 
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -358,35 +357,51 @@ fn fit_liquidity_with_bound(
     sqrt_price_x96: Uint256,
     sqrt_lower_x96: Uint256,
     sqrt_upper_x96: Uint256,
-    mut liquidity_delta: Uint128,
+    liquidity_delta: Uint128,
     max_amount_0: Uint128,
     max_amount_1: Uint128,
 ) -> Result<(Uint128, Uint128, Uint128), ContractError> {
     if liquidity_delta.is_zero() {
         return Ok((Uint128::zero(), Uint128::zero(), Uint128::zero()));
     }
-    for _ in 0..MAX_LIQUIDITY_ADJUSTMENT_STEPS {
-        let (amount_0_u256, amount_1_u256) = get_amounts_for_liquidity(
-            sqrt_price_x96,
-            sqrt_lower_x96,
-            sqrt_upper_x96,
-            liquidity_delta,
-            true,
-        )?;
-        let amount_0 =
-            Uint128::try_from(amount_0_u256).map_err(|_| ContractError::new("amount0 overflow"))?;
-        let amount_1 =
-            Uint128::try_from(amount_1_u256).map_err(|_| ContractError::new("amount1 overflow"))?;
-        if amount_0 <= max_amount_0 && amount_1 <= max_amount_1 {
-            return Ok((liquidity_delta, amount_0, amount_1));
+    let fits = |liq: Uint128| -> Result<Option<(Uint128, Uint128)>, ContractError> {
+        let (a0_u256, a1_u256) =
+            get_amounts_for_liquidity(sqrt_price_x96, sqrt_lower_x96, sqrt_upper_x96, liq, true)?;
+        let a0 =
+            Uint128::try_from(a0_u256).map_err(|_| ContractError::new("amount0 overflow"))?;
+        let a1 =
+            Uint128::try_from(a1_u256).map_err(|_| ContractError::new("amount1 overflow"))?;
+        if a0 <= max_amount_0 && a1 <= max_amount_1 {
+            Ok(Some((a0, a1)))
+        } else {
+            Ok(None)
         }
-        liquidity_delta = liquidity_delta
-            .checked_sub(Uint128::new(1))
-            .map_err(|_| ContractError::new("failed to fit liquidity to nominal amounts"))?;
+    };
+
+    if let Some((a0, a1)) = fits(liquidity_delta)? {
+        return Ok((liquidity_delta, a0, a1));
     }
-    Err(ContractError::new(
-        "failed to fit liquidity amounts within provided amounts",
-    ))
+
+    let mut lo = Uint128::zero();
+    let mut hi = liquidity_delta;
+    let mut best: Option<(Uint128, Uint128, Uint128)> = None;
+
+    for _ in 0..128u32 {
+        if lo >= hi {
+            break;
+        }
+        let mid = lo.checked_add(hi.checked_sub(lo)? / Uint128::new(2))?;
+        if let Some((a0, a1)) = fits(mid)? {
+            best = Some((mid, a0, a1));
+            lo = mid.checked_add(Uint128::new(1))?;
+        } else {
+            hi = mid;
+        }
+    }
+
+    best.ok_or_else(|| {
+        ContractError::new("failed to fit liquidity amounts within provided amounts")
+    })
 }
 
 fn add_signed_liquidity(value: Uint128, delta: i128) -> Result<Uint128, ContractError> {

--- a/contracts/hub/concentrated_vlp/src/reply.rs
+++ b/contracts/hub/concentrated_vlp/src/reply.rs
@@ -5,14 +5,12 @@ use function_name::named;
 
 #[named]
 pub fn on_next_swap_reply(_deps: DepsMut, msg: Reply) -> Result<Response, ContractError> {
-    match msg.result.clone() {
+    match msg.result {
         SubMsgResult::Err(err) => Err(ContractError::Reply {
             action: function_name!().to_string(),
             err,
         }),
-        SubMsgResult::Ok(..) => {
-            let msg_clone = msg.clone();
-            let result = msg_clone.result.unwrap();
+        SubMsgResult::Ok(result) => {
             #[allow(deprecated)]
             let data = result.data.unwrap_or_default();
 

--- a/contracts/hub/concentrated_vlp/src/state.rs
+++ b/contracts/hub/concentrated_vlp/src/state.rs
@@ -20,8 +20,6 @@ pub const CHAIN_LP_TOKENS: Map<ChainUid, Uint128> = Map::new("chain_lp_tokens");
 
 pub const BALANCES: Map<Token, Uint128> = Map::new("balances");
 
-pub const COLLATERAL_LP_TOKENS: Item<Uint128> = Item::new("collateral_lp_tokens");
-
 pub const POOL_KEY: Item<PoolKey> = Item::new("pool_key");
 
 pub const MIN_TICK: i64 = -887272;
@@ -34,7 +32,6 @@ pub struct Slot0 {
     pub observation_index: u64,
     pub observation_cardinality: u16,
     pub observation_cardinality_next: u16,
-    pub unlocked: bool,
 }
 
 pub const SLOT0: Item<Slot0> = Item::new("slot0");

--- a/contracts/hub/concentrated_vlp/src/state.rs
+++ b/contracts/hub/concentrated_vlp/src/state.rs
@@ -125,7 +125,10 @@ pub fn initialize_position_namespace_if_missing(
             computed
         }
     };
-    let mut max_nonce = POSITION_NONCE.may_load(storage)?.unwrap_or(0);
+    if POSITION_NONCE.may_load(storage)?.is_some() {
+        return Ok(());
+    }
+    let mut max_nonce: u64 = 0;
     for item in POSITIONS.range(storage, None, None, Order::Ascending) {
         let (id, _) = item?;
         if ((id >> 64) as u64) == prefix {
@@ -145,7 +148,7 @@ pub fn next_position_id(storage: &mut dyn cosmwasm_std::Storage) -> Result<Uint1
         .ok_or_else(|| ContractError::new("position id prefix not initialized"))?;
     let mut nonce = POSITION_NONCE.may_load(storage)?.unwrap_or(0);
 
-    loop {
+    for _ in 0..1024u32 {
         nonce = nonce
             .checked_add(1)
             .ok_or_else(|| ContractError::new("position id overflow"))?;
@@ -155,4 +158,7 @@ pub fn next_position_id(storage: &mut dyn cosmwasm_std::Storage) -> Result<Uint1
             return Ok(Uint128::new(id));
         }
     }
+    Err(ContractError::new(
+        "exhausted position id search after 1024 attempts",
+    ))
 }

--- a/contracts/hub/concentrated_vlp/src/tests.rs
+++ b/contracts/hub/concentrated_vlp/src/tests.rs
@@ -20,12 +20,14 @@ use euclid::{
 use mock::{mock::mock_app, mock_builder::MockEuclidBuilder};
 
 use crate::{
+    contract::amounts_for_position_liquidity_with_bound,
     math::{liquidity_amounts::get_amounts_for_liquidity, tick_math::get_sqrt_ratio_at_tick},
-    migrate::migrate,
+    migrate::{fit_liquidity_with_bound, migrate},
     mock::mock_concentrated_vlp,
     state::{
-        ConcentratedPosition, MigrationMetadata, TickInfo, ACTIVE_LIQUIDITY, BALANCES,
-        CHAIN_LP_TOKENS, FEE_GROWTH_GLOBAL_0_X128, FEE_GROWTH_GLOBAL_1_X128, MIGRATION_METADATA,
+        initialize_position_namespace_if_missing, next_position_id, ConcentratedPosition,
+        MigrationMetadata, TickInfo, ACTIVE_LIQUIDITY, BALANCES, CHAIN_LP_TOKENS,
+        FEE_GROWTH_GLOBAL_0_X128, FEE_GROWTH_GLOBAL_1_X128, MIGRATION_METADATA,
         MIGRATION_REVISION, OBSERVATIONS, POOL_KEY, POSITIONS, POSITION_ID_PREFIX, POSITION_NONCE,
         PROTOCOL_FEES_0, PROTOCOL_FEES_1, SLOT0, STATE, TICKS,
     },
@@ -734,4 +736,266 @@ fn migration_status_markers_are_written() {
         .may_load(deps.as_ref().storage, 0)
         .unwrap()
         .is_some());
+}
+
+// ---------------------------------------------------------------------------
+// next_position_id — table-driven
+// ---------------------------------------------------------------------------
+
+#[test]
+fn next_position_id_table() {
+    struct Case {
+        label: &'static str,
+        /// Position IDs to pre-populate (simulates existing positions).
+        existing: Vec<u128>,
+        /// Expected nonce component of the returned ID (lower 64 bits).
+        expected_nonce: u64,
+    }
+
+    let cases = vec![
+        Case {
+            label: "empty storage yields nonce 1",
+            existing: vec![],
+            expected_nonce: 1,
+        },
+        Case {
+            label: "skips occupied nonce 1, returns nonce 2",
+            existing: vec![1], // nonce 1 under same prefix
+            expected_nonce: 2,
+        },
+        Case {
+            label: "skips occupied nonces 1-3, returns nonce 4",
+            existing: vec![1, 2, 3],
+            expected_nonce: 4,
+        },
+    ];
+
+    for case in cases {
+        let mut deps = mock_dependencies();
+        let prefix: u64 = 42;
+        POSITION_ID_PREFIX
+            .save(deps.as_mut().storage, &prefix)
+            .unwrap();
+        POSITION_NONCE.save(deps.as_mut().storage, &0).unwrap();
+
+        let pool_key = sample_pool_key(sample_pair());
+        for nonce in &case.existing {
+            let id = (u128::from(prefix) << 64) | u128::from(*nonce);
+            let pos = make_position(
+                owner("andr", "alice"),
+                pool_key.clone(),
+                -10,
+                10,
+                Uint128::new(100),
+            );
+            POSITIONS.save(deps.as_mut().storage, id, &pos).unwrap();
+        }
+
+        let result = next_position_id(deps.as_mut().storage).unwrap();
+        let got_nonce = result.u128() as u64;
+        assert_eq!(
+            got_nonce, case.expected_nonce,
+            "FAIL [{}]: expected nonce {}, got {}",
+            case.label, case.expected_nonce, got_nonce,
+        );
+    }
+}
+
+#[test]
+fn next_position_id_exhaustion_returns_error() {
+    let mut deps = mock_dependencies();
+    let prefix: u64 = 1;
+    POSITION_ID_PREFIX
+        .save(deps.as_mut().storage, &prefix)
+        .unwrap();
+    POSITION_NONCE.save(deps.as_mut().storage, &0).unwrap();
+
+    let pool_key = sample_pool_key(sample_pair());
+    // Fill nonces 1..=1024 so the loop exhausts all attempts.
+    for nonce in 1..=1024u64 {
+        let id = (u128::from(prefix) << 64) | u128::from(nonce);
+        let pos = make_position(
+            owner("andr", "alice"),
+            pool_key.clone(),
+            -10,
+            10,
+            Uint128::new(1),
+        );
+        POSITIONS.save(deps.as_mut().storage, id, &pos).unwrap();
+    }
+
+    let err = next_position_id(deps.as_mut().storage).unwrap_err();
+    assert!(
+        err.to_string().contains("exhausted"),
+        "expected exhaustion error, got: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// initialize_position_namespace_if_missing — table-driven
+// ---------------------------------------------------------------------------
+
+#[test]
+fn initialize_position_namespace_table() {
+    struct Case {
+        label: &'static str,
+        /// If Some, pre-save POSITION_NONCE to this value.
+        pre_nonce: Option<u64>,
+        /// Position IDs to pre-populate.
+        existing_ids: Vec<u128>,
+        /// Expected POSITION_NONCE value after the call.
+        expected_nonce: u64,
+    }
+
+    let contract_addr = "wasm1concentrated";
+    let cases = vec![
+        Case {
+            label: "early return when nonce already set",
+            pre_nonce: Some(99),
+            existing_ids: vec![],
+            expected_nonce: 99,
+        },
+        Case {
+            label: "fresh state with no positions yields nonce 0",
+            pre_nonce: None,
+            existing_ids: vec![],
+            expected_nonce: 0,
+        },
+    ];
+
+    for case in cases {
+        let mut deps = mock_dependencies();
+        if let Some(nonce) = case.pre_nonce {
+            POSITION_NONCE
+                .save(deps.as_mut().storage, &nonce)
+                .unwrap();
+        }
+        let pool_key = sample_pool_key(sample_pair());
+        for id in &case.existing_ids {
+            let pos = make_position(
+                owner("andr", "alice"),
+                pool_key.clone(),
+                -10,
+                10,
+                Uint128::new(1),
+            );
+            POSITIONS.save(deps.as_mut().storage, *id, &pos).unwrap();
+        }
+
+        initialize_position_namespace_if_missing(deps.as_mut().storage, contract_addr).unwrap();
+
+        let nonce = POSITION_NONCE.load(deps.as_ref().storage).unwrap();
+        assert_eq!(
+            nonce, case.expected_nonce,
+            "FAIL [{}]: expected nonce {}, got {}",
+            case.label, case.expected_nonce, nonce,
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// amounts_for_position_liquidity_with_bound — table-driven
+// ---------------------------------------------------------------------------
+
+/// Helper: sqrt prices for the standard tick range [-10, 10] around tick 0.
+fn sqrt_prices_for_range() -> (Uint256, Uint256, Uint256) {
+    let sqrt_price = get_sqrt_ratio_at_tick(0).unwrap(); // price = 1.0
+    let sqrt_lower = get_sqrt_ratio_at_tick(-10).unwrap();
+    let sqrt_upper = get_sqrt_ratio_at_tick(10).unwrap();
+    (sqrt_price, sqrt_lower, sqrt_upper)
+}
+
+#[test]
+fn liquidity_bound_search_table() {
+    let (sqrt_price, sqrt_lower, sqrt_upper) = sqrt_prices_for_range();
+
+    struct Case {
+        label: &'static str,
+        liquidity: u128,
+        max_0: u128,
+        max_1: u128,
+        /// If true, the target liquidity should fit without binary search.
+        expect_exact_fit: bool,
+    }
+
+    let cases = vec![
+        Case {
+            label: "zero liquidity returns zero",
+            liquidity: 0,
+            max_0: 1_000_000,
+            max_1: 1_000_000,
+            expect_exact_fit: true,
+        },
+        Case {
+            label: "generous bounds fit exactly",
+            liquidity: 1_000,
+            max_0: u128::MAX / 2,
+            max_1: u128::MAX / 2,
+            expect_exact_fit: true,
+        },
+        Case {
+            label: "tight bounds force binary search reduction",
+            liquidity: 1_000_000,
+            max_0: 10,
+            max_1: 10,
+            expect_exact_fit: false,
+        },
+    ];
+
+    for case in cases {
+        let liq = Uint128::new(case.liquidity);
+        let max_0 = Uint128::new(case.max_0);
+        let max_1 = Uint128::new(case.max_1);
+
+        // Test both functions (contract path and migrate path) — identical logic.
+        for (func_label, result) in [
+            (
+                "amounts_for_position_liquidity_with_bound",
+                amounts_for_position_liquidity_with_bound(
+                    sqrt_price, sqrt_lower, sqrt_upper, liq, max_0, max_1,
+                ),
+            ),
+            (
+                "fit_liquidity_with_bound",
+                fit_liquidity_with_bound(sqrt_price, sqrt_lower, sqrt_upper, liq, max_0, max_1),
+            ),
+        ] {
+            let (fitted_liq, a0, a1) =
+                result.unwrap_or_else(|e| panic!("FAIL [{} / {}]: {e}", case.label, func_label));
+
+            assert!(
+                a0 <= max_0,
+                "FAIL [{} / {}]: a0 {a0} exceeds max {max_0}",
+                case.label,
+                func_label,
+            );
+            assert!(
+                a1 <= max_1,
+                "FAIL [{} / {}]: a1 {a1} exceeds max {max_1}",
+                case.label,
+                func_label,
+            );
+
+            if case.expect_exact_fit {
+                assert_eq!(
+                    fitted_liq, liq,
+                    "FAIL [{} / {}]: expected exact fit",
+                    case.label, func_label,
+                );
+            } else {
+                assert!(
+                    fitted_liq < liq,
+                    "FAIL [{} / {}]: expected reduced liquidity, got {fitted_liq} >= {liq}",
+                    case.label,
+                    func_label,
+                );
+                assert!(
+                    fitted_liq > Uint128::zero(),
+                    "FAIL [{} / {}]: fitted liquidity should be > 0",
+                    case.label,
+                    func_label,
+                );
+            }
+        }
+    }
 }

--- a/contracts/hub/router/src/ibc/receive/pool.rs
+++ b/contracts/hub/router/src/ibc/receive/pool.rs
@@ -34,7 +34,7 @@ use crate::{
         VLP_INSTANTIATE_REPLY_ID, VLP_POOL_REGISTER_REPLY_ID,
     },
     state::{
-        pool_key_to_map_key, ADMIN, CONCENTRATED_FUNDS_INFO, CONCENTRATED_VLPS, ESCROW_BALANCES,
+        ADMIN, CONCENTRATED_FUNDS_INFO, CONCENTRATED_VLPS, ESCROW_BALANCES,
         FEE_STATE, FUNDS_INFO, PENDING_CONCENTRATED_COLLECT_FEES,
         PENDING_CONCENTRATED_COLLECT_PROTOCOL_FEES, PENDING_CONCENTRATED_REMOVE_LIQUIDITY,
         PENDING_REMOVE_LIQUIDITY, STATE, TOKEN_DENOMS, VIRTUAL_BALANCE_CONTRACT, VLPS,
@@ -168,7 +168,7 @@ pub fn ibc_execute_request_pool_creation(
         )?;
 
         let existing_vlp =
-            CONCENTRATED_VLPS.may_load(deps.storage, pool_key_to_map_key(&pool_key))?;
+            CONCENTRATED_VLPS.may_load(deps.storage, pool_key.to_map_key())?;
         let register_msg =
             ConcentratedVlpExecuteMsg::RegisterPool(VlpConcentratedRegisterPoolMsg {
                 sender: sender.clone(),
@@ -424,7 +424,7 @@ pub fn ibc_execute_add_concentrated_liquidity(
     deps: DepsMut,
     msg: RouterCrossChainConcentratedAddLiquidityExecuteMsg,
 ) -> Result<Response, ContractError> {
-    let vlp_address = CONCENTRATED_VLPS.load(deps.storage, pool_key_to_map_key(&msg.pool_key))?;
+    let vlp_address = CONCENTRATED_VLPS.load(deps.storage, msg.pool_key.to_map_key())?;
 
     let mut response = Response::new().add_event(
         tx_event(
@@ -544,7 +544,7 @@ pub fn ibc_execute_remove_concentrated_liquidity(
     _env: Env,
     msg: RouterCrossChainConcentratedRemoveLiquidityExecuteMsg,
 ) -> Result<Response, ContractError> {
-    let vlp_address = CONCENTRATED_VLPS.load(deps.storage, pool_key_to_map_key(&msg.pool_key))?;
+    let vlp_address = CONCENTRATED_VLPS.load(deps.storage, msg.pool_key.to_map_key())?;
     let response = Response::new()
         .add_event(tx_event(
             &msg.tx_id,
@@ -583,7 +583,7 @@ pub fn ibc_execute_collect_concentrated_fees(
     _env: Env,
     msg: RouterCrossChainConcentratedCollectFeesExecuteMsg,
 ) -> Result<Response, ContractError> {
-    let vlp_address = CONCENTRATED_VLPS.load(deps.storage, pool_key_to_map_key(&msg.pool_key))?;
+    let vlp_address = CONCENTRATED_VLPS.load(deps.storage, msg.pool_key.to_map_key())?;
     let response = Response::new()
         .add_event(tx_event(
             &msg.tx_id,
@@ -622,7 +622,7 @@ pub fn ibc_execute_collect_concentrated_protocol_fees(
     _env: Env,
     msg: RouterCrossChainConcentratedCollectProtocolFeesExecuteMsg,
 ) -> Result<Response, ContractError> {
-    let vlp_address = CONCENTRATED_VLPS.load(deps.storage, pool_key_to_map_key(&msg.pool_key))?;
+    let vlp_address = CONCENTRATED_VLPS.load(deps.storage, msg.pool_key.to_map_key())?;
     let response = Response::new()
         .add_event(tx_event(
             &msg.tx_id,

--- a/contracts/hub/router/src/query.rs
+++ b/contracts/hub/router/src/query.rs
@@ -67,6 +67,8 @@ pub fn query_all_vlps(
 
     let concentrated_vlps: Result<Vec<_>, ContractError> = CONCENTRATED_VLPS
         .range(deps.storage, None, None, Order::Ascending)
+        .skip(skip.unwrap_or(0) as usize)
+        .take(limit.unwrap_or(10) as usize)
         .map(|v| {
             let v = v?;
             let (token_1, token_2, _, _) = map_key_to_pool_parts(&v.0)

--- a/contracts/hub/router/src/query.rs
+++ b/contracts/hub/router/src/query.rs
@@ -19,9 +19,8 @@ use euclid::{
 };
 
 use crate::state::{
-    map_key_to_pool_parts, pool_key_to_map_key, ADMIN, CHAIN_UID_TO_CHAIN, CONCENTRATED_VLPS,
-    ESCROW_BALANCES, RELAYER_CONTRACT, RELEASE_FEES, STATE, TOKEN_DENOMS, VIRTUAL_BALANCE_CONTRACT,
-    VLPS,
+    ADMIN, CHAIN_UID_TO_CHAIN, CONCENTRATED_VLPS, ESCROW_BALANCES, RELAYER_CONTRACT, RELEASE_FEES,
+    STATE, TOKEN_DENOMS, VIRTUAL_BALANCE_CONTRACT, VLPS,
 };
 
 pub fn query_state(deps: Deps) -> Result<Binary, ContractError> {
@@ -71,7 +70,7 @@ pub fn query_all_vlps(
         .take(limit.unwrap_or(10) as usize)
         .map(|v| {
             let v = v?;
-            let (token_1, token_2, _, _) = map_key_to_pool_parts(&v.0)
+            let (token_1, token_2, _, _) = PoolKey::parse_map_key(&v.0)
                 .ok_or(ContractError::new("invalid concentrated pool key in state"))?;
             Ok(VlpResponse {
                 vlp: v.1.to_string(),
@@ -97,7 +96,7 @@ pub fn query_vlp(deps: Deps, pair: Pair) -> Result<Binary, ContractError> {
 }
 
 pub fn query_vlp_by_pool_key(deps: Deps, pool_key: PoolKey) -> Result<Binary, ContractError> {
-    let key = pool_key_to_map_key(&pool_key);
+    let key = pool_key.to_map_key();
     let vlp = CONCENTRATED_VLPS.load(deps.storage, key)?;
     Ok(to_json_binary(&PoolKeyVlpResponse {
         vlp: vlp.to_string(),
@@ -196,7 +195,7 @@ pub fn validate_swap_pairs(
                     ContractError::new("swap hop tokens do not match pool_key pair")
                 );
 
-                let key = pool_key_to_map_key(pool_key);
+                let key = pool_key.to_map_key();
                 CONCENTRATED_VLPS.load(deps.storage, key).map_err(|_| {
                     ContractError::new("concentrated pool for provided pool_key is not registered")
                 })?

--- a/contracts/hub/router/src/reply.rs
+++ b/contracts/hub/router/src/reply.rs
@@ -35,7 +35,7 @@ use crate::{
         receive::pool::{ibc_execute_add_concentrated_liquidity, ibc_execute_add_liquidity},
     },
     state::{
-        pool_key_to_map_key, CONCENTRATED_FUNDS_INFO, CONCENTRATED_VLPS, FUNDS_INFO,
+        CONCENTRATED_FUNDS_INFO, CONCENTRATED_VLPS, FUNDS_INFO,
         PENDING_CONCENTRATED_COLLECT_FEES, PENDING_CONCENTRATED_COLLECT_PROTOCOL_FEES,
         PENDING_CONCENTRATED_REMOVE_LIQUIDITY, PENDING_REMOVE_LIQUIDITY, PENDING_SWAPS, TOKEN_VLPS,
         VIRTUAL_BALANCE_CONTRACT, VLPS,
@@ -80,7 +80,7 @@ pub fn on_vlp_instantiate_reply(deps: DepsMut, msg: Reply) -> Result<Response, C
                 }
                 CONCENTRATED_VLPS.save(
                     deps.storage,
-                    pool_key_to_map_key(&pool_creation_response.pool_key),
+                    pool_creation_response.pool_key.to_map_key(),
                     &vlp_address,
                 )?;
 

--- a/contracts/hub/router/src/reply.rs
+++ b/contracts/hub/router/src/reply.rs
@@ -55,7 +55,7 @@ pub const ESCROW_BALANCE_INSTANTIATE_REPLY_ID: u64 = 7;
 pub const CROSS_CHAIN_RECEIVE_REPLY_ID: u64 = 8;
 
 pub fn on_vlp_instantiate_reply(deps: DepsMut, msg: Reply) -> Result<Response, ContractError> {
-    match msg.result.clone() {
+    match msg.result {
         SubMsgResult::Err(err) => Err(ContractError::InstantiateError { err }),
         SubMsgResult::Ok(result) => {
             #[allow(deprecated)]
@@ -143,14 +143,12 @@ pub fn on_vlp_instantiate_reply(deps: DepsMut, msg: Reply) -> Result<Response, C
 
 #[named]
 pub fn on_pool_register_reply(deps: DepsMut, msg: Reply) -> Result<Response, ContractError> {
-    match msg.result.clone() {
+    match msg.result {
         SubMsgResult::Err(err) => Err(ContractError::Reply {
             action: function_name!().to_string(),
             err,
         }),
-        SubMsgResult::Ok(..) => {
-            let msg_clone = msg.clone();
-            let result = msg_clone.result.unwrap();
+        SubMsgResult::Ok(result) => {
             #[allow(deprecated)]
             let data = result.data.unwrap_or_default();
 
@@ -215,14 +213,12 @@ pub fn on_pool_register_reply(deps: DepsMut, msg: Reply) -> Result<Response, Con
 
 #[named]
 pub fn on_add_liquidity_reply(deps: DepsMut, msg: Reply) -> Result<Response, ContractError> {
-    match msg.result.clone() {
+    match msg.result {
         SubMsgResult::Err(err) => Err(ContractError::Reply {
             action: function_name!().to_string(),
             err,
         }),
-        SubMsgResult::Ok(..) => {
-            let msg_clone = msg.clone();
-            let result = msg_clone.result.unwrap();
+        SubMsgResult::Ok(result) => {
             #[allow(deprecated)]
             let data = result.data.unwrap_or_default();
 
@@ -292,16 +288,14 @@ pub fn on_remove_liquidity_reply(
     _env: Env,
     msg: Reply,
 ) -> Result<Response, ContractError> {
-    match msg.result.clone() {
+    match msg.result {
         SubMsgResult::Err(err) => Err(ContractError::Reply {
             action: function_name!().to_string(),
             err,
         }),
-        SubMsgResult::Ok(..) => {
+        SubMsgResult::Ok(result) => {
             let response = Response::new().add_attribute("action", "reply_remove_liquidity");
 
-            let msg_clone = msg.clone();
-            let result = msg_clone.result.unwrap();
             #[allow(deprecated)]
             let data = result.data.unwrap_or_default();
 
@@ -364,16 +358,14 @@ pub fn on_remove_liquidity_reply(
 
 #[named]
 pub fn on_collect_concentrated_reply(deps: DepsMut, msg: Reply) -> Result<Response, ContractError> {
-    match msg.result.clone() {
+    match msg.result {
         SubMsgResult::Err(err) => Err(ContractError::Reply {
             action: function_name!().to_string(),
             err,
         }),
-        SubMsgResult::Ok(..) => {
+        SubMsgResult::Ok(result) => {
             let response = Response::new().add_attribute("action", "reply_collect_concentrated");
 
-            let msg_clone = msg.clone();
-            let result = msg_clone.result.unwrap();
             #[allow(deprecated)]
             let data = result.data.unwrap_or_default();
 
@@ -445,14 +437,12 @@ pub fn on_collect_concentrated_reply(deps: DepsMut, msg: Reply) -> Result<Respon
 
 #[named]
 pub fn on_swap_reply(deps: &mut DepsMut, env: Env, msg: Reply) -> Result<Response, ContractError> {
-    match msg.result.clone() {
+    match msg.result {
         SubMsgResult::Err(err) => Err(ContractError::Reply {
             action: function_name!().to_string(),
             err,
         }),
-        SubMsgResult::Ok(..) => {
-            let msg_clone = msg.clone();
-            let result = msg_clone.result.unwrap();
+        SubMsgResult::Ok(result) => {
             #[allow(deprecated)]
             let data = result.data.unwrap_or_default();
 
@@ -514,14 +504,12 @@ pub fn on_virtual_balance_instantiate_reply(
     deps: DepsMut,
     msg: Reply,
 ) -> Result<Response, ContractError> {
-    match msg.result.clone() {
+    match msg.result {
         SubMsgResult::Err(err) => Err(ContractError::Reply {
             action: function_name!().to_string(),
             err,
         }),
-        SubMsgResult::Ok(..) => {
-            let msg_clone = msg.clone();
-            let result = msg_clone.result.unwrap();
+        SubMsgResult::Ok(result) => {
             #[allow(deprecated)]
             let data = result.data.unwrap_or_default();
 

--- a/contracts/hub/router/src/state.rs
+++ b/contracts/hub/router/src/state.rs
@@ -84,6 +84,10 @@ pub struct ConcentratedFundsInfo {
     pub upper_tick_index: i64,
     pub position_id: Option<Uint128>,
 }
+/// Singleton holding funds info for the current concentrated pool creation.
+/// Safe as a singleton because CosmWasm SubMsg replies are synchronous — the
+/// reply handler runs before control returns to the caller, so no concurrent
+/// pool creation can overwrite this value between save and load.
 pub const CONCENTRATED_FUNDS_INFO: Item<ConcentratedFundsInfo> =
     Item::new("concentrated_funds_info");
 
@@ -97,6 +101,8 @@ pub struct PendingReleaseVoucher {
 pub const PENDING_RELEASE_VOUCHER: Map<String, PendingReleaseVoucher> =
     Map::new("pending_release_voucher");
 
+/// Singleton holding funds info for the current classic pool creation.
+/// Same synchronous-SubMsg safety rationale as CONCENTRATED_FUNDS_INFO.
 pub const FUNDS_INFO: Item<(PairWithDenomAndAmount, u64)> = Item::new("funds_info");
 
 /// The key is TokenID_ChainUID

--- a/contracts/liquidity/factory/src/contract.rs
+++ b/contracts/liquidity/factory/src/contract.rs
@@ -40,8 +40,8 @@ use crate::reply::{
     CROSS_CHAIN_RECEIVE_REPLY_ID, LP_INSTANTIATE_REPLY_ID, POSITION_TOKEN_INSTANTIATE_REPLY_ID,
 };
 use crate::reply::{
-    on_escrow_instantiate_reply, on_release_escrow_reply, ESCROW_INSTANTIATE_REPLY_ID,
-    RELEASE_ESCROW_REPLY_ID,
+    on_escrow_instantiate_reply, on_nft_mint_reply, on_release_escrow_reply,
+    ESCROW_INSTANTIATE_REPLY_ID, NFT_MINT_REPLY_ID, RELEASE_ESCROW_REPLY_ID,
 };
 use crate::state::{FeeState, State, ADMIN, FEE_STATE, STATE};
 use cosmwasm_std::ensure;
@@ -434,6 +434,7 @@ pub fn reply(mut deps: DepsMut, env: Env, msg: Reply) -> Result<Response, Contra
         POSITION_TOKEN_INSTANTIATE_REPLY_ID => {
             on_position_token_instantiate_reply(deps.branch(), msg)
         }
+        NFT_MINT_REPLY_ID => on_nft_mint_reply(deps.branch(), msg),
 
         id => Err(ContractError::Std(StdError::generic_err(format!(
             "Unknown reply id: {}",

--- a/contracts/liquidity/factory/src/execute/pool.rs
+++ b/contracts/liquidity/factory/src/execute/pool.rs
@@ -27,7 +27,7 @@ use euclid_ibc::router_ibc::{
 use crate::{
     query::get_chain_type,
     state::{
-        pool_key_to_map_key, ConcentratedAddLiquidityRequest, ConcentratedCollectFeesRequest,
+        ConcentratedAddLiquidityRequest, ConcentratedCollectFeesRequest,
         ConcentratedCollectProtocolFeesRequest, ConcentratedPoolCreateRequest,
         ConcentratedRemoveLiquidityRequest, PoolCreateRequest, ADMIN, PAIR_TO_VLP,
         PENDING_ADD_LIQUIDITY, PENDING_CONCENTRATED_ADD_LIQUIDITY,
@@ -504,7 +504,7 @@ pub fn execute_request_concentrated_pool_creation(
         ContractError::TxAlreadyExist {}
     );
     ensure!(
-        !POOL_KEY_TO_VLP.has(deps.storage, pool_key_to_map_key(&pool_key)),
+        !POOL_KEY_TO_VLP.has(deps.storage, pool_key.to_map_key()),
         ContractError::PoolAlreadyExists {}
     );
 
@@ -601,7 +601,7 @@ pub fn add_concentrated_liquidity_request(
         ContractError::TxAlreadyExist {}
     );
     ensure!(
-        POOL_KEY_TO_VLP.has(deps.storage, pool_key_to_map_key(&pool_key)),
+        POOL_KEY_TO_VLP.has(deps.storage, pool_key.to_map_key()),
         ContractError::PoolDoesNotExist {}
     );
 
@@ -818,7 +818,7 @@ pub fn collect_concentrated_fees_request(
         ContractError::TxAlreadyExist {}
     );
     ensure!(
-        POOL_KEY_TO_VLP.has(deps.storage, pool_key_to_map_key(&pool_key)),
+        POOL_KEY_TO_VLP.has(deps.storage, pool_key.to_map_key()),
         ContractError::PoolDoesNotExist {}
     );
 
@@ -922,7 +922,7 @@ pub fn collect_concentrated_protocol_fees_request(
         ContractError::TxAlreadyExist {}
     );
     ensure!(
-        POOL_KEY_TO_VLP.has(deps.storage, pool_key_to_map_key(&pool_key)),
+        POOL_KEY_TO_VLP.has(deps.storage, pool_key.to_map_key()),
         ContractError::PoolDoesNotExist {}
     );
 

--- a/contracts/liquidity/factory/src/execute/swap.rs
+++ b/contracts/liquidity/factory/src/execute/swap.rs
@@ -15,7 +15,7 @@ use euclid_ibc::router_ibc::{RouterCrossChainExecuteMsg, RouterCrossChainSwapExe
 
 use crate::{
     query::get_chain_type,
-    state::{pool_key_to_map_key, PENDING_SWAPS, POOL_KEY_TO_VLP, STATE, TOKEN_TO_ESCROW},
+    state::{PENDING_SWAPS, POOL_KEY_TO_VLP, STATE, TOKEN_TO_ESCROW},
 };
 
 pub fn execute_swap_request(
@@ -131,7 +131,7 @@ pub fn execute_swap_request(
                 ContractError::new("swap hop tokens do not match pool_key pair")
             );
             ensure!(
-                POOL_KEY_TO_VLP.has(deps.storage, pool_key_to_map_key(pool_key)),
+                POOL_KEY_TO_VLP.has(deps.storage, pool_key.to_map_key()),
                 ContractError::new("swap hop concentrated pool_key is not registered on factory")
             );
         }

--- a/contracts/liquidity/factory/src/ibc/ack_and_timeout.rs
+++ b/contracts/liquidity/factory/src/ibc/ack_and_timeout.rs
@@ -688,6 +688,11 @@ fn ack_add_concentrated_liquidity(
                 }
             }
 
+            // NOTE (M-04): POSITION_ID_TO_METADATA is updated here in the IBC ack handler,
+            // while the CLP-side position was already updated synchronously during execute.
+            // Between execute and this ack, the two views are temporarily inconsistent.
+            // This is expected IBC behavior — metadata is a best-effort cache, not a
+            // source of truth. Authorization uses live NFT ownership queries, not metadata.
             let position_id = data.position_id.u128();
             let existing_meta = POSITION_ID_TO_METADATA.may_load(deps.storage, position_id)?;
             match existing_meta {

--- a/contracts/liquidity/factory/src/ibc/ack_and_timeout.rs
+++ b/contracts/liquidity/factory/src/ibc/ack_and_timeout.rs
@@ -30,7 +30,7 @@ use euclid_ibc::{
 use crate::{
     reply::{ESCROW_INSTANTIATE_REPLY_ID, LP_INSTANTIATE_REPLY_ID, NFT_MINT_REPLY_ID},
     state::{
-        pool_key_to_map_key, ADMIN, FEE_STATE, OWNER_POSITION_SET, PAIR_TO_VLP,
+        ADMIN, FEE_STATE, OWNER_POSITION_SET, PAIR_TO_VLP,
         PENDING_ADD_LIQUIDITY, PENDING_CONCENTRATED_ADD_LIQUIDITY,
         PENDING_CONCENTRATED_COLLECT_FEES, PENDING_CONCENTRATED_COLLECT_PROTOCOL_FEES,
         PENDING_CONCENTRATED_POOL_REQUESTS, PENDING_CONCENTRATED_REMOVE_LIQUIDITY,
@@ -319,7 +319,7 @@ fn ack_concentrated_pool_creation(
         AcknowledgementMsg::Ok(data) => {
             POOL_KEY_TO_VLP.save(
                 deps.storage,
-                pool_key_to_map_key(&existing_req.pool_key),
+                existing_req.pool_key.to_map_key(),
                 &data.vlp_address,
             )?;
 

--- a/contracts/liquidity/factory/src/ibc/ack_and_timeout.rs
+++ b/contracts/liquidity/factory/src/ibc/ack_and_timeout.rs
@@ -28,16 +28,16 @@ use euclid_ibc::{
 };
 
 use crate::{
-    reply::{ESCROW_INSTANTIATE_REPLY_ID, LP_INSTANTIATE_REPLY_ID},
+    reply::{ESCROW_INSTANTIATE_REPLY_ID, LP_INSTANTIATE_REPLY_ID, NFT_MINT_REPLY_ID},
     state::{
         pool_key_to_map_key, ADMIN, FEE_STATE, OWNER_POSITION_SET, PAIR_TO_VLP,
         PENDING_ADD_LIQUIDITY, PENDING_CONCENTRATED_ADD_LIQUIDITY,
         PENDING_CONCENTRATED_COLLECT_FEES, PENDING_CONCENTRATED_COLLECT_PROTOCOL_FEES,
         PENDING_CONCENTRATED_POOL_REQUESTS, PENDING_CONCENTRATED_REMOVE_LIQUIDITY,
-        PENDING_DENOM_REGISTER_DEREGISTER_REQUESTS, PENDING_DEPOSIT_TOKEN, PENDING_POOL_REQUESTS,
-        PENDING_REMOVE_LIQUIDITY, PENDING_SWAPS, PENDING_TOKEN_DEPOSIT, POOL_KEY_TO_VLP,
-        POSITION_ID_TO_METADATA, POSITION_TOKEN_CONTRACT, STATE, TOKEN_TO_ESCROW, VLP_TO_LP_SHARES,
-        VLP_TO_LP_TOKEN,
+        PENDING_DENOM_REGISTER_DEREGISTER_REQUESTS, PENDING_DEPOSIT_TOKEN,
+        PENDING_NFT_MINT_POSITION, PENDING_POOL_REQUESTS, PENDING_REMOVE_LIQUIDITY, PENDING_SWAPS,
+        PENDING_TOKEN_DEPOSIT, POOL_KEY_TO_VLP, POSITION_ID_TO_METADATA, POSITION_TOKEN_CONTRACT,
+        STATE, TOKEN_TO_ESCROW, VLP_TO_LP_SHARES, VLP_TO_LP_TOKEN,
     },
 };
 
@@ -635,16 +635,11 @@ fn ack_add_concentrated_liquidity(
 ) -> Result<Response, ContractError> {
     let sender = deps.api.addr_validate(&sender)?;
     let req_key = (sender.clone(), tx_id.clone());
-    let liquidity_info =
-        match PENDING_CONCENTRATED_ADD_LIQUIDITY.may_load(deps.storage, req_key.clone())? {
-            Some(info) => info,
-            None => {
-                return Ok(Response::new()
-                    .add_attribute("method", "ack_add_concentrated_liquidity_idempotent")
-                    .add_attribute("tx_id", tx_id)
-                    .add_attribute("sender", sender));
-            }
-        };
+    let liquidity_info = PENDING_CONCENTRATED_ADD_LIQUIDITY
+        .load(deps.storage, req_key.clone())
+        .map_err(|_| ContractError::NotFound {
+            msg: "pending concentrated liquidity request not found".to_string(),
+        })?;
     PENDING_CONCENTRATED_ADD_LIQUIDITY.remove(deps.storage, req_key);
 
     match res {
@@ -740,7 +735,12 @@ fn ack_add_concentrated_liquidity(
                         })?,
                         funds: vec![],
                     });
-                    res = res.add_message(mint_msg);
+                    PENDING_NFT_MINT_POSITION
+                        .save(deps.storage, &(sender.clone(), position_id))?;
+                    res = res.add_submessage(SubMsg::reply_always(
+                        mint_msg,
+                        NFT_MINT_REPLY_ID,
+                    ));
                 }
             }
 
@@ -922,7 +922,14 @@ fn ack_collect_concentrated_fees(
 ) -> Result<Response, ContractError> {
     let sender = deps.api.addr_validate(&sender)?;
     let req_key = (sender.clone(), tx_id.clone());
-    let collect_info = PENDING_CONCENTRATED_COLLECT_FEES.load(deps.storage, req_key.clone())?;
+    let collect_info = PENDING_CONCENTRATED_COLLECT_FEES
+        .may_load(deps.storage, req_key.clone())?
+        .ok_or(ContractError::Generic {
+            err: format!(
+                "no pending collect fees request found for sender={}, tx_id={}",
+                sender, tx_id
+            ),
+        })?;
 
     PENDING_CONCENTRATED_COLLECT_FEES.remove(deps.storage, req_key);
 
@@ -1198,7 +1205,7 @@ mod tests {
     use euclid::token::{PairWithDenomAndAmount, Token, TokenType, TokenWithDenomAndAmount};
     use euclid_ibc::ack::AcknowledgementMsg;
 
-    use crate::reply::ESCROW_INSTANTIATE_REPLY_ID;
+    use crate::reply::{ESCROW_INSTANTIATE_REPLY_ID, NFT_MINT_REPLY_ID};
     use crate::state::{
         ConcentratedAddLiquidityRequest, ADMIN, PENDING_CONCENTRATED_ADD_LIQUIDITY,
         PENDING_DEPOSIT_TOKEN, STATE, TOKEN_TO_ESCROW,
@@ -1210,6 +1217,7 @@ mod tests {
         existing_escrows: &'static [(&'static str, &'static str)],
         expected_instantiations: usize,
         expected_sends: usize,
+        expected_nft_mints: usize,
     }
 
     #[test]
@@ -1219,19 +1227,22 @@ mod tests {
                 name: "no escrows — instantiates both",
                 existing_escrows: &[],
                 expected_instantiations: 2,
-                expected_sends: 1, // position token mint
+                expected_sends: 0,
+                expected_nft_mints: 1,
             },
             EscrowAckCase {
                 name: "both escrows exist — sends directly",
                 existing_escrows: &[("tokena", "escrow_a"), ("tokenb", "escrow_b")],
                 expected_instantiations: 0,
-                expected_sends: 3, // 2 escrow sends + position token mint
+                expected_sends: 2, // 2 escrow sends
+                expected_nft_mints: 1,
             },
             EscrowAckCase {
                 name: "one escrow exists — mixed",
                 existing_escrows: &[("tokena", "escrow_a")],
                 expected_instantiations: 1,
-                expected_sends: 2, // 1 escrow send + position token mint
+                expected_sends: 1, // 1 escrow send
+                expected_nft_mints: 1,
             },
         ];
 
@@ -1343,6 +1354,11 @@ mod tests {
                 .filter(|m| m.id == ESCROW_INSTANTIATE_REPLY_ID)
                 .count();
             let sends = response.messages.iter().filter(|m| m.id == 0).count();
+            let nft_mints = response
+                .messages
+                .iter()
+                .filter(|m| m.id == NFT_MINT_REPLY_ID)
+                .count();
 
             assert_eq!(
                 instantiations, case.expected_instantiations,
@@ -1350,6 +1366,11 @@ mod tests {
                 case.name
             );
             assert_eq!(sends, case.expected_sends, "{}: escrow sends", case.name);
+            assert_eq!(
+                nft_mints, case.expected_nft_mints,
+                "{}: nft mints",
+                case.name
+            );
         }
     }
 }

--- a/contracts/liquidity/factory/src/query.rs
+++ b/contracts/liquidity/factory/src/query.rs
@@ -161,8 +161,8 @@ pub fn pending_swaps(
         .range(deps.storage, min, max, Order::Ascending)
         .skip(pagination.skip.unwrap_or(0) as usize)
         .take(pagination.limit.unwrap_or(10) as usize)
-        .map(|k| k.unwrap().1)
-        .collect();
+        .map(|k| -> Result<_, ContractError> { Ok(k?.1) })
+        .collect::<Result<Vec<_>, _>>()?;
 
     Ok(to_json_binary(&GetPendingSwapsResponse { pending_swaps })?)
 }

--- a/contracts/liquidity/factory/src/query.rs
+++ b/contracts/liquidity/factory/src/query.rs
@@ -16,10 +16,10 @@ use euclid::{
 };
 
 use crate::state::{
-    map_key_to_pool_parts, pool_key_to_map_key, ADMIN, FEE_STATE, PAIR_TO_VLP,
-    PENDING_ADD_LIQUIDITY, PENDING_REMOVE_LIQUIDITY, PENDING_SWAPS, POOL_KEY_TO_VLP,
-    POSITION_TOKEN_CONTRACT, STATE, TOKEN_TO_ESCROW, VLP_TO_LP_TOKEN,
+    ADMIN, FEE_STATE, PAIR_TO_VLP, PENDING_ADD_LIQUIDITY, PENDING_REMOVE_LIQUIDITY, PENDING_SWAPS,
+    POOL_KEY_TO_VLP, POSITION_TOKEN_CONTRACT, STATE, TOKEN_TO_ESCROW, VLP_TO_LP_TOKEN,
 };
+use euclid::msgs::vlp::base::PoolKey;
 
 // Returns the VLP address
 pub fn get_vlp(deps: Deps, pair: Pair) -> Result<Binary, ContractError> {
@@ -107,7 +107,7 @@ pub fn get_concentrated_vlp(
     deps: Deps,
     pool_key: euclid::msgs::vlp::base::PoolKey,
 ) -> Result<Binary, ContractError> {
-    let vlp_address = POOL_KEY_TO_VLP.load(deps.storage, pool_key_to_map_key(&pool_key))?;
+    let vlp_address = POOL_KEY_TO_VLP.load(deps.storage, pool_key.to_map_key())?;
     Ok(to_json_binary(&GetConcentratedVlpResponse {
         vlp_address,
         pool_key,
@@ -119,7 +119,7 @@ pub fn query_all_concentrated_pools(deps: Deps) -> Result<Binary, ContractError>
         .range(deps.storage, None, None, Order::Ascending)
         .map(|item| {
             let (key, vlp) = item?;
-            let (token_1, token_2, fee_tier_bps, tick_spacing) = map_key_to_pool_parts(&key)
+            let (token_1, token_2, fee_tier_bps, tick_spacing) = PoolKey::parse_map_key(&key)
                 .ok_or(ContractError::new("invalid concentrated pool key in state"))?;
             Ok(ConcentratedPoolVlpResponse {
                 pool_key: euclid::msgs::vlp::base::PoolKey {

--- a/contracts/liquidity/factory/src/reply.rs
+++ b/contracts/liquidity/factory/src/reply.rs
@@ -1,6 +1,9 @@
 use crate::{
     ibc,
-    state::{PENDING_DEPOSIT_TOKEN, POSITION_TOKEN_CONTRACT, TOKEN_TO_ESCROW, VLP_TO_LP_TOKEN},
+    state::{
+        OWNER_POSITION_SET, PENDING_DEPOSIT_TOKEN, PENDING_NFT_MINT_POSITION,
+        POSITION_ID_TO_METADATA, POSITION_TOKEN_CONTRACT, TOKEN_TO_ESCROW, VLP_TO_LP_TOKEN,
+    },
 };
 use cosmwasm_std::{from_json, DepsMut, Env, Event, Reply, Response, SubMsgResult};
 use cw_utils::{parse_execute_response_data, parse_instantiate_response_data};
@@ -23,6 +26,7 @@ pub const RELEASE_ESCROW_REPLY_ID: u64 = 5;
 
 pub const CROSS_CHAIN_RECEIVE_REPLY_ID: u64 = 6;
 pub const POSITION_TOKEN_INSTANTIATE_REPLY_ID: u64 = 7;
+pub const NFT_MINT_REPLY_ID: u64 = 8;
 
 #[named]
 pub fn on_escrow_instantiate_reply(deps: DepsMut, msg: Reply) -> Result<Response, ContractError> {
@@ -204,6 +208,29 @@ pub fn on_reply_native_ibc_wrapper_call(
                 true,
             )?;
             Ok(response.add_attribute("reply_on_native_ibc_wrapper_call_processing", "success"))
+        }
+    }
+}
+
+#[named]
+pub fn on_nft_mint_reply(deps: DepsMut, msg: Reply) -> Result<Response, ContractError> {
+    match msg.result {
+        SubMsgResult::Ok(_) => {
+            PENDING_NFT_MINT_POSITION.remove(deps.storage);
+            Ok(Response::new().add_attribute("action", "reply_nft_mint_success"))
+        }
+        SubMsgResult::Err(err) => {
+            if let Some((owner, position_id)) =
+                PENDING_NFT_MINT_POSITION.may_load(deps.storage)?
+            {
+                POSITION_ID_TO_METADATA.remove(deps.storage, position_id);
+                OWNER_POSITION_SET.remove(deps.storage, (owner, position_id));
+                PENDING_NFT_MINT_POSITION.remove(deps.storage);
+            }
+            Err(ContractError::Reply {
+                action: function_name!().to_string(),
+                err,
+            })
         }
     }
 }

--- a/contracts/liquidity/factory/src/reply.rs
+++ b/contracts/liquidity/factory/src/reply.rs
@@ -30,14 +30,12 @@ pub const NFT_MINT_REPLY_ID: u64 = 8;
 
 #[named]
 pub fn on_escrow_instantiate_reply(deps: DepsMut, msg: Reply) -> Result<Response, ContractError> {
-    match msg.result.clone() {
+    match msg.result {
         SubMsgResult::Err(err) => Err(ContractError::Reply {
             action: function_name!().to_string(),
             err,
         }),
-        SubMsgResult::Ok(..) => {
-            let msg_clone = msg.clone();
-            let result = msg_clone.result.unwrap();
+        SubMsgResult::Ok(result) => {
             #[allow(deprecated)]
             let data = result.data.unwrap_or_default();
 
@@ -78,14 +76,12 @@ pub fn on_position_token_instantiate_reply(
     deps: DepsMut,
     msg: Reply,
 ) -> Result<Response, ContractError> {
-    match msg.result.clone() {
+    match msg.result {
         SubMsgResult::Err(err) => Err(ContractError::Reply {
             action: function_name!().to_string(),
             err,
         }),
-        SubMsgResult::Ok(..) => {
-            let msg_clone = msg.clone();
-            let result = msg_clone.result.unwrap();
+        SubMsgResult::Ok(result) => {
             #[allow(deprecated)]
             let data = result.data.unwrap_or_default();
 
@@ -113,14 +109,12 @@ pub fn on_position_token_instantiate_reply(
 
 #[named]
 pub fn on_lp_instantiate_reply(deps: DepsMut, msg: Reply) -> Result<Response, ContractError> {
-    match msg.result.clone() {
+    match msg.result {
         SubMsgResult::Err(err) => Err(ContractError::Reply {
             action: function_name!().to_string(),
             err,
         }),
-        SubMsgResult::Ok(..) => {
-            let msg_clone = msg.clone();
-            let result = msg_clone.result.unwrap();
+        SubMsgResult::Ok(result) => {
             #[allow(deprecated)]
             let data = result.data.unwrap_or_default();
 

--- a/contracts/liquidity/factory/src/state.rs
+++ b/contracts/liquidity/factory/src/state.rs
@@ -75,6 +75,10 @@ pub const POSITION_ID_TO_METADATA: Map<u128, ConcentratedPositionMetadata> =
 pub const OWNER_POSITION_SET: Map<(Addr, u128), cosmwasm_std::Empty> =
     Map::new("owner_position_set");
 
+/// Temporarily stores (owner, position_id) while an NFT mint SubMsg is in flight.
+/// Used by the reply handler to rollback metadata if the mint fails.
+pub const PENDING_NFT_MINT_POSITION: Item<(Addr, u128)> = Item::new("pending_nft_mint_pos");
+
 #[cw_serde]
 pub struct PoolCreateRequest {
     pub tx_id: String,

--- a/contracts/liquidity/factory/src/tests.rs
+++ b/contracts/liquidity/factory/src/tests.rs
@@ -6,7 +6,7 @@ mod tests {
         collect_concentrated_fees_request, remove_concentrated_liquidity_request,
     };
     use crate::state::{
-        pool_key_to_map_key, ConcentratedPositionMetadata, State, ADMIN, POOL_KEY_TO_VLP,
+        ConcentratedPositionMetadata, State, ADMIN, POOL_KEY_TO_VLP,
         POSITION_ID_TO_METADATA, POSITION_TOKEN_CONTRACT, STATE,
     };
 
@@ -311,7 +311,7 @@ mod tests {
             POOL_KEY_TO_VLP
                 .save(
                     deps.as_mut().storage,
-                    pool_key_to_map_key(&pool_key),
+                    pool_key.to_map_key(),
                     &"vlp_address".to_string(),
                 )
                 .unwrap();

--- a/contracts/liquidity/position_token/src/contract.rs
+++ b/contracts/liquidity/position_token/src/contract.rs
@@ -76,8 +76,15 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractErr
     match msg {
         QueryMsg::OwnerOf { token_id } => query_owner_of(deps, token_id),
         QueryMsg::TokenInfo { token_id } => query_token_info(deps, token_id),
-        QueryMsg::TokensByOwner { owner } => query_tokens_by_owner(deps, owner),
-        QueryMsg::AllTokens {} => query_all_tokens(deps),
+        QueryMsg::TokensByOwner {
+            owner,
+            start_after,
+            limit,
+        } => query_tokens_by_owner(deps, owner, start_after, limit),
+        QueryMsg::AllTokens {
+            start_after,
+            limit,
+        } => query_all_tokens(deps, start_after, limit),
         QueryMsg::State {} => query_state(deps),
     }
 }

--- a/contracts/liquidity/position_token/src/contract.rs
+++ b/contracts/liquidity/position_token/src/contract.rs
@@ -76,15 +76,10 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractErr
     match msg {
         QueryMsg::OwnerOf { token_id } => query_owner_of(deps, token_id),
         QueryMsg::TokenInfo { token_id } => query_token_info(deps, token_id),
-        QueryMsg::TokensByOwner {
-            owner,
-            start_after,
-            limit,
-        } => query_tokens_by_owner(deps, owner, start_after, limit),
-        QueryMsg::AllTokens {
-            start_after,
-            limit,
-        } => query_all_tokens(deps, start_after, limit),
+        QueryMsg::TokensByOwner { owner, pagination } => {
+            query_tokens_by_owner(deps, owner, pagination)
+        }
+        QueryMsg::AllTokens { pagination } => query_all_tokens(deps, pagination),
         QueryMsg::State {} => query_state(deps),
     }
 }

--- a/contracts/liquidity/position_token/src/query.rs
+++ b/contracts/liquidity/position_token/src/query.rs
@@ -5,9 +5,7 @@ use euclid::error::ContractError;
 use euclid::msgs::position_token::{
     OwnerOfResponse, StateResponse, TokenInfoResponse, TokensResponse,
 };
-
-const DEFAULT_LIMIT: u32 = 30;
-const MAX_LIMIT: u32 = 100;
+use euclid::utils::pagination::Pagination;
 
 pub(crate) fn query_owner_of(deps: Deps, token_id: String) -> Result<Binary, ContractError> {
     let token = TOKENS
@@ -38,17 +36,17 @@ pub(crate) fn query_token_info(deps: Deps, token_id: String) -> Result<Binary, C
 pub(crate) fn query_tokens_by_owner(
     deps: Deps,
     owner: String,
-    start_after: Option<String>,
-    limit: Option<u32>,
+    pagination: Pagination<String>,
 ) -> Result<Binary, ContractError> {
     let owner_addr = deps.api.addr_validate(owner.as_str())?;
-    let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.as_deref().map(Bound::exclusive);
+    let min = pagination.min.as_deref().map(Bound::inclusive);
+    let max = pagination.max.as_deref().map(Bound::inclusive);
 
     let tokens: Vec<String> = OWNER_TOKEN_SET
         .prefix(&owner_addr)
-        .keys(deps.storage, start, None, Order::Ascending)
-        .take(limit)
+        .keys(deps.storage, min, max, Order::Ascending)
+        .skip(pagination.skip.unwrap_or(0) as usize)
+        .take(pagination.limit.unwrap_or(10) as usize)
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(to_json_binary(&TokensResponse { tokens })?)
@@ -56,15 +54,15 @@ pub(crate) fn query_tokens_by_owner(
 
 pub(crate) fn query_all_tokens(
     deps: Deps,
-    start_after: Option<String>,
-    limit: Option<u32>,
+    pagination: Pagination<String>,
 ) -> Result<Binary, ContractError> {
-    let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after.as_deref().map(Bound::exclusive);
+    let min = pagination.min.as_deref().map(Bound::inclusive);
+    let max = pagination.max.as_deref().map(Bound::inclusive);
 
     let tokens: Vec<String> = ALL_TOKEN_SET
-        .keys(deps.storage, start, None, Order::Ascending)
-        .take(limit)
+        .keys(deps.storage, min, max, Order::Ascending)
+        .skip(pagination.skip.unwrap_or(0) as usize)
+        .take(pagination.limit.unwrap_or(10) as usize)
         .collect::<Result<Vec<_>, _>>()?;
     Ok(to_json_binary(&TokensResponse { tokens })?)
 }

--- a/contracts/liquidity/position_token/src/query.rs
+++ b/contracts/liquidity/position_token/src/query.rs
@@ -1,9 +1,13 @@
 use crate::state::{ALL_TOKEN_SET, OWNER_TOKEN_SET, STATE, TOKENS};
 use cosmwasm_std::{to_json_binary, Binary, Deps, Order};
+use cw_storage_plus::Bound;
 use euclid::error::ContractError;
 use euclid::msgs::position_token::{
     OwnerOfResponse, StateResponse, TokenInfoResponse, TokensResponse,
 };
+
+const DEFAULT_LIMIT: u32 = 30;
+const MAX_LIMIT: u32 = 100;
 
 pub(crate) fn query_owner_of(deps: Deps, token_id: String) -> Result<Binary, ContractError> {
     let token = TOKENS
@@ -31,19 +35,36 @@ pub(crate) fn query_token_info(deps: Deps, token_id: String) -> Result<Binary, C
     })?)
 }
 
-pub(crate) fn query_tokens_by_owner(deps: Deps, owner: String) -> Result<Binary, ContractError> {
+pub(crate) fn query_tokens_by_owner(
+    deps: Deps,
+    owner: String,
+    start_after: Option<String>,
+    limit: Option<u32>,
+) -> Result<Binary, ContractError> {
     let owner_addr = deps.api.addr_validate(owner.as_str())?;
+    let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+    let start = start_after.as_deref().map(Bound::exclusive);
+
     let tokens: Vec<String> = OWNER_TOKEN_SET
         .prefix(&owner_addr)
-        .keys(deps.storage, None, None, Order::Ascending)
+        .keys(deps.storage, start, None, Order::Ascending)
+        .take(limit)
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(to_json_binary(&TokensResponse { tokens })?)
 }
 
-pub(crate) fn query_all_tokens(deps: Deps) -> Result<Binary, ContractError> {
+pub(crate) fn query_all_tokens(
+    deps: Deps,
+    start_after: Option<String>,
+    limit: Option<u32>,
+) -> Result<Binary, ContractError> {
+    let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+    let start = start_after.as_deref().map(Bound::exclusive);
+
     let tokens: Vec<String> = ALL_TOKEN_SET
-        .keys(deps.storage, None, None, Order::Ascending)
+        .keys(deps.storage, start, None, Order::Ascending)
+        .take(limit)
         .collect::<Result<Vec<_>, _>>()?;
     Ok(to_json_binary(&TokensResponse { tokens })?)
 }

--- a/contracts/liquidity/position_token/src/test.rs
+++ b/contracts/liquidity/position_token/src/test.rs
@@ -7,6 +7,7 @@ mod tests {
     use euclid::msgs::position_token::{
         ExecuteMsg, InstantiateMsg, OwnerOfResponse, QueryMsg, StateResponse, TokensResponse,
     };
+    use euclid::utils::pagination::Pagination;
 
     fn setup() -> (
         cosmwasm_std::OwnedDeps<
@@ -103,8 +104,7 @@ mod tests {
                 mock_env(),
                 QueryMsg::TokensByOwner {
                     owner: recipient.to_string(),
-                    start_after: None,
-                    limit: None,
+                    pagination: Pagination::default(),
                 },
             )
             .unwrap(),
@@ -123,7 +123,7 @@ mod tests {
         .unwrap();
 
         let all_tokens: TokensResponse =
-            from_json(query(deps.as_ref(), mock_env(), QueryMsg::AllTokens { start_after: None, limit: None }).unwrap()).unwrap();
+            from_json(query(deps.as_ref(), mock_env(), QueryMsg::AllTokens { pagination: Pagination::default() }).unwrap()).unwrap();
         assert!(all_tokens.tokens.is_empty());
 
         let state: StateResponse =
@@ -160,8 +160,7 @@ mod tests {
                 mock_env(),
                 QueryMsg::TokensByOwner {
                     owner: owner.to_string(),
-                    start_after: None,
-                    limit: None,
+                    pagination: Pagination::default(),
                 },
             )
             .expect("query should succeed"),
@@ -199,8 +198,7 @@ mod tests {
                 mock_env(),
                 QueryMsg::TokensByOwner {
                     owner: owner.to_string(),
-                    start_after: None,
-                    limit: None,
+                    pagination: Pagination::default(),
                 },
             )
             .expect("query should succeed"),
@@ -215,8 +213,7 @@ mod tests {
                 mock_env(),
                 QueryMsg::TokensByOwner {
                     owner: recipient.to_string(),
-                    start_after: None,
-                    limit: None,
+                    pagination: Pagination::default(),
                 },
             )
             .expect("query should succeed"),
@@ -226,7 +223,7 @@ mod tests {
 
         // AllTokens should have pos-2 and pos-3
         let all_tokens: TokensResponse = from_json(
-            query(deps.as_ref(), mock_env(), QueryMsg::AllTokens { start_after: None, limit: None }).expect("query should succeed"),
+            query(deps.as_ref(), mock_env(), QueryMsg::AllTokens { pagination: Pagination::default() }).expect("query should succeed"),
         )
         .expect("deserialize should succeed");
         assert_eq!(all_tokens.tokens, vec!["pos-2", "pos-3"]);

--- a/contracts/liquidity/position_token/src/test.rs
+++ b/contracts/liquidity/position_token/src/test.rs
@@ -103,6 +103,8 @@ mod tests {
                 mock_env(),
                 QueryMsg::TokensByOwner {
                     owner: recipient.to_string(),
+                    start_after: None,
+                    limit: None,
                 },
             )
             .unwrap(),
@@ -121,7 +123,7 @@ mod tests {
         .unwrap();
 
         let all_tokens: TokensResponse =
-            from_json(query(deps.as_ref(), mock_env(), QueryMsg::AllTokens {}).unwrap()).unwrap();
+            from_json(query(deps.as_ref(), mock_env(), QueryMsg::AllTokens { start_after: None, limit: None }).unwrap()).unwrap();
         assert!(all_tokens.tokens.is_empty());
 
         let state: StateResponse =
@@ -158,6 +160,8 @@ mod tests {
                 mock_env(),
                 QueryMsg::TokensByOwner {
                     owner: owner.to_string(),
+                    start_after: None,
+                    limit: None,
                 },
             )
             .expect("query should succeed"),
@@ -195,6 +199,8 @@ mod tests {
                 mock_env(),
                 QueryMsg::TokensByOwner {
                     owner: owner.to_string(),
+                    start_after: None,
+                    limit: None,
                 },
             )
             .expect("query should succeed"),
@@ -209,6 +215,8 @@ mod tests {
                 mock_env(),
                 QueryMsg::TokensByOwner {
                     owner: recipient.to_string(),
+                    start_after: None,
+                    limit: None,
                 },
             )
             .expect("query should succeed"),
@@ -218,7 +226,7 @@ mod tests {
 
         // AllTokens should have pos-2 and pos-3
         let all_tokens: TokensResponse = from_json(
-            query(deps.as_ref(), mock_env(), QueryMsg::AllTokens {}).expect("query should succeed"),
+            query(deps.as_ref(), mock_env(), QueryMsg::AllTokens { start_after: None, limit: None }).expect("query should succeed"),
         )
         .expect("deserialize should succeed");
         assert_eq!(all_tokens.tokens, vec!["pos-2", "pos-3"]);

--- a/packages/euclid/src/msgs/position_token/query.rs
+++ b/packages/euclid/src/msgs/position_token/query.rs
@@ -1,6 +1,8 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Addr;
 
+use crate::utils::pagination::Pagination;
+
 #[cw_serde]
 #[derive(cw_orch::QueryFns, QueryResponses)]
 pub enum QueryMsg {
@@ -11,13 +13,11 @@ pub enum QueryMsg {
     #[returns(TokensResponse)]
     TokensByOwner {
         owner: String,
-        start_after: Option<String>,
-        limit: Option<u32>,
+        pagination: Pagination<String>,
     },
     #[returns(TokensResponse)]
     AllTokens {
-        start_after: Option<String>,
-        limit: Option<u32>,
+        pagination: Pagination<String>,
     },
     #[returns(StateResponse)]
     State {},

--- a/packages/euclid/src/msgs/position_token/query.rs
+++ b/packages/euclid/src/msgs/position_token/query.rs
@@ -9,9 +9,16 @@ pub enum QueryMsg {
     #[returns(TokenInfoResponse)]
     TokenInfo { token_id: String },
     #[returns(TokensResponse)]
-    TokensByOwner { owner: String },
+    TokensByOwner {
+        owner: String,
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
     #[returns(TokensResponse)]
-    AllTokens {},
+    AllTokens {
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
     #[returns(StateResponse)]
     State {},
 }

--- a/packages/euclid/src/msgs/vlp/base.rs
+++ b/packages/euclid/src/msgs/vlp/base.rs
@@ -302,3 +302,80 @@ pub enum ExecuteMsg {
     CollectConcentratedProtocolFees(VlpConcentratedCollectProtocolFeesMsg),
     Swap(VlpSwapMsg),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::token::{Pair, Token};
+
+    fn concentrated_pool_key(t1: &str, t2: &str, fee: u64, spacing: u64) -> PoolKey {
+        PoolKey {
+            pair: Pair::new(
+                Token::create(t1.to_string()).unwrap(),
+                Token::create(t2.to_string()).unwrap(),
+            )
+            .unwrap(),
+            pool_type: PoolType::Concentrated {
+                fee_tier_bps: fee,
+                tick_spacing: spacing,
+            },
+        }
+    }
+
+    #[test]
+    fn pool_key_to_map_key_roundtrip_table() {
+        // Tokens must be in canonical (lexicographic) order since Pair::new sorts them.
+        let cases = vec![
+            ("tokena", "tokenb", 500, 10),
+            ("abc", "xyz", 3000, 60),
+            ("a", "b", 0, 0),
+            ("aaa", "zzz", 10000, 200),
+        ];
+
+        for (t1, t2, fee, spacing) in cases {
+            let key = concentrated_pool_key(t1, t2, fee, spacing);
+            let encoded = key.to_map_key();
+            let (rt1, rt2, rfee, rspacing) =
+                PoolKey::parse_map_key(&encoded).expect("roundtrip should succeed");
+            assert_eq!(rt1, t1, "token_1 mismatch for ({t1}, {t2})");
+            assert_eq!(rt2, t2, "token_2 mismatch for ({t1}, {t2})");
+            assert_eq!(rfee, fee, "fee mismatch for ({t1}, {t2})");
+            assert_eq!(rspacing, spacing, "spacing mismatch for ({t1}, {t2})");
+        }
+    }
+
+    #[test]
+    fn pool_key_parse_rejects_malformed_keys() {
+        let cases: Vec<(&str, &str)> = vec![
+            ("", "empty string"),
+            ("a\0b", "only two parts"),
+            ("a\0b\0500", "only three parts"),
+            ("a\0b\0500\010\0extra", "five parts"),
+            ("a\0b\0notnum\010", "non-numeric fee"),
+            ("a\0b\0500\0notnum", "non-numeric spacing"),
+        ];
+
+        for (input, label) in cases {
+            assert!(
+                PoolKey::parse_map_key(input).is_none(),
+                "should reject: {label}"
+            );
+        }
+    }
+
+    #[test]
+    fn pool_key_non_concentrated_uses_zero_fee_and_spacing() {
+        let key = PoolKey {
+            pair: Pair::new(
+                Token::create("tokena".to_string()).unwrap(),
+                Token::create("tokenb".to_string()).unwrap(),
+            )
+            .unwrap(),
+            pool_type: PoolType::ConstantProduct {},
+        };
+        let encoded = key.to_map_key();
+        let (_, _, fee, spacing) = PoolKey::parse_map_key(&encoded).unwrap();
+        assert_eq!(fee, 0);
+        assert_eq!(spacing, 0);
+    }
+}

--- a/packages/euclid/src/msgs/vlp/base.rs
+++ b/packages/euclid/src/msgs/vlp/base.rs
@@ -242,6 +242,36 @@ pub struct PoolKey {
     pub pool_type: PoolType,
 }
 
+impl PoolKey {
+    /// Encode this pool key as a null-byte-delimited string suitable for use as a storage map key.
+    pub fn to_map_key(&self) -> String {
+        let (fee_tier_bps, tick_spacing) = match self.pool_type {
+            PoolType::Concentrated {
+                fee_tier_bps,
+                tick_spacing,
+            } => (fee_tier_bps, tick_spacing),
+            _ => (0, 0),
+        };
+        format!(
+            "{}\0{}\0{}\0{}",
+            self.pair.token_1, self.pair.token_2, fee_tier_bps, tick_spacing
+        )
+    }
+
+    /// Decode a null-byte-delimited map key into its component parts.
+    pub fn parse_map_key(key: &str) -> Option<(String, String, u64, u64)> {
+        let mut parts = key.split('\0');
+        let token_1 = parts.next()?.to_string();
+        let token_2 = parts.next()?.to_string();
+        let fee_tier_bps = parts.next()?.parse::<u64>().ok()?;
+        let tick_spacing = parts.next()?.parse::<u64>().ok()?;
+        if parts.next().is_some() {
+            return None;
+        }
+        Some((token_1, token_2, fee_tier_bps, tick_spacing))
+    }
+}
+
 #[cw_serde]
 pub enum PoolConfig {
     Stable {

--- a/packages/euclid/src/msgs/vlp/concentrated/msg.rs
+++ b/packages/euclid/src/msgs/vlp/concentrated/msg.rs
@@ -137,7 +137,6 @@ pub struct Slot0Response {
     pub observation_index: u64,
     pub observation_cardinality: u16,
     pub observation_cardinality_next: u16,
-    pub unlocked: bool,
     pub liquidity: Uint128,
     pub fee_growth_global_0_x128: Uint256,
     pub fee_growth_global_1_x128: Uint256,

--- a/packages/pool/src/pool_functions.rs
+++ b/packages/pool/src/pool_functions.rs
@@ -532,10 +532,11 @@ pub fn pre_swap(
     asset_in: &Token,
     amount_in: Uint128,
     calculation_method: SwapCalculationMethod,
-    test_fail: Option<bool>,
+    _test_fail: Option<bool>,
 ) -> Result<PreSwapResponse, ContractError> {
+    #[cfg(test)]
     ensure!(
-        !test_fail.unwrap_or(false),
+        !_test_fail.unwrap_or(false),
         ContractError::new("Force fail flag")
     );
     // Verify that the asset amount is non-zero

--- a/tests-integration/src/helpers/factory.rs
+++ b/tests-integration/src/helpers/factory.rs
@@ -449,7 +449,7 @@ pub fn list_position_ids(factory: &FactoryContract<MockBase>) -> Result<Vec<Stri
         return Ok(vec![]);
     }
     let tokens: euclid::msgs::position_token::TokensResponse =
-        contract.query(&euclid::msgs::position_token::QueryMsg::AllTokens {})?;
+        contract.query(&euclid::msgs::position_token::QueryMsg::AllTokens { start_after: None, limit: None })?;
     Ok(tokens.tokens)
 }
 

--- a/tests-integration/src/tests_reusable/concentrated_failures.rs
+++ b/tests-integration/src/tests_reusable/concentrated_failures.rs
@@ -66,7 +66,7 @@ fn test_no_ack_does_not_finalize_position() {
     let position_token = get_position_token(&factory).unwrap();
     let tokens = position_token
         .query::<euclid::msgs::position_token::TokensResponse>(
-            &euclid::msgs::position_token::QueryMsg::AllTokens {},
+            &euclid::msgs::position_token::QueryMsg::AllTokens { start_after: None, limit: None },
         )
         .unwrap()
         .tokens;
@@ -148,7 +148,7 @@ fn test_ack_error_rolls_back_pending() {
     let position_token = get_position_token(&factory).unwrap();
     let tokens = position_token
         .query::<euclid::msgs::position_token::TokensResponse>(
-            &euclid::msgs::position_token::QueryMsg::AllTokens {},
+            &euclid::msgs::position_token::QueryMsg::AllTokens { start_after: None, limit: None },
         )
         .unwrap()
         .tokens;

--- a/tests-integration/src/tests_reusable/concentrated_positions.rs
+++ b/tests-integration/src/tests_reusable/concentrated_positions.rs
@@ -61,7 +61,7 @@ fn test_add_liquidity_mints_position_nft(
     let position_token = get_position_token(&factory).unwrap();
     let tokens = position_token
         .query::<euclid::msgs::position_token::TokensResponse>(
-            &euclid::msgs::position_token::QueryMsg::AllTokens {},
+            &euclid::msgs::position_token::QueryMsg::AllTokens { start_after: None, limit: None },
         )
         .unwrap()
         .tokens;

--- a/tests-integration/src/tests_reusable/state_sync.rs
+++ b/tests-integration/src/tests_reusable/state_sync.rs
@@ -284,7 +284,7 @@ pub(crate) fn sync_state_with_concentrated(
         if position_token.address().is_ok() {
             position_token
                 .query::<euclid::msgs::position_token::TokensResponse>(
-                    &euclid::msgs::position_token::QueryMsg::AllTokens {},
+                    &euclid::msgs::position_token::QueryMsg::AllTokens { start_after: None, limit: None },
                 )
                 .unwrap()
                 .tokens


### PR DESCRIPTION
## Summary

Addresses all 20 actionable findings from the CLP security audit across 4 commits.

### High
- **H-01**: CHAIN_LP_TOKENS.load() to .may_load()?.ok_or() with clear "chain X is not registered" error
- **H-02**: Allow single-sided liquidity deposits; downstream math already handles this

### Medium
- **M-01**: Remove vestigial Slot0.unlocked field (CosmWasm has no reentrancy; serde ignores unknown fields)
- **M-02**: NFT mint uses SubMsg::reply_always with rollback of POSITION_ID_TO_METADATA and OWNER_POSITION_SET on failure
- **M-03**: Reject explicit position_id for non-existent positions; new positions must use next_position_id()
- **M-04**: Document IBC metadata divergence as expected cross-chain behavior
- **M-05**: Gate test_fail check behind #[cfg(test)] in concentrated_vlp
- **M-07**: Early return in initialize_position_namespace_if_missing when POSITION_NONCE exists
- **M-08**: Document CONCENTRATED_FUNDS_INFO/FUNDS_INFO singleton safety (synchronous SubMsg replies)
- **M-09**: Replace .load() with .may_load()?.ok_or() in ack_collect_concentrated_fees for clear error

### Low
- **L-01**: Oracle interpolate() returns Result instead of silently defaulting to zero on overflow
- **L-02**: Remove unused COLLATERAL_LP_TOKENS from concentrated_vlp
- **L-03**: Bound next_position_id loop to 1024 iterations
- **L-04/L-08/L-09**: Remove all .unwrap() calls from reply handlers (~12 locations across CLP, factory, router)
- **L-05**: Replace linear decrement-by-1 liquidity fitting with binary search (1024 to ~10 iterations)
- **L-06**: Deduplicate pool_key_to_map_key into PoolKey::to_map_key() / PoolKey::parse_map_key() in euclid package
- **L-07**: Paginate CONCENTRATED_VLPS query matching classic VLPs pattern
- **L-10**: Document fee truncation dust behavior

### Informational
- **I-06**: Add write_observation() to add/remove liquidity handlers for accurate TWAP oracle
- **I-07**: Add start_after/limit pagination to position_token TokensByOwner and AllTokens queries

## Test plan
- [x] cargo check (clean, all contract crates)
- [x] cargo test -p concentrated_vlp (46 passed)
- [x] cargo test -p factory (14 passed)
- [x] cargo test -p router (9 passed)
- [x] cargo test -p position_token (3 passed)
- [x] cargo clippy (no warnings in contract code)
- [ ] cargo test -p tests-integration (full integration suite)