### PR TITLE
fix: enforce CrossChainUser address validation across contracts

### DIFF
--- a/contracts/hub/meta_transaction/src/execute.rs
+++ b/contracts/hub/meta_transaction/src/execute.rs
@@ -145,6 +145,7 @@ pub fn execute_meta_transaction(
         meta_transaction.data.signer_chain_uid.clone(),
         meta_transaction.data.signer_address.clone(),
     );
+    verified_sender.validate()?;
 
     for call_data in meta_transaction.data.call_data {
         let meta_receive = MetaReceive {

--- a/contracts/hub/meta_transaction/src/execute.rs
+++ b/contracts/hub/meta_transaction/src/execute.rs
@@ -145,6 +145,7 @@ pub fn execute_meta_transaction(
         meta_transaction.data.signer_chain_uid.clone(),
         meta_transaction.data.signer_address.clone(),
     );
+    // Reject mixed-case or empty addresses before dispatching calls
     verified_sender.validate()?;
 
     for call_data in meta_transaction.data.call_data {

--- a/contracts/hub/router/src/ibc/ack_and_timeout.rs
+++ b/contracts/hub/router/src/ibc/ack_and_timeout.rs
@@ -43,6 +43,9 @@ pub fn reusable_internal_ack_call(
         } => {
             let res = from_json(ack)?;
             let recipient = CrossChainUser::new(chain_uid, recipient.to_string());
+            // Reject mixed-case or empty addresses from IBC packet data
+            sender.validate()?;
+            recipient.validate()?;
             ibc_ack_release_escrow(deps, env, sender, amount, token, res, recipient, tx_id)?
         }
     };

--- a/contracts/hub/router/src/ibc/receive/base.rs
+++ b/contracts/hub/router/src/ibc/receive/base.rs
@@ -34,6 +34,8 @@ pub fn reusable_internal_call(
         ContractError::DeregisteredChain {}
     );
     let tx_id = msg.get_tx_id();
+    // Reject mixed-case or empty addresses from IBC packet data
+    msg.get_sender().validate()?;
 
     let mut response = match msg {
         RouterCrossChainExecuteMsg::RegisterDenom {

--- a/contracts/hub/virtual_balance/src/contract.rs
+++ b/contracts/hub/virtual_balance/src/contract.rs
@@ -5,8 +5,9 @@ use cw2::set_contract_version;
 use euclid::admin::EuclidAdmin;
 
 use crate::execute::{
-    execute_approve, execute_burn, execute_mint, execute_remove_zero_state_values,
-    execute_transfer, execute_update_admin, execute_update_router,
+    execute_approve, execute_burn, execute_mint, execute_normalize_balance_keys,
+    execute_remove_zero_state_values, execute_transfer, execute_update_admin,
+    execute_update_router,
 };
 use crate::query::{
     query_admin, query_all_balances, query_allowance, query_balance, query_state,
@@ -64,6 +65,9 @@ pub fn execute(
         ExecuteMsg::Approve(msg) => execute_approve(deps, info, msg),
         ExecuteMsg::RemoveZeroStateValues { start_after, limit } => {
             execute_remove_zero_state_values(deps, info, start_after, limit)
+        }
+        ExecuteMsg::NormalizeBalanceKeys { start_after, limit } => {
+            execute_normalize_balance_keys(deps, info, start_after, limit)
         }
     }
 }

--- a/contracts/hub/virtual_balance/src/execute.rs
+++ b/contracts/hub/virtual_balance/src/execute.rs
@@ -28,6 +28,7 @@ pub fn execute_mint(
     ensure!(info.sender == state.router, ContractError::Unauthorized {});
     // Zero amounts not allowed
     ensure!(!msg.amount.is_zero(), ContractError::ZeroAssetAmount {});
+    // Reject mixed-case or empty addresses before mutating state
     msg.balance_key.cross_chain_user.validate()?;
 
     let key = msg.balance_key.clone().to_serialized_balance_key();
@@ -68,6 +69,7 @@ pub fn execute_burn(
 
     // Zero amounts not allowed
     ensure!(!msg.amount.is_zero(), ContractError::ZeroAssetAmount {});
+    // Reject mixed-case or empty addresses before mutating state
     msg.balance_key.cross_chain_user.validate()?;
 
     let key = msg.balance_key.clone().to_serialized_balance_key();
@@ -120,6 +122,7 @@ pub fn execute_transfer(
     } else {
         CrossChainUser::new(ChainUid::vsl_chain_uid()?, info.sender.to_string())
     };
+    // Validate all CrossChainUser fields to reject mixed-case or empty addresses
     sender.validate()?;
     transfer_msg.to.validate()?;
 
@@ -340,6 +343,7 @@ pub fn execute_approve(
     } else {
         CrossChainUser::new(vsl_chain_uid.clone(), info.sender.to_string())
     };
+    // Reject mixed-case or empty addresses before mutating state
     spender.validate()?;
     owner.validate()?;
 
@@ -430,6 +434,8 @@ pub fn execute_remove_zero_state_values(
     Ok(Response::new().add_attribute("action", "execute_remove_zero_state_values"))
 }
 
+/// Migrates mixed-case balance/allowance keys to lowercase.
+/// Call repeatedly with pagination until normalized_count returns 0.
 pub fn execute_normalize_balance_keys(
     deps: DepsMut,
     info: MessageInfo,
@@ -442,11 +448,12 @@ pub fn execute_normalize_balance_keys(
         ContractError::Unauthorized {}
     );
 
+    // Default to 100 to stay within gas limits on production chains
     let limit = limit.unwrap_or(100) as usize;
     let start = start_after.map(Bound::exclusive);
     let mut normalized_count: u32 = 0;
 
-    // Normalize BALANCES
+    // Collect first to avoid mutating storage while iterating
     let balance_entries: Vec<(SerializedBalanceKey, Uint128)> = BALANCES
         .range(deps.storage, start.clone(), None, Order::Ascending)
         .take(limit)
@@ -457,20 +464,19 @@ pub fn execute_normalize_balance_keys(
         let (chain_uid, address, token_id) = key.clone();
         let lowercase_address = address.to_lowercase();
         if lowercase_address != address {
+            // Remove the mixed-case entry
             BALANCES.remove(deps.storage, key);
+            // Add balance to the lowercase key, combining with any existing balance
             let normalized_key: SerializedBalanceKey = (chain_uid, lowercase_address, token_id);
-            let existing = BALANCES
-                .may_load(deps.storage, normalized_key.clone())?
-                .unwrap_or(Uint128::zero());
-            let combined = existing.checked_add(balance)?;
-            if !combined.is_zero() {
-                BALANCES.save(deps.storage, normalized_key, &combined)?;
-            }
+            BALANCES.update(deps.storage, normalized_key, |existing| {
+                let combined = existing.unwrap_or(Uint128::zero()).checked_add(balance)?;
+                Ok::<_, ContractError>(combined)
+            })?;
             normalized_count += 1;
         }
     }
 
-    // Normalize ALLOWANCES
+    // Collect first to avoid mutating storage while iterating
     let allowance_entries: Vec<(SerializedBalanceKey, _)> = ALLOWANCES
         .range(deps.storage, start, None, Order::Ascending)
         .take(limit)
@@ -483,6 +489,7 @@ pub fn execute_normalize_balance_keys(
         if lowercase_address != address {
             ALLOWANCES.remove(deps.storage, key);
             let normalized_key: SerializedBalanceKey = (chain_uid, lowercase_address, token_id);
+            // Only write if no lowercase entry exists yet (avoid overwriting a valid allowance)
             if !ALLOWANCES.has(deps.storage, normalized_key.clone()) {
                 ALLOWANCES.save(deps.storage, normalized_key, &allowance)?;
             }

--- a/contracts/hub/virtual_balance/src/execute.rs
+++ b/contracts/hub/virtual_balance/src/execute.rs
@@ -435,7 +435,10 @@ pub fn execute_remove_zero_state_values(
 }
 
 /// Migrates mixed-case balance/allowance keys to lowercase.
-/// Call repeatedly with pagination until normalized_count returns 0.
+/// Call repeatedly with `start_after: None` until both
+/// `normalized_balances` and `normalized_allowances` return "0".
+/// Note: the `start_after` cursor applies independently to both BALANCES
+/// and ALLOWANCES ranges, so for simplest usage pass `None` each call.
 pub fn execute_normalize_balance_keys(
     deps: DepsMut,
     info: MessageInfo,
@@ -451,14 +454,22 @@ pub fn execute_normalize_balance_keys(
     // Default to 100 to stay within gas limits on production chains
     let limit = limit.unwrap_or(100) as usize;
     let start = start_after.map(Bound::exclusive);
-    let mut normalized_count: u32 = 0;
+    let mut normalized_balances: u32 = 0;
+    let mut normalized_allowances: u32 = 0;
+    let mut skipped_errors: u32 = 0;
 
-    // Collect first to avoid mutating storage while iterating
-    let balance_entries: Vec<(SerializedBalanceKey, Uint128)> = BALANCES
+    // Collect first to avoid mutating storage while iterating.
+    // Deserialization errors are counted (skipped_errors) rather than silently dropped.
+    let mut balance_entries: Vec<(SerializedBalanceKey, Uint128)> = Vec::new();
+    for result in BALANCES
         .range(deps.storage, start.clone(), None, Order::Ascending)
         .take(limit)
-        .filter_map(|result| result.ok())
-        .collect();
+    {
+        match result {
+            Ok(entry) => balance_entries.push(entry),
+            Err(_) => skipped_errors += 1,
+        }
+    }
 
     for (key, balance) in balance_entries {
         let (chain_uid, address, token_id) = key.clone();
@@ -472,16 +483,21 @@ pub fn execute_normalize_balance_keys(
                 let combined = existing.unwrap_or(Uint128::zero()).checked_add(balance)?;
                 Ok::<_, ContractError>(combined)
             })?;
-            normalized_count += 1;
+            normalized_balances += 1;
         }
     }
 
     // Collect first to avoid mutating storage while iterating
-    let allowance_entries: Vec<(SerializedBalanceKey, _)> = ALLOWANCES
+    let mut allowance_entries: Vec<(SerializedBalanceKey, _)> = Vec::new();
+    for result in ALLOWANCES
         .range(deps.storage, start, None, Order::Ascending)
         .take(limit)
-        .filter_map(|result| result.ok())
-        .collect();
+    {
+        match result {
+            Ok(entry) => allowance_entries.push(entry),
+            Err(_) => skipped_errors += 1,
+        }
+    }
 
     for (key, allowance) in allowance_entries {
         let (chain_uid, address, token_id) = key.clone();
@@ -489,15 +505,23 @@ pub fn execute_normalize_balance_keys(
         if lowercase_address != address {
             ALLOWANCES.remove(deps.storage, key);
             let normalized_key: SerializedBalanceKey = (chain_uid, lowercase_address, token_id);
-            // Only write if no lowercase entry exists yet (avoid overwriting a valid allowance)
-            if !ALLOWANCES.has(deps.storage, normalized_key.clone()) {
+            // On collision, keep the higher allowance to avoid silently dropping approved value
+            if let Some(existing) = ALLOWANCES.may_load(deps.storage, normalized_key.clone())? {
+                let merged = Allowance {
+                    amount: existing.amount.max(allowance.amount),
+                    spender: existing.spender,
+                };
+                ALLOWANCES.save(deps.storage, normalized_key, &merged)?;
+            } else {
                 ALLOWANCES.save(deps.storage, normalized_key, &allowance)?;
             }
-            normalized_count += 1;
+            normalized_allowances += 1;
         }
     }
 
     Ok(Response::new()
         .add_attribute("action", "execute_normalize_balance_keys")
-        .add_attribute("normalized_count", normalized_count.to_string()))
+        .add_attribute("normalized_balances", normalized_balances.to_string())
+        .add_attribute("normalized_allowances", normalized_allowances.to_string())
+        .add_attribute("skipped_errors", skipped_errors.to_string()))
 }

--- a/contracts/hub/virtual_balance/src/execute.rs
+++ b/contracts/hub/virtual_balance/src/execute.rs
@@ -28,6 +28,7 @@ pub fn execute_mint(
     ensure!(info.sender == state.router, ContractError::Unauthorized {});
     // Zero amounts not allowed
     ensure!(!msg.amount.is_zero(), ContractError::ZeroAssetAmount {});
+    msg.balance_key.cross_chain_user.validate()?;
 
     let key = msg.balance_key.clone().to_serialized_balance_key();
 
@@ -67,6 +68,7 @@ pub fn execute_burn(
 
     // Zero amounts not allowed
     ensure!(!msg.amount.is_zero(), ContractError::ZeroAssetAmount {});
+    msg.balance_key.cross_chain_user.validate()?;
 
     let key = msg.balance_key.clone().to_serialized_balance_key();
     let old_balance =
@@ -118,8 +120,11 @@ pub fn execute_transfer(
     } else {
         CrossChainUser::new(ChainUid::vsl_chain_uid()?, info.sender.to_string())
     };
+    sender.validate()?;
+    transfer_msg.to.validate()?;
 
     let mut response = if let Some(from) = transfer_msg.from {
+        from.validate()?;
         let attributes = _deduct_allowance(
             deps,
             &sender,
@@ -335,6 +340,8 @@ pub fn execute_approve(
     } else {
         CrossChainUser::new(vsl_chain_uid.clone(), info.sender.to_string())
     };
+    spender.validate()?;
+    owner.validate()?;
 
     // Ensure that spender and owner are not the same
     ensure!(spender != owner, ContractError::SameAddress {});
@@ -421,4 +428,71 @@ pub fn execute_remove_zero_state_values(
     }
 
     Ok(Response::new().add_attribute("action", "execute_remove_zero_state_values"))
+}
+
+pub fn execute_normalize_balance_keys(
+    deps: DepsMut,
+    info: MessageInfo,
+    start_after: Option<SerializedBalanceKey>,
+    limit: Option<u32>,
+) -> Result<Response, ContractError> {
+    let admin = ADMIN.load(deps.storage)?;
+    ensure!(
+        admin.general_admin == info.sender,
+        ContractError::Unauthorized {}
+    );
+
+    let limit = limit.unwrap_or(100) as usize;
+    let start = start_after.map(Bound::exclusive);
+    let mut normalized_count: u32 = 0;
+
+    // Normalize BALANCES
+    let balance_entries: Vec<(SerializedBalanceKey, Uint128)> = BALANCES
+        .range(deps.storage, start.clone(), None, Order::Ascending)
+        .take(limit)
+        .filter_map(|result| result.ok())
+        .collect();
+
+    for (key, balance) in balance_entries {
+        let (chain_uid, address, token_id) = key.clone();
+        let lowercase_address = address.to_lowercase();
+        if lowercase_address != address {
+            BALANCES.remove(deps.storage, key);
+            let normalized_key: SerializedBalanceKey =
+                (chain_uid, lowercase_address, token_id);
+            let existing = BALANCES
+                .may_load(deps.storage, normalized_key.clone())?
+                .unwrap_or(Uint128::zero());
+            let combined = existing.checked_add(balance)?;
+            if !combined.is_zero() {
+                BALANCES.save(deps.storage, normalized_key, &combined)?;
+            }
+            normalized_count += 1;
+        }
+    }
+
+    // Normalize ALLOWANCES
+    let allowance_entries: Vec<(SerializedBalanceKey, _)> = ALLOWANCES
+        .range(deps.storage, start, None, Order::Ascending)
+        .take(limit)
+        .filter_map(|result| result.ok())
+        .collect();
+
+    for (key, allowance) in allowance_entries {
+        let (chain_uid, address, token_id) = key.clone();
+        let lowercase_address = address.to_lowercase();
+        if lowercase_address != address {
+            ALLOWANCES.remove(deps.storage, key);
+            let normalized_key: SerializedBalanceKey =
+                (chain_uid, lowercase_address, token_id);
+            if !ALLOWANCES.has(deps.storage, normalized_key.clone()) {
+                ALLOWANCES.save(deps.storage, normalized_key, &allowance)?;
+            }
+            normalized_count += 1;
+        }
+    }
+
+    Ok(Response::new()
+        .add_attribute("action", "execute_normalize_balance_keys")
+        .add_attribute("normalized_count", normalized_count.to_string()))
 }

--- a/contracts/hub/virtual_balance/src/execute.rs
+++ b/contracts/hub/virtual_balance/src/execute.rs
@@ -458,8 +458,7 @@ pub fn execute_normalize_balance_keys(
         let lowercase_address = address.to_lowercase();
         if lowercase_address != address {
             BALANCES.remove(deps.storage, key);
-            let normalized_key: SerializedBalanceKey =
-                (chain_uid, lowercase_address, token_id);
+            let normalized_key: SerializedBalanceKey = (chain_uid, lowercase_address, token_id);
             let existing = BALANCES
                 .may_load(deps.storage, normalized_key.clone())?
                 .unwrap_or(Uint128::zero());
@@ -483,8 +482,7 @@ pub fn execute_normalize_balance_keys(
         let lowercase_address = address.to_lowercase();
         if lowercase_address != address {
             ALLOWANCES.remove(deps.storage, key);
-            let normalized_key: SerializedBalanceKey =
-                (chain_uid, lowercase_address, token_id);
+            let normalized_key: SerializedBalanceKey = (chain_uid, lowercase_address, token_id);
             if !ALLOWANCES.has(deps.storage, normalized_key.clone()) {
                 ALLOWANCES.save(deps.storage, normalized_key, &allowance)?;
             }

--- a/contracts/hub/virtual_balance/src/tests.rs
+++ b/contracts/hub/virtual_balance/src/tests.rs
@@ -464,7 +464,12 @@ mod tests {
             let router = deps.api.addr_make("router");
             let admin = EuclidAdmin::default(router.clone());
             STATE
-                .save(&mut deps.storage, &State { router: router.clone() })
+                .save(
+                    &mut deps.storage,
+                    &State {
+                        router: router.clone(),
+                    },
+                )
                 .unwrap();
             ADMIN.save(&mut deps.storage, &admin).unwrap();
             router
@@ -551,14 +556,10 @@ mod tests {
             let env = mock_env();
             let router = setup_with_state(&mut deps);
 
-            let owner = CrossChainUser::new(
-                ChainUid::vsl_chain_uid().unwrap(),
-                "owner".to_string(),
-            );
-            let mixed_case_spender = CrossChainUser::new(
-                ChainUid::vsl_chain_uid().unwrap(),
-                "Spender".to_string(),
-            );
+            let owner =
+                CrossChainUser::new(ChainUid::vsl_chain_uid().unwrap(), "owner".to_string());
+            let mixed_case_spender =
+                CrossChainUser::new(ChainUid::vsl_chain_uid().unwrap(), "Spender".to_string());
 
             let approve_msg = ExecuteMsg::Approve(ExecuteApprove {
                 amount: Uint128::new(10),
@@ -671,8 +672,7 @@ mod tests {
             let chain = ChainUid::create("cosmos".to_string()).unwrap();
             let key1: (ChainUid, String, String) =
                 (chain.clone(), "AAAA".to_string(), "eucl".to_string());
-            let key2: (ChainUid, String, String) =
-                (chain, "BBBB".to_string(), "eucl".to_string());
+            let key2: (ChainUid, String, String) = (chain, "BBBB".to_string(), "eucl".to_string());
 
             BALANCES
                 .save(&mut deps.storage, key1.clone(), &Uint128::new(10))

--- a/contracts/hub/virtual_balance/src/tests.rs
+++ b/contracts/hub/virtual_balance/src/tests.rs
@@ -605,7 +605,7 @@ mod tests {
             assert_eq!(
                 res.attributes
                     .iter()
-                    .find(|a| a.key == "normalized_count")
+                    .find(|a| a.key == "normalized_balances")
                     .unwrap()
                     .value,
                 "1"
@@ -694,7 +694,7 @@ mod tests {
             assert_eq!(
                 res.attributes
                     .iter()
-                    .find(|a| a.key == "normalized_count")
+                    .find(|a| a.key == "normalized_balances")
                     .unwrap()
                     .value,
                 "1"
@@ -717,7 +717,7 @@ mod tests {
             assert_eq!(
                 res.attributes
                     .iter()
-                    .find(|a| a.key == "normalized_count")
+                    .find(|a| a.key == "normalized_balances")
                     .unwrap()
                     .value,
                 "1"
@@ -770,11 +770,75 @@ mod tests {
             assert_eq!(
                 res.attributes
                     .iter()
-                    .find(|a| a.key == "normalized_count")
+                    .find(|a| a.key == "normalized_balances")
                     .unwrap()
                     .value,
                 "0"
             );
+        }
+
+        #[test]
+        fn test_normalize_allowance_keeps_max_on_collision() {
+            let mut deps = mock_dependencies();
+            let _router = setup_with_state(&mut deps);
+            let env = mock_env();
+            let admin = ADMIN.load(&deps.storage).unwrap();
+
+            let chain = ChainUid::create("cosmos".to_string()).unwrap();
+            let spender =
+                CrossChainUser::new(ChainUid::vsl_chain_uid().unwrap(), "spender".to_string());
+
+            let mixed_key: (ChainUid, String, String) =
+                (chain.clone(), "Owner".to_string(), "eucl".to_string());
+            let lowercase_key: (ChainUid, String, String) =
+                (chain, "owner".to_string(), "eucl".to_string());
+
+            // Mixed-case entry has higher allowance
+            ALLOWANCES
+                .save(
+                    &mut deps.storage,
+                    mixed_key.clone(),
+                    &Allowance {
+                        amount: Uint128::new(200),
+                        spender: spender.clone(),
+                    },
+                )
+                .unwrap();
+            // Lowercase entry has lower allowance
+            ALLOWANCES
+                .save(
+                    &mut deps.storage,
+                    lowercase_key.clone(),
+                    &Allowance {
+                        amount: Uint128::new(50),
+                        spender: spender.clone(),
+                    },
+                )
+                .unwrap();
+
+            let msg = ExecuteMsg::NormalizeBalanceKeys {
+                start_after: None,
+                limit: None,
+            };
+            let info = MessageInfo {
+                sender: admin.general_admin,
+                funds: vec![],
+            };
+            let res = execute(deps.as_mut(), env, info, msg).unwrap();
+            assert_eq!(
+                res.attributes
+                    .iter()
+                    .find(|a| a.key == "normalized_allowances")
+                    .unwrap()
+                    .value,
+                "1"
+            );
+
+            // Mixed-case removed
+            assert!(ALLOWANCES.load(&deps.storage, mixed_key).is_err());
+            // Keeps max(200, 50) = 200
+            let result = ALLOWANCES.load(&deps.storage, lowercase_key).unwrap();
+            assert_eq!(result.amount, Uint128::new(200));
         }
     }
 }

--- a/contracts/hub/virtual_balance/src/tests.rs
+++ b/contracts/hub/virtual_balance/src/tests.rs
@@ -450,4 +450,331 @@ mod tests {
         assert!(BALANCES.load(&deps.storage, key("owner")).is_err());
         assert!(BALANCES.load(&deps.storage, key("owner2")).is_ok());
     }
+
+    mod cross_chain_user_test {
+        use super::*;
+
+        fn setup_with_state(
+            deps: &mut cosmwasm_std::OwnedDeps<
+                cosmwasm_std::MemoryStorage,
+                cosmwasm_std::testing::MockApi,
+                MockQuerier,
+            >,
+        ) -> Addr {
+            let router = deps.api.addr_make("router");
+            let admin = EuclidAdmin::default(router.clone());
+            STATE
+                .save(&mut deps.storage, &State { router: router.clone() })
+                .unwrap();
+            ADMIN.save(&mut deps.storage, &admin).unwrap();
+            router
+        }
+
+        #[test]
+        fn test_mint_rejects_mixed_case() {
+            let mut deps = mock_dependencies();
+            let env = mock_env();
+            let router = setup_with_state(&mut deps);
+            let info = MessageInfo {
+                sender: router,
+                funds: vec![],
+            };
+
+            let mixed_case_user = CrossChainUser::new(
+                ChainUid::create("cosmos".to_string()).unwrap(),
+                "Cosmos1AbCdEf".to_string(),
+            );
+            let balance_key = BalanceKey {
+                cross_chain_user: mixed_case_user,
+                token_id: "eucl".to_string(),
+            };
+
+            let msg = ExecuteMsg::Mint(ExecuteMint {
+                amount: Uint128::new(100),
+                balance_key,
+            });
+
+            let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+            assert!(err.to_string().contains("Address must be lowercase"));
+        }
+
+        #[test]
+        fn test_transfer_rejects_mixed_case_to() {
+            let mut deps = mock_dependencies();
+            let env = mock_env();
+            let router = setup_with_state(&mut deps);
+
+            // First mint some tokens to a valid user
+            let valid_user = CrossChainUser::new(
+                ChainUid::create("cosmos".to_string()).unwrap(),
+                "cosmos1sender".to_string(),
+            );
+            let balance_key = BalanceKey {
+                cross_chain_user: valid_user.clone(),
+                token_id: "eucl".to_string(),
+            };
+            let mint_msg = ExecuteMsg::Mint(ExecuteMint {
+                amount: Uint128::new(100),
+                balance_key,
+            });
+            let info = MessageInfo {
+                sender: router.clone(),
+                funds: vec![],
+            };
+            execute(deps.as_mut(), env.clone(), info, mint_msg).unwrap();
+
+            // Try to transfer to a mixed-case address
+            let mixed_case_to = CrossChainUser::new(
+                ChainUid::create("cosmos".to_string()).unwrap(),
+                "Cosmos1MiXeD".to_string(),
+            );
+            let transfer_msg = ExecuteMsg::Transfer(ExecuteTransfer {
+                amount: Uint128::new(50),
+                token_id: "eucl".to_string(),
+                sender: Some(valid_user),
+                to: mixed_case_to,
+                from: None,
+                msg: None,
+            });
+            let info = MessageInfo {
+                sender: router,
+                funds: vec![],
+            };
+
+            let err = execute(deps.as_mut(), env, info, transfer_msg).unwrap_err();
+            assert!(err.to_string().contains("Address must be lowercase"));
+        }
+
+        #[test]
+        fn test_approve_rejects_mixed_case_spender() {
+            let mut deps = mock_dependencies();
+            let env = mock_env();
+            let router = setup_with_state(&mut deps);
+
+            let owner = CrossChainUser::new(
+                ChainUid::vsl_chain_uid().unwrap(),
+                "owner".to_string(),
+            );
+            let mixed_case_spender = CrossChainUser::new(
+                ChainUid::vsl_chain_uid().unwrap(),
+                "Spender".to_string(),
+            );
+
+            let approve_msg = ExecuteMsg::Approve(ExecuteApprove {
+                amount: Uint128::new(10),
+                token_id: "eucl".to_string(),
+                spender: mixed_case_spender,
+                owner: owner,
+            });
+            let info = MessageInfo {
+                sender: router,
+                funds: vec![],
+            };
+
+            let err = execute(deps.as_mut(), env, info, approve_msg).unwrap_err();
+            assert!(err.to_string().contains("Address must be lowercase"));
+        }
+
+        #[test]
+        fn test_normalize_balance_keys_basic() {
+            let mut deps = mock_dependencies();
+            let router = setup_with_state(&mut deps);
+            let env = mock_env();
+            let admin = ADMIN.load(&deps.storage).unwrap();
+
+            // Directly write a mixed-case balance entry
+            let mixed_key: (ChainUid, String, String) = (
+                ChainUid::create("cosmos".to_string()).unwrap(),
+                "Cosmos1AbC".to_string(),
+                "eucl".to_string(),
+            );
+            BALANCES
+                .save(&mut deps.storage, mixed_key.clone(), &Uint128::new(100))
+                .unwrap();
+
+            let msg = ExecuteMsg::NormalizeBalanceKeys {
+                start_after: None,
+                limit: None,
+            };
+            let info = MessageInfo {
+                sender: admin.general_admin,
+                funds: vec![],
+            };
+            let res = execute(deps.as_mut(), env, info, msg).unwrap();
+            assert_eq!(
+                res.attributes
+                    .iter()
+                    .find(|a| a.key == "normalized_count")
+                    .unwrap()
+                    .value,
+                "1"
+            );
+
+            // Mixed-case entry removed
+            assert!(BALANCES.load(&deps.storage, mixed_key).is_err());
+            // Lowercase entry exists with same balance
+            let normalized_key: (ChainUid, String, String) = (
+                ChainUid::create("cosmos".to_string()).unwrap(),
+                "cosmos1abc".to_string(),
+                "eucl".to_string(),
+            );
+            assert_eq!(
+                BALANCES.load(&deps.storage, normalized_key).unwrap(),
+                Uint128::new(100)
+            );
+        }
+
+        #[test]
+        fn test_normalize_balance_keys_combines_balances() {
+            let mut deps = mock_dependencies();
+            let _router = setup_with_state(&mut deps);
+            let env = mock_env();
+            let admin = ADMIN.load(&deps.storage).unwrap();
+
+            let chain = ChainUid::create("cosmos".to_string()).unwrap();
+            let mixed_key: (ChainUid, String, String) =
+                (chain.clone(), "Cosmos1AbC".to_string(), "eucl".to_string());
+            let lowercase_key: (ChainUid, String, String) =
+                (chain, "cosmos1abc".to_string(), "eucl".to_string());
+
+            BALANCES
+                .save(&mut deps.storage, mixed_key.clone(), &Uint128::new(100))
+                .unwrap();
+            BALANCES
+                .save(&mut deps.storage, lowercase_key.clone(), &Uint128::new(50))
+                .unwrap();
+
+            let msg = ExecuteMsg::NormalizeBalanceKeys {
+                start_after: None,
+                limit: None,
+            };
+            let info = MessageInfo {
+                sender: admin.general_admin,
+                funds: vec![],
+            };
+            execute(deps.as_mut(), env, info, msg).unwrap();
+
+            assert!(BALANCES.load(&deps.storage, mixed_key).is_err());
+            assert_eq!(
+                BALANCES.load(&deps.storage, lowercase_key).unwrap(),
+                Uint128::new(150)
+            );
+        }
+
+        #[test]
+        fn test_normalize_balance_keys_pagination() {
+            let mut deps = mock_dependencies();
+            setup_with_state(&mut deps);
+            let env = mock_env();
+            let admin = ADMIN.load(&deps.storage).unwrap();
+
+            let chain = ChainUid::create("cosmos".to_string()).unwrap();
+            let key1: (ChainUid, String, String) =
+                (chain.clone(), "AAAA".to_string(), "eucl".to_string());
+            let key2: (ChainUid, String, String) =
+                (chain, "BBBB".to_string(), "eucl".to_string());
+
+            BALANCES
+                .save(&mut deps.storage, key1.clone(), &Uint128::new(10))
+                .unwrap();
+            BALANCES
+                .save(&mut deps.storage, key2.clone(), &Uint128::new(20))
+                .unwrap();
+
+            // Process only 1 entry
+            let msg = ExecuteMsg::NormalizeBalanceKeys {
+                start_after: None,
+                limit: Some(1),
+            };
+            let info = MessageInfo {
+                sender: admin.general_admin.clone(),
+                funds: vec![],
+            };
+            let res = execute(deps.as_mut(), env.clone(), info, msg).unwrap();
+            assert_eq!(
+                res.attributes
+                    .iter()
+                    .find(|a| a.key == "normalized_count")
+                    .unwrap()
+                    .value,
+                "1"
+            );
+
+            // key1 should be normalized, key2 still mixed
+            assert!(BALANCES.load(&deps.storage, key1.clone()).is_err());
+            assert!(BALANCES.load(&deps.storage, key2.clone()).is_ok());
+
+            // Process remaining with start_after
+            let msg = ExecuteMsg::NormalizeBalanceKeys {
+                start_after: Some(key1),
+                limit: Some(10),
+            };
+            let info = MessageInfo {
+                sender: admin.general_admin,
+                funds: vec![],
+            };
+            let res = execute(deps.as_mut(), env, info, msg).unwrap();
+            assert_eq!(
+                res.attributes
+                    .iter()
+                    .find(|a| a.key == "normalized_count")
+                    .unwrap()
+                    .value,
+                "1"
+            );
+            assert!(BALANCES.load(&deps.storage, key2).is_err());
+        }
+
+        #[test]
+        fn test_normalize_balance_keys_admin_gated() {
+            let mut deps = mock_dependencies();
+            setup_with_state(&mut deps);
+            let env = mock_env();
+
+            let not_admin = deps.api.addr_make("not_admin");
+            let msg = ExecuteMsg::NormalizeBalanceKeys {
+                start_after: None,
+                limit: None,
+            };
+            let info = MessageInfo {
+                sender: not_admin,
+                funds: vec![],
+            };
+            let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+            assert_eq!(err, ContractError::Unauthorized {});
+        }
+
+        #[test]
+        fn test_normalize_balance_keys_noop() {
+            let mut deps = mock_dependencies();
+            setup_with_state(&mut deps);
+            let env = mock_env();
+            let admin = ADMIN.load(&deps.storage).unwrap();
+
+            let chain = ChainUid::create("cosmos".to_string()).unwrap();
+            let key: (ChainUid, String, String) =
+                (chain, "alreadylowercase".to_string(), "eucl".to_string());
+            BALANCES
+                .save(&mut deps.storage, key, &Uint128::new(100))
+                .unwrap();
+
+            let msg = ExecuteMsg::NormalizeBalanceKeys {
+                start_after: None,
+                limit: None,
+            };
+            let info = MessageInfo {
+                sender: admin.general_admin,
+                funds: vec![],
+            };
+            let res = execute(deps.as_mut(), env, info, msg).unwrap();
+            assert_eq!(
+                res.attributes
+                    .iter()
+                    .find(|a| a.key == "normalized_count")
+                    .unwrap()
+                    .value,
+                "0"
+            );
+        }
+    }
 }

--- a/contracts/hub_utilities/claimer/src/execute.rs
+++ b/contracts/hub_utilities/claimer/src/execute.rs
@@ -64,6 +64,7 @@ pub fn execute_create_voucher_claim(
     amount: Uint128,
     msg: CreateVoucherClaim,
 ) -> Result<Response, ContractError> {
+    // Reject mixed-case or empty addresses before storing the claim
     sender.validate()?;
     // Lets create a claim
     let claim_id = CLAIM_ID.load(deps.storage).unwrap_or(0u128); // Get latest claim id

--- a/contracts/hub_utilities/claimer/src/execute.rs
+++ b/contracts/hub_utilities/claimer/src/execute.rs
@@ -64,6 +64,7 @@ pub fn execute_create_voucher_claim(
     amount: Uint128,
     msg: CreateVoucherClaim,
 ) -> Result<Response, ContractError> {
+    sender.validate()?;
     // Lets create a claim
     let claim_id = CLAIM_ID.load(deps.storage).unwrap_or(0u128); // Get latest claim id
     CLAIM_ID.save(

--- a/contracts/hub_utilities/orderbook_deposits/src/execute.rs
+++ b/contracts/hub_utilities/orderbook_deposits/src/execute.rs
@@ -128,6 +128,7 @@ fn execute_deposit(
     sender: CrossChainUser,
 ) -> Result<Response, ContractError> {
     ensure!(!amount.is_zero(), ContractError::InvalidAmount {});
+    // Reject mixed-case or empty addresses before mutating state
     sender.validate()?;
 
     let is_whitelisted = WHITELISTED_ASSETS
@@ -446,6 +447,7 @@ fn execute_withdraw(
 
     let destination_chain_uid = ChainUid::create(destination_chain_uid)?;
     let destination_user = CrossChainUser::new(destination_chain_uid, destination.clone());
+    // Reject mixed-case or empty addresses before sending to virtual_balance
     destination_user.validate()?;
     let transfer_msg = VirtualBalanceExecuteMsg::Transfer(ExecuteTransfer {
         amount,

--- a/contracts/hub_utilities/orderbook_deposits/src/execute.rs
+++ b/contracts/hub_utilities/orderbook_deposits/src/execute.rs
@@ -128,6 +128,7 @@ fn execute_deposit(
     sender: CrossChainUser,
 ) -> Result<Response, ContractError> {
     ensure!(!amount.is_zero(), ContractError::InvalidAmount {});
+    sender.validate()?;
 
     let is_whitelisted = WHITELISTED_ASSETS
         .may_load(deps.storage, token_id.clone())?
@@ -445,6 +446,7 @@ fn execute_withdraw(
 
     let destination_chain_uid = ChainUid::create(destination_chain_uid)?;
     let destination_user = CrossChainUser::new(destination_chain_uid, destination.clone());
+    destination_user.validate()?;
     let transfer_msg = VirtualBalanceExecuteMsg::Transfer(ExecuteTransfer {
         amount,
         token_id: permit_data.token_id.clone(),

--- a/contracts/liquidity/factory/src/execute/pool.rs
+++ b/contracts/liquidity/factory/src/execute/pool.rs
@@ -344,6 +344,10 @@ pub fn remove_liquidity_request(
     recipient: CrossChainUser,
     cross_chain_config: CrossChainConfig,
 ) -> Result<Response, ContractError> {
+    // Reject mixed-case or empty addresses before mutating state
+    sender.validate()?;
+    recipient.validate()?;
+
     let state = STATE.load(deps.storage)?;
     let sender_addr = deps.api.addr_validate(&sender.address)?;
 

--- a/contracts/liquidity/factory/src/execute/swap.rs
+++ b/contracts/liquidity/factory/src/execute/swap.rs
@@ -31,6 +31,7 @@ pub fn execute_swap_request(
     cross_chain_config: CrossChainConfig,
     partner_fee: Option<PartnerFee>,
 ) -> Result<Response, ContractError> {
+    sender.validate()?;
     // Validate asset in
     asset_in.token_type.validate(&deps.as_ref())?;
     asset_in.token.validate()?;

--- a/contracts/liquidity/factory/src/execute/swap.rs
+++ b/contracts/liquidity/factory/src/execute/swap.rs
@@ -31,6 +31,7 @@ pub fn execute_swap_request(
     cross_chain_config: CrossChainConfig,
     partner_fee: Option<PartnerFee>,
 ) -> Result<Response, ContractError> {
+    // Reject mixed-case or empty addresses before mutating state
     sender.validate()?;
     // Validate asset in
     asset_in.token_type.validate(&deps.as_ref())?;

--- a/contracts/liquidity/factory/src/execute/token.rs
+++ b/contracts/liquidity/factory/src/execute/token.rs
@@ -201,6 +201,7 @@ pub fn execute_deposit_token(
     recipients: Vec<Recipient>,
     cross_chain_config: CrossChainConfig,
 ) -> Result<Response, ContractError> {
+    sender.validate()?;
     let sender_addr = deps.api.addr_validate(&sender.address)?;
     let state = STATE.load(deps.storage)?;
     ensure!(

--- a/contracts/liquidity/factory/src/execute/token.rs
+++ b/contracts/liquidity/factory/src/execute/token.rs
@@ -322,6 +322,11 @@ pub fn execute_transfer_voucher(
         recipient.validate()?;
     }
 
+    // Validate optional from address before sending cross-chain
+    if let Some(ref from) = from {
+        from.validate()?;
+    }
+
     let sender = CrossChainUser::new(state.chain_uid.clone(), info.sender.to_string());
     let tx_id = generate_tx(deps, &env, &sender)?;
 

--- a/contracts/liquidity/factory/src/execute/token.rs
+++ b/contracts/liquidity/factory/src/execute/token.rs
@@ -201,6 +201,7 @@ pub fn execute_deposit_token(
     recipients: Vec<Recipient>,
     cross_chain_config: CrossChainConfig,
 ) -> Result<Response, ContractError> {
+    // Reject mixed-case or empty addresses before mutating state
     sender.validate()?;
     let sender_addr = deps.api.addr_validate(&sender.address)?;
     let state = STATE.load(deps.storage)?;

--- a/packages/euclid/src/cross_chain_user.rs
+++ b/packages/euclid/src/cross_chain_user.rs
@@ -36,3 +36,38 @@ impl CrossChainUser {
         Ok(self)
     }
 }
+
+#[cfg(test)]
+mod cross_chain_user_test {
+    use super::*;
+    use crate::chain::ChainUid;
+
+    #[test]
+    fn test_mixed_case_address_validate_rejects() {
+        let user = CrossChainUser::new(
+            ChainUid::create("cosmos".to_string()).unwrap(),
+            "Cosmos1AbCdEf".to_string(),
+        );
+        let err = user.validate().unwrap_err();
+        assert!(err.to_string().contains("Address must be lowercase"));
+    }
+
+    #[test]
+    fn test_lowercase_address_validate_accepts() {
+        let user = CrossChainUser::new(
+            ChainUid::create("cosmos".to_string()).unwrap(),
+            "cosmos1abcdef".to_string(),
+        );
+        user.validate().unwrap();
+    }
+
+    #[test]
+    fn test_empty_address_validate_rejects() {
+        let user = CrossChainUser::new(
+            ChainUid::create("cosmos".to_string()).unwrap(),
+            "".to_string(),
+        );
+        let err = user.validate().unwrap_err();
+        assert!(err.to_string().contains("Address cannot be empty"));
+    }
+}

--- a/packages/euclid/src/msgs/virtual_balance/msg.rs
+++ b/packages/euclid/src/msgs/virtual_balance/msg.rs
@@ -38,6 +38,10 @@ pub enum ExecuteMsg {
         start_after: Option<SerializedBalanceKey>,
         limit: Option<u32>,
     },
+    NormalizeBalanceKeys {
+        start_after: Option<SerializedBalanceKey>,
+        limit: Option<u32>,
+    },
     Approve(ExecuteApprove),
 }
 

--- a/packages/euclid_ibc/src/router_ibc.rs
+++ b/packages/euclid_ibc/src/router_ibc.rs
@@ -82,6 +82,20 @@ impl RouterCrossChainExecuteMsg {
         }
     }
 
+    /// Returns a reference to the sender CrossChainUser from any variant.
+    pub fn get_sender(&self) -> &CrossChainUser {
+        match self {
+            Self::RegisterDenom { sender, .. } => sender,
+            Self::DeregisterDenom { sender, .. } => sender,
+            Self::DepositToken(msg) => &msg.sender,
+            Self::TransferVoucher(msg) => &msg.sender,
+            Self::RequestPoolCreation { sender, .. } => sender,
+            Self::AddLiquidity { sender, .. } => sender,
+            Self::RemoveLiquidity(msg) => &msg.sender,
+            Self::Swap(msg) => &msg.sender,
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn to_msg(
         &self,


### PR DESCRIPTION
# Pull Request

## Description

`CrossChainUser::validate()` enforces lowercase, non-empty addresses but was not being called in most execute handlers. This allowed mixed-case addresses to be stored as balance keys, creating duplicate entries for the same logical user.

This PR adds `validate()` calls across all execute handlers that accept CrossChainUser (virtual_balance, factory, orderbook_deposits, meta_transaction, claimer) and adds a paginated admin migration function (`NormalizeBalanceKeys`) to fix existing mixed-case balance keys in virtual_balance.

## Type of Change

- [x] Bug fix
- [x] New feature

## Related Issue

N/A

## Testing

Steps to test:

1. `cargo build` to verify all contracts compile
2. `cargo test` to verify all 11 new tests pass (3 in cross_chain_user, 8 in virtual_balance)
3. `cargo clippy` to verify no new warnings introduced

## Checklist

- [x] Self-review completed
- [x] Tests added/updated (if applicable)
- [ ] Documentation updated (if applicable)

## Additional Notes

The `NormalizeBalanceKeys` function uses cursor-based pagination (`start_after` + `limit`, default 100) to safely process large numbers of entries without hitting gas limits. It combines balances when both a mixed-case and lowercase entry exist for the same user. The admin should call it repeatedly until `normalized_count` returns 0.