### PR TITLE
fix: UpdateChainTimeout and UpdateDefaultReleaseFee had no auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2908,7 +2908,7 @@ dependencies = [
 
 [[package]]
 name = "router"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",

--- a/contracts/hub/router/Cargo.toml
+++ b/contracts/hub/router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "router"
-version = "0.2.4"
+version = "0.2.5"
 authors = [
   "Anshudhar Kumar Singh <anshudhar2001@gmail.com>",
   "Joe Monem <jmonem@icloud.com>",

--- a/contracts/hub/router/src/execute/base.rs
+++ b/contracts/hub/router/src/execute/base.rs
@@ -145,6 +145,10 @@ pub fn execute_manage_router_state(
         ManageRouterState::UpdateDefaultReleaseFee {
             default_release_fee,
         } => {
+            ensure!(
+                info.sender == admins.fee_admin,
+                ContractError::Unauthorized {}
+            );
             DEFAULT_RELEASE_FEE.save(deps.storage, &default_release_fee)?;
             Ok(Response::new()
                 .add_attribute("method", "update_default_release_fee")
@@ -185,6 +189,10 @@ pub fn execute_manage_router_state(
                 .add_attribute("locked", "false"))
         }
         ManageRouterState::UpdateChainTimeout { chain_uid, timeout } => {
+            ensure!(
+                info.sender == admins.general_admin,
+                ContractError::Unauthorized {}
+            );
             CHAIN_TIMEOUT_SECONDS.save(deps.storage, chain_uid.clone(), &timeout)?;
             Ok(Response::new()
                 .add_attribute("method", "update_chain_timeout")

--- a/contracts/hub/router/src/tests.rs
+++ b/contracts/hub/router/src/tests.rs
@@ -161,9 +161,9 @@ mod tests {
         let random = deps.api.addr_make("random");
         let creator = deps.api.addr_make("creator");
         let info = message_info(&creator, &[]);
-        init(deps.as_mut(), info);
+        init(deps.as_mut(), info.clone());
 
-        // UpdateDefaultReleaseFee: no require guard in the contract.
+        // UpdateDefaultReleaseFee: unauthorized caller is rejected.
         let err = execute(
             deps.as_mut(),
             mock_env(),
@@ -175,7 +175,18 @@ mod tests {
         .unwrap_err();
         assert_eq!(err, ContractError::Unauthorized {});
 
-        // UpdateChainTimeout: no auth guard either.
+        // UpdateDefaultReleaseFee: fee_admin (creator) succeeds.
+        execute(
+            deps.as_mut(),
+            mock_env(),
+            info.clone(),
+            ExecuteMsg::ManageRouterState(ManageRouterState::UpdateDefaultReleaseFee {
+                default_release_fee: Uint128::new(42),
+            }),
+        )
+        .unwrap();
+
+        // UpdateChainTimeout: unauthorized caller is rejected.
         let err = execute(
             deps.as_mut(),
             mock_env(),
@@ -187,5 +198,17 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(err, ContractError::Unauthorized {});
+
+        // UpdateChainTimeout: general_admin (creator) succeeds.
+        execute(
+            deps.as_mut(),
+            mock_env(),
+            info,
+            ExecuteMsg::ManageRouterState(ManageRouterState::UpdateChainTimeout {
+                chain_uid: ChainUid::create("chain1".to_string()).unwrap(),
+                timeout: 600,
+            }),
+        )
+        .unwrap();
     }
 }

--- a/contracts/hub/router/src/tests.rs
+++ b/contracts/hub/router/src/tests.rs
@@ -5,12 +5,15 @@ mod tests {
     use crate::contract::{execute, instantiate};
     use crate::state::{State, ADMIN, STATE};
     use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env};
-    use cosmwasm_std::{from_json, Addr, CosmosMsg, DepsMut, IbcMsg, MessageInfo, Response};
+    use cosmwasm_std::{
+        from_json, Addr, CosmosMsg, DepsMut, IbcMsg, MessageInfo, Response, Uint128,
+    };
     use euclid::admin::EuclidAdmin;
     use euclid::chain::ChainUid;
     use euclid::error::ContractError;
     use euclid::msgs::router::{
-        ExecuteMsg, InstantiateMsg, RegisterFactoryChainNative, RegisterFactoryChainType,
+        ExecuteMsg, InstantiateMsg, ManageRouterState, RegisterFactoryChainNative,
+        RegisterFactoryChainType,
     };
     use euclid_ibc::factory_ibc::FactoryCrossChainExecuteMsg;
 
@@ -150,5 +153,39 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_unguarded_manage_variants_accept_any_caller() {
+        let mut deps = mock_dependencies();
+        let random = deps.api.addr_make("random");
+        let creator = deps.api.addr_make("creator");
+        let info = message_info(&creator, &[]);
+        init(deps.as_mut(), info);
+
+        // UpdateDefaultReleaseFee: no require guard in the contract.
+        let err = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&random, &[]),
+            ExecuteMsg::ManageRouterState(ManageRouterState::UpdateDefaultReleaseFee {
+                default_release_fee: Uint128::new(42),
+            }),
+        )
+        .unwrap_err();
+        assert_eq!(err, ContractError::Unauthorized {});
+
+        // UpdateChainTimeout: no auth guard either.
+        let err = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&random, &[]),
+            ExecuteMsg::ManageRouterState(ManageRouterState::UpdateChainTimeout {
+                chain_uid: ChainUid::create("chain1".to_string()).unwrap(),
+                timeout: 600,
+            }),
+        )
+        .unwrap_err();
+        assert_eq!(err, ContractError::Unauthorized {});
     }
 }


### PR DESCRIPTION
## Summary
- `UpdateDefaultReleaseFee` was missing an authorization check — now requires `fee_admin`
- `UpdateChainTimeout` was missing an authorization check — now requires `general_admin`
- Added unit tests confirming unauthorized callers are rejected for both variants

## Test plan
- [x] Verify `test_unguarded_manage_variants_accept_any_caller` passes
- [x] Verify authorized callers (fee_admin / general_admin) can still execute these state updates

🤖 Generated with [Claude Code](https://claude.ai/code)