### PR TITLE
test: relayer unit tests

### DIFF
--- a/.claude/agents/unit-test-writer.md
+++ b/.claude/agents/unit-test-writer.md
@@ -7,30 +7,46 @@ You are a unit test writer for the Euclid CosmWasm smart contracts. Your job is 
 
 ## Test File Conventions
 
-- Tests live in `src/tests.rs` within each contract, imported via `mod tests;` in `src/lib.rs`.
-- Always wrap in `#[allow(clippy::module_inception)] #[cfg(test)] mod tests { ... }`.
+Tests must be co-located with the functions they test — **never** put all tests in a single `src/tests.rs`.
+
+- Tests for functions in `src/contract.rs` → append a `#[cfg(test)] mod tests { ... }` block at the bottom of `src/contract.rs`.
+- Tests for functions in `src/execute.rs` → append a `#[cfg(test)] mod tests { ... }` block at the bottom of `src/execute.rs`.
+- Tests for functions in `src/query.rs` → append a `#[cfg(test)] mod tests { ... }` block at the bottom of `src/query.rs`.
+- If a `#[cfg(test)]` module already exists in a file, append to it without removing existing tests.
+
+**Shared helpers and fixtures** must live in a dedicated `src/testing/` directory, not inline in any test module:
+
+- `src/testing/helpers.rs` — `MockDeps` type alias, address constants, `init()`, seed helpers, and any utility functions used across test files. Items live at file top-level (no inner `mod` block) so imports stay flat: `use crate::testing::helpers::init`.
+- `src/testing/fixtures.rs` — rstest `#[fixture]` functions that return pre-seeded `MockDeps`. All items must be gated with `#[cfg(test)]`.
+- `src/testing/mod.rs` — declares both modules:
+  ```rust
+  pub mod fixtures;
+  #[cfg(test)]
+  pub mod helpers;
+  ```
+
+If `src/testing/` does not exist yet, create all three files and add `#[cfg(test)] mod testing;` to `src/lib.rs`.
+
+- Always wrap test modules in `#[cfg(test)] mod tests { ... }`.
 - Import from `cosmwasm_std::testing::{message_info, mock_dependencies, mock_env, MockQuerier}`.
 - Generate addresses with `deps.api.addr_make("name")` — never use `Addr::unchecked` for actor addresses in tests.
 - Use `Addr::unchecked` only for contract addresses stored in state (router, relayer, etc.).
 
 ## Standard `init` Helper Pattern
 
-Every test file has a local `init` function that instantiates the contract:
+Define `init` in `src/testing/helpers.rs` (not in individual test modules):
 
 ```rust
-fn init(
-    deps: &mut cosmwasm_std::OwnedDeps<
-        cosmwasm_std::MemoryStorage,
-        cosmwasm_std::testing::MockApi,
-        MockQuerier,
-    >,
-) -> Response {
+// src/testing/helpers.rs
+pub fn init(deps: &mut MockDeps) -> Response {
     let msg = InstantiateMsg { /* ... */ };
     let sender = deps.api.addr_make("sender");
     let info = message_info(&sender, &[]);
     instantiate(deps.as_mut(), mock_env(), info, msg).unwrap()
 }
 ```
+
+Test modules import it as `use crate::testing::helpers::init;`.
 
 ## Test Case Struct Pattern
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,10 +1616,13 @@ dependencies = [
  "cw-utils 2.0.0",
  "cw2 2.0.0",
  "euclid",
+ "k256",
  "mock",
  "relayer",
+ "rstest",
  "schemars",
  "serde",
+ "sha2 0.10.8",
  "thiserror 1.0.69",
 ]
 

--- a/contracts/common/euclid-relayer/Cargo.toml
+++ b/contracts/common/euclid-relayer/Cargo.toml
@@ -36,3 +36,8 @@ relayer = { workspace = true }
 cw-orch = { workspace = true }
 cw-multi-test = { workspace = true }
 mock = { workspace = true }
+
+[dev-dependencies]
+rstest = "0.19.0"
+k256 = { version = "0.13", features = ["ecdsa"] }
+sha2 = "0.10"

--- a/contracts/common/euclid-relayer/src/contract.rs
+++ b/contracts/common/euclid-relayer/src/contract.rs
@@ -80,3 +80,86 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractErr
         QueryMsg::Validators {} => Ok(to_json_binary(&get_validators(&deps)?)?),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{ADMIN, NONCES, STATE, VALIDATORS};
+    use crate::testing::helpers::{get_signer_key, init, test_chain_uid};
+    use cosmwasm_std::{
+        attr,
+        testing::{message_info, mock_dependencies, mock_env},
+    };
+    use euclid::admin::EuclidAdmin;
+    use relayer::msgs::{InstantiateMsg, Validator};
+
+    // -----------------------------------------------------------------------
+    // Instantiate
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_instantiate_stores_state_and_admin() {
+        let mut deps = mock_dependencies();
+        let res = init(&mut deps);
+
+        assert_eq!(res.attributes[0], attr("method", "instantiate"));
+
+        let (_, pub_key) = get_signer_key();
+        let state = STATE.load(&deps.storage).unwrap();
+        assert_eq!(state.message_signer.pubkey, pub_key);
+        assert_eq!(state.signature_threshold, 1);
+
+        let sender = deps.api.addr_make("sender");
+        let admin = ADMIN.load(&deps.storage).unwrap();
+        assert_eq!(admin, EuclidAdmin::default(sender));
+    }
+
+    #[test]
+    fn test_instantiate_emits_expected_attributes() {
+        let mut deps = mock_dependencies();
+        let (_, pub_key) = get_signer_key();
+        let msg = InstantiateMsg {
+            message_signer: Validator {
+                pubkey: pub_key.clone(),
+                address: "signer_address".to_string(),
+            },
+            signature_threshold: 3,
+        };
+        let sender = deps.api.addr_make("sender");
+        let info = message_info(&sender, &[]);
+        let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
+
+        let keys: Vec<&str> = res.attributes.iter().map(|a| a.key.as_str()).collect();
+        assert!(keys.contains(&"method"));
+        assert!(keys.contains(&"message_signer_pubkey"));
+        assert!(keys.contains(&"message_signer_address"));
+        assert!(keys.contains(&"signature_threshold"));
+
+        let threshold_attr = res
+            .attributes
+            .iter()
+            .find(|a| a.key == "signature_threshold")
+            .unwrap();
+        assert_eq!(threshold_attr.value, "3");
+    }
+
+    #[test]
+    fn test_instantiate_no_validators_registered() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+
+        let chain_uid = test_chain_uid();
+        let validators = VALIDATORS
+            .load(&deps.storage, chain_uid)
+            .unwrap_or_default();
+        assert!(validators.is_empty());
+    }
+
+    #[test]
+    fn test_instantiate_no_nonces() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+        let relayed = NONCES.has(&deps.storage, "any_nonce".to_string());
+        assert!(!relayed);
+    }
+}

--- a/contracts/common/euclid-relayer/src/execute.rs
+++ b/contracts/common/euclid-relayer/src/execute.rs
@@ -175,6 +175,576 @@ fn expiry_call_data(data: &str, expiry: u64, chain_uid: &str) -> String {
     expiry_call_data
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{ADMIN, NONCES, STATE, VALIDATORS};
+    use crate::testing::helpers::{
+        expiry_call_data as helper_expiry_call_data, get_signer_key, init,
+        make_valid_meta_transaction, make_validator, sign_message, test_chain_uid,
+    };
+    use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env};
+    use cosmwasm_std::{attr, to_json_binary, Addr, Timestamp};
+    use euclid::admin::{AdminType, EuclidAdmin};
+    use euclid::chain::ChainUid;
+    use euclid::error::ContractError;
+    use relayer::msgs::{MetaTransactionData, UpdateAdminMsg, UpdateStateMsg, Validator};
+    use rstest::rstest;
+
+    // -----------------------------------------------------------------------
+    // execute_update_state
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_update_state_happy_path() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+
+        let sender = deps.api.addr_make("sender");
+        let info = message_info(&sender, &[]);
+
+        let (_, new_pub_key) = get_signer_key();
+        let new_signer = Validator {
+            pubkey: new_pub_key.clone(),
+            address: "new_address".to_string(),
+        };
+        let msg = UpdateStateMsg {
+            message_signer: Some(new_signer),
+            signature_threshold: Some(2),
+        };
+
+        let res = execute_update_state(&mut deps.as_mut(), &info, msg).unwrap();
+
+        let state = STATE.load(&deps.storage).unwrap();
+        assert_eq!(state.message_signer.pubkey, new_pub_key);
+        assert_eq!(state.signature_threshold, 2);
+
+        // Response has the old and new attribute keys
+        let keys: Vec<&str> = res.attributes.iter().map(|a| a.key.as_str()).collect();
+        assert!(keys.contains(&"message_signer_pubkey_old_value"));
+        assert!(keys.contains(&"message_signer_pubkey_new_value"));
+        assert!(keys.contains(&"signature_threshold_old_value"));
+        assert!(keys.contains(&"signature_threshold_new_value"));
+    }
+
+    #[test]
+    fn test_update_state_partial_update_signer_only() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+        let sender = deps.api.addr_make("sender");
+        let info = message_info(&sender, &[]);
+
+        let (_, new_pub_key) = get_signer_key();
+        let msg = UpdateStateMsg {
+            message_signer: Some(Validator {
+                pubkey: new_pub_key.clone(),
+                address: "addr".to_string(),
+            }),
+            signature_threshold: None,
+        };
+        execute_update_state(&mut deps.as_mut(), &info, msg).unwrap();
+
+        let state = STATE.load(&deps.storage).unwrap();
+        assert_eq!(state.message_signer.pubkey, new_pub_key);
+        assert_eq!(state.signature_threshold, 1); // unchanged
+    }
+
+    #[test]
+    fn test_update_state_partial_update_threshold_only() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+        let sender = deps.api.addr_make("sender");
+        let info = message_info(&sender, &[]);
+
+        let msg = UpdateStateMsg {
+            message_signer: None,
+            signature_threshold: Some(5),
+        };
+        execute_update_state(&mut deps.as_mut(), &info, msg).unwrap();
+
+        let state = STATE.load(&deps.storage).unwrap();
+        assert_eq!(state.signature_threshold, 5);
+    }
+
+    #[test]
+    fn test_update_state_unauthorized() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+        let not_admin = deps.api.addr_make("not_admin");
+        let info = message_info(&not_admin, &[]);
+
+        let msg = UpdateStateMsg {
+            message_signer: None,
+            signature_threshold: Some(2),
+        };
+        let err = execute_update_state(&mut deps.as_mut(), &info, msg).unwrap_err();
+        assert_eq!(err, ContractError::Unauthorized {});
+    }
+
+    // -----------------------------------------------------------------------
+    // execute_update_admin
+    // -----------------------------------------------------------------------
+
+    #[rstest]
+    #[case::general_admin(AdminType::GeneralAdmin)]
+    #[case::fee_admin(AdminType::FeeAdmin)]
+    #[case::migration_admin(AdminType::MigrationAdmin)]
+    fn test_update_admin_happy_path(#[case] admin_type: AdminType) {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+        let env = mock_env();
+
+        let sender = deps.api.addr_make("sender");
+        let info = message_info(&sender, &[]);
+        let new_admin = deps.api.addr_make("new_admin");
+
+        let msg = UpdateAdminMsg {
+            new_admin: new_admin.to_string(),
+            admin_type: admin_type.clone(),
+        };
+
+        let res = execute_update_admin(&mut deps.as_mut(), env, &info, msg).unwrap();
+
+        let keys: Vec<&str> = res.attributes.iter().map(|a| a.key.as_str()).collect();
+        assert!(keys.contains(&"old_admin"));
+        assert!(keys.contains(&"new_admin"));
+
+        let saved_admin = ADMIN.load(&deps.storage).unwrap();
+        match admin_type {
+            AdminType::GeneralAdmin => assert_eq!(saved_admin.general_admin, new_admin),
+            AdminType::FeeAdmin => assert_eq!(saved_admin.fee_admin, new_admin),
+            AdminType::MigrationAdmin => assert_eq!(saved_admin.migration_admin, new_admin),
+        }
+    }
+
+    #[test]
+    fn test_update_admin_unauthorized() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+        let env = mock_env();
+
+        let not_admin = deps.api.addr_make("not_admin");
+        let info = message_info(&not_admin, &[]);
+
+        let msg = UpdateAdminMsg {
+            new_admin: not_admin.to_string(),
+            admin_type: AdminType::GeneralAdmin,
+        };
+        let err = execute_update_admin(&mut deps.as_mut(), env, &info, msg).unwrap_err();
+        // EuclidAdmin::verify_update_access returns UnauthorizedWithMsg, not Unauthorized
+        assert!(matches!(err, ContractError::UnauthorizedWithMsg { .. }));
+    }
+
+    // -----------------------------------------------------------------------
+    // execute_add_validator / execute_remove_validator
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_add_validator_happy_path() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+
+        let sender = deps.api.addr_make("sender");
+        let info = message_info(&sender, &[]);
+        let chain_uid = test_chain_uid();
+
+        let (validator, _) =
+            make_validator("2268A9118C1681EC6A649F01886995DE55E90C7E71B0BC5E409C551B92FF7369");
+        let validator_address = validator.address.clone();
+
+        let res = execute_add_validator(
+            &mut deps.as_mut(),
+            &info,
+            validator.clone(),
+            chain_uid.clone(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            res.attributes[0],
+            attr("validator_added", &validator_address)
+        );
+
+        let saved = VALIDATORS.load(&deps.storage, chain_uid).unwrap();
+        assert_eq!(saved.len(), 1);
+        assert_eq!(saved[0], validator);
+    }
+
+    #[test]
+    fn test_add_validator_unauthorized() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+
+        let not_admin = deps.api.addr_make("not_admin");
+        let info = message_info(&not_admin, &[]);
+        let chain_uid = test_chain_uid();
+        let (validator, _) =
+            make_validator("2268A9118C1681EC6A649F01886995DE55E90C7E71B0BC5E409C551B92FF7369");
+        let err =
+            execute_add_validator(&mut deps.as_mut(), &info, validator, chain_uid).unwrap_err();
+        assert_eq!(err, ContractError::Unauthorized {});
+    }
+
+    #[test]
+    fn test_add_validator_duplicate_rejected() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+        let sender = deps.api.addr_make("sender");
+        let info = message_info(&sender, &[]);
+        let chain_uid = test_chain_uid();
+        let (validator, _) =
+            make_validator("2268A9118C1681EC6A649F01886995DE55E90C7E71B0BC5E409C551B92FF7369");
+
+        execute_add_validator(
+            &mut deps.as_mut(),
+            &info,
+            validator.clone(),
+            chain_uid.clone(),
+        )
+        .unwrap();
+        let err =
+            execute_add_validator(&mut deps.as_mut(), &info, validator, chain_uid).unwrap_err();
+        assert!(matches!(err, ContractError::Generic { .. }));
+    }
+
+    #[test]
+    fn test_add_multiple_validators_different_chains() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+        let sender = deps.api.addr_make("sender");
+        let info = message_info(&sender, &[]);
+
+        let (v1, _) =
+            make_validator("2268A9118C1681EC6A649F01886995DE55E90C7E71B0BC5E409C551B92FF7369");
+        let chain_a = ChainUid::create("chaina".to_string()).unwrap();
+        let chain_b = ChainUid::create("chainb".to_string()).unwrap();
+
+        execute_add_validator(&mut deps.as_mut(), &info, v1.clone(), chain_a.clone()).unwrap();
+        execute_add_validator(&mut deps.as_mut(), &info, v1.clone(), chain_b.clone()).unwrap();
+
+        assert_eq!(VALIDATORS.load(&deps.storage, chain_a).unwrap().len(), 1);
+        assert_eq!(VALIDATORS.load(&deps.storage, chain_b).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_remove_validator_happy_path() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+        let sender = deps.api.addr_make("sender");
+        let info = message_info(&sender, &[]);
+        let chain_uid = test_chain_uid();
+
+        let (validator, _) =
+            make_validator("2268A9118C1681EC6A649F01886995DE55E90C7E71B0BC5E409C551B92FF7369");
+        execute_add_validator(
+            &mut deps.as_mut(),
+            &info,
+            validator.clone(),
+            chain_uid.clone(),
+        )
+        .unwrap();
+
+        let res = execute_remove_validator(&mut deps.as_mut(), &info, validator, chain_uid.clone())
+            .unwrap();
+
+        assert_eq!(res.attributes[0].key, "validator_removed");
+
+        let saved = VALIDATORS.load(&deps.storage, chain_uid).unwrap();
+        assert!(saved.is_empty());
+    }
+
+    #[test]
+    fn test_remove_validator_unauthorized() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+        let not_admin = deps.api.addr_make("not_admin");
+        let info = message_info(&not_admin, &[]);
+        let chain_uid = test_chain_uid();
+        let (validator, _) =
+            make_validator("2268A9118C1681EC6A649F01886995DE55E90C7E71B0BC5E409C551B92FF7369");
+        let err =
+            execute_remove_validator(&mut deps.as_mut(), &info, validator, chain_uid).unwrap_err();
+        assert_eq!(err, ContractError::Unauthorized {});
+    }
+
+    #[test]
+    fn test_remove_validator_not_found() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+        let sender = deps.api.addr_make("sender");
+        let info = message_info(&sender, &[]);
+        let chain_uid = test_chain_uid();
+
+        let (validator, _) =
+            make_validator("2268A9118C1681EC6A649F01886995DE55E90C7E71B0BC5E409C551B92FF7369");
+        let err =
+            execute_remove_validator(&mut deps.as_mut(), &info, validator, chain_uid).unwrap_err();
+        assert!(matches!(err, ContractError::Generic { .. }));
+    }
+
+    // -----------------------------------------------------------------------
+    // execute_meta_transaction — error paths that don't need real sigs
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_meta_transaction_nonce_already_used() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+
+        // Pre-seed a used nonce
+        NONCES
+            .save(
+                deps.as_mut().storage,
+                "used-nonce".to_string(),
+                &cosmwasm_std::Uint128::from(1u64),
+            )
+            .unwrap();
+
+        let meta_data = MetaTransactionData {
+            target: Addr::unchecked("some_target"),
+            call_data: to_json_binary(&"dummy").unwrap(),
+            nonce: "used-nonce".to_string(),
+        };
+        let data_str = cosmwasm_std::to_json_string(&meta_data).unwrap();
+
+        let msg = relayer::msgs::MetaTransaction {
+            data: data_str,
+            expiry: u64::MAX,
+            admin_signature: cosmwasm_std::Binary::from(vec![0u8; 64]),
+            validator_signatures: vec![],
+            chain_uid: test_chain_uid(),
+        };
+
+        let sender = deps.api.addr_make("sender");
+        let info = message_info(&sender, &[]);
+        let err =
+            execute_meta_transaction(&mut deps.as_mut(), &mock_env(), &info, msg).unwrap_err();
+        assert!(matches!(err, ContractError::Generic { .. }));
+    }
+
+    #[test]
+    fn test_meta_transaction_expired_timestamp() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+
+        let meta_data = MetaTransactionData {
+            target: Addr::unchecked("some_target"),
+            call_data: to_json_binary(&"dummy").unwrap(),
+            nonce: "fresh-nonce".to_string(),
+        };
+        let data_str = cosmwasm_std::to_json_string(&meta_data).unwrap();
+
+        // expiry = 0 means any block time > 0 will exceed it
+        let msg = relayer::msgs::MetaTransaction {
+            data: data_str,
+            expiry: 0,
+            admin_signature: cosmwasm_std::Binary::from(vec![0u8; 64]),
+            validator_signatures: vec![],
+            chain_uid: test_chain_uid(),
+        };
+
+        let sender = deps.api.addr_make("sender");
+        let info = message_info(&sender, &[]);
+        let env = mock_env(); // mock_env has block.time = 1_571_797_419
+        let err = execute_meta_transaction(&mut deps.as_mut(), &env, &info, msg).unwrap_err();
+        assert!(matches!(err, ContractError::Generic { .. }));
+    }
+
+    // -----------------------------------------------------------------------
+    // execute_meta_transaction — happy path with real secp256k1 signatures
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_meta_transaction_happy_path() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+
+        // Use the same signing key as the admin signer (set in init)
+        let (_, validator_sk) = {
+            use k256::ecdsa::SigningKey;
+            use k256::elliptic_curve::NonZeroScalar;
+            use std::str::FromStr;
+            let scalar = NonZeroScalar::from_str(
+                "2268A9118C1681EC6A649F01886995DE55E90C7E71B0BC5E409C551B92FF7369",
+            )
+            .unwrap();
+            let sk = SigningKey::from(scalar);
+            ((), sk)
+        };
+
+        let chain_uid_str = "testchain";
+        // Use a far-future expiry (year ~2100)
+        let expiry = 4_102_444_800u64;
+
+        let msg = make_valid_meta_transaction(
+            &mut deps,
+            "nonce-1",
+            "some_target",
+            &validator_sk,
+            expiry,
+            chain_uid_str,
+        );
+
+        let sender = deps.api.addr_make("sender");
+        let info = message_info(&sender, &[]);
+
+        let mut env = mock_env();
+        env.block.time = Timestamp::from_seconds(1_000_000); // well before expiry
+
+        let res = execute_meta_transaction(&mut deps.as_mut(), &env, &info, msg).unwrap();
+
+        assert_eq!(res.messages.len(), 1);
+        assert_eq!(
+            res.attributes
+                .iter()
+                .find(|a| a.key == "relayer_nonce")
+                .unwrap()
+                .value,
+            "nonce-1"
+        );
+        assert_eq!(
+            res.attributes
+                .iter()
+                .find(|a| a.key == "relayer_target")
+                .unwrap()
+                .value,
+            "some_target"
+        );
+        assert_eq!(
+            res.attributes
+                .iter()
+                .find(|a| a.key == "relayer_sender")
+                .unwrap()
+                .value,
+            sender.to_string()
+        );
+
+        // Nonce is now recorded
+        assert!(NONCES.has(&deps.storage, "nonce-1".to_string()));
+    }
+
+    #[test]
+    fn test_meta_transaction_nonce_saved_after_relay() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+
+        let (_, validator_sk) = {
+            use k256::ecdsa::SigningKey;
+            use k256::elliptic_curve::NonZeroScalar;
+            use std::str::FromStr;
+            let scalar = NonZeroScalar::from_str(
+                "2268A9118C1681EC6A649F01886995DE55E90C7E71B0BC5E409C551B92FF7369",
+            )
+            .unwrap();
+            ((), SigningKey::from(scalar))
+        };
+
+        let expiry = 4_102_444_800u64;
+        let msg = make_valid_meta_transaction(
+            &mut deps,
+            "unique-nonce",
+            "target",
+            &validator_sk,
+            expiry,
+            "testchain",
+        );
+
+        let sender = deps.api.addr_make("sender");
+        let info = message_info(&sender, &[]);
+        let mut env = mock_env();
+        env.block.time = Timestamp::from_seconds(1_000_000);
+
+        execute_meta_transaction(&mut deps.as_mut(), &env, &info, msg).unwrap();
+
+        assert!(NONCES.has(&deps.storage, "unique-nonce".to_string()));
+        let block_height = NONCES
+            .load(&deps.storage, "unique-nonce".to_string())
+            .unwrap();
+        assert_eq!(block_height, cosmwasm_std::Uint128::from(env.block.height));
+    }
+
+    #[test]
+    fn test_meta_transaction_threshold_not_met() {
+        let mut deps = mock_dependencies();
+        // Set threshold to 2
+        let (_, pub_key) = get_signer_key();
+        let state = relayer::msgs::State {
+            message_signer: Validator {
+                pubkey: pub_key,
+                address: "signer".to_string(),
+            },
+            signature_threshold: 2,
+        };
+        let sender = deps.api.addr_make("sender");
+        STATE.save(deps.as_mut().storage, &state).unwrap();
+        ADMIN
+            .save(deps.as_mut().storage, &EuclidAdmin::default(sender.clone()))
+            .unwrap();
+
+        let (_, validator_sk) = {
+            use k256::ecdsa::SigningKey;
+            use k256::elliptic_curve::NonZeroScalar;
+            use std::str::FromStr;
+            let scalar = NonZeroScalar::from_str(
+                "2268A9118C1681EC6A649F01886995DE55E90C7E71B0BC5E409C551B92FF7369",
+            )
+            .unwrap();
+            ((), SigningKey::from(scalar))
+        };
+
+        // make_valid_meta_transaction provides only 1 validator sig
+        let expiry = 4_102_444_800u64;
+        let msg = make_valid_meta_transaction(
+            &mut deps,
+            "nonce-threshold",
+            "target",
+            &validator_sk,
+            expiry,
+            "testchain",
+        );
+
+        let info = message_info(&sender, &[]);
+        let mut env = mock_env();
+        env.block.time = Timestamp::from_seconds(1_000_000);
+
+        let err = execute_meta_transaction(&mut deps.as_mut(), &env, &info, msg).unwrap_err();
+        assert!(matches!(err, ContractError::Generic { .. }));
+    }
+
+    #[test]
+    fn test_meta_transaction_no_validators_for_chain() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+
+        let meta_data = MetaTransactionData {
+            target: Addr::unchecked("target"),
+            call_data: to_json_binary(&"dummy").unwrap(),
+            nonce: "nonce-no-validators".to_string(),
+        };
+        let data_str = cosmwasm_std::to_json_string(&meta_data).unwrap();
+
+        // Sign admin payload so we can get past admin sig check
+        let admin_payload = helper_expiry_call_data(&data_str, 4_102_444_800, "unknownchain");
+        let (admin_sig, _) = sign_message(&admin_payload);
+
+        let msg = relayer::msgs::MetaTransaction {
+            data: data_str,
+            expiry: 4_102_444_800,
+            admin_signature: admin_sig,
+            validator_signatures: vec![],
+            chain_uid: ChainUid::create("unknownchain".to_string()).unwrap(),
+        };
+
+        let sender = deps.api.addr_make("sender");
+        let info = message_info(&sender, &[]);
+        let mut env = mock_env();
+        env.block.time = Timestamp::from_seconds(1_000_000);
+
+        let err = execute_meta_transaction(&mut deps.as_mut(), &env, &info, msg).unwrap_err();
+        assert!(matches!(err, ContractError::Generic { .. }));
+    }
+}
+
 pub fn execute_add_validator(
     deps: &mut DepsMut,
     info: &MessageInfo,

--- a/contracts/common/euclid-relayer/src/lib.rs
+++ b/contracts/common/euclid-relayer/src/lib.rs
@@ -6,6 +6,9 @@ pub mod migrate;
 pub mod query;
 pub mod state;
 
+#[cfg(test)]
+mod testing;
+
 #[cfg(not(target_arch = "wasm32"))]
 mod interface;
 #[cfg(not(target_arch = "wasm32"))]

--- a/contracts/common/euclid-relayer/src/query.rs
+++ b/contracts/common/euclid-relayer/src/query.rs
@@ -32,3 +32,165 @@ pub fn get_validators(deps: &Deps) -> Result<ValidatorsResponse, ContractError> 
     }
     Ok(ValidatorsResponse { validators })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{NONCES, VALIDATORS};
+    use crate::testing::helpers::{get_signer_key, init, make_validator, test_chain_uid};
+    use cosmwasm_std::testing::mock_dependencies;
+    use euclid::chain::ChainUid;
+    use relayer::msgs::Validator;
+
+    // -----------------------------------------------------------------------
+    // get_state
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_get_state_returns_initialized_state() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+
+        let (_, pub_key) = get_signer_key();
+        let state = get_state(&deps.as_ref()).unwrap();
+
+        assert_eq!(state.message_signer.pubkey, pub_key);
+        assert_eq!(state.signature_threshold, 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // get_admin
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_get_admin_returns_sender_as_all_admin_roles() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+
+        let sender = deps.api.addr_make("sender");
+        let admin = get_admin(&deps.as_ref()).unwrap();
+
+        assert_eq!(admin.general_admin, sender);
+        assert_eq!(admin.fee_admin, sender);
+        assert_eq!(admin.migration_admin, sender);
+    }
+
+    // -----------------------------------------------------------------------
+    // get_nonce_relayed
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_nonce_not_relayed() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+
+        let relayed = get_nonce_relayed(&deps.as_ref(), "fresh-nonce".to_string()).unwrap();
+        assert!(!relayed);
+    }
+
+    #[test]
+    fn test_nonce_relayed_after_storage_write() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+
+        NONCES
+            .save(
+                deps.as_mut().storage,
+                "used-nonce".to_string(),
+                &cosmwasm_std::Uint128::from(100u64),
+            )
+            .unwrap();
+
+        let relayed = get_nonce_relayed(&deps.as_ref(), "used-nonce".to_string()).unwrap();
+        assert!(relayed);
+    }
+
+    // -----------------------------------------------------------------------
+    // get_validators
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_get_validators_empty() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+
+        let resp = get_validators(&deps.as_ref()).unwrap();
+        assert!(resp.validators.is_empty());
+    }
+
+    #[test]
+    fn test_get_validators_single_chain() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+
+        let chain_uid = test_chain_uid();
+        let (v, _) =
+            make_validator("2268A9118C1681EC6A649F01886995DE55E90C7E71B0BC5E409C551B92FF7369");
+        VALIDATORS
+            .save(deps.as_mut().storage, chain_uid.clone(), &vec![v.clone()])
+            .unwrap();
+
+        let resp = get_validators(&deps.as_ref()).unwrap();
+        assert_eq!(resp.validators.len(), 1);
+        assert_eq!(resp.validators[0].validator, v);
+        assert_eq!(resp.validators[0].chain_uid, chain_uid);
+    }
+
+    #[test]
+    fn test_get_validators_multiple_chains() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+
+        let chain_a = ChainUid::create("chaina".to_string()).unwrap();
+        let chain_b = ChainUid::create("chainb".to_string()).unwrap();
+
+        let (v1, _) =
+            make_validator("2268A9118C1681EC6A649F01886995DE55E90C7E71B0BC5E409C551B92FF7369");
+        // Use a different valid compressed pubkey for v2
+        let v2 = Validator {
+            pubkey: cosmwasm_std::Binary::from(vec![0x03u8; 33]),
+            address: "validator_other".to_string(),
+        };
+
+        VALIDATORS
+            .save(deps.as_mut().storage, chain_a.clone(), &vec![v1.clone()])
+            .unwrap();
+        VALIDATORS
+            .save(deps.as_mut().storage, chain_b.clone(), &vec![v2.clone()])
+            .unwrap();
+
+        let resp = get_validators(&deps.as_ref()).unwrap();
+        // Results are ascending by chain_uid key
+        assert_eq!(resp.validators.len(), 2);
+        let chain_uids: Vec<ChainUid> = resp
+            .validators
+            .iter()
+            .map(|v| v.chain_uid.clone())
+            .collect();
+        assert!(chain_uids.contains(&chain_a));
+        assert!(chain_uids.contains(&chain_b));
+    }
+
+    #[test]
+    fn test_get_validators_two_validators_same_chain() {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+
+        let chain_uid = test_chain_uid();
+        let (v1, _) =
+            make_validator("2268A9118C1681EC6A649F01886995DE55E90C7E71B0BC5E409C551B92FF7369");
+        let v2 = Validator {
+            pubkey: cosmwasm_std::Binary::from(vec![0x02u8; 33]),
+            address: "validator_second".to_string(),
+        };
+
+        VALIDATORS
+            .save(deps.as_mut().storage, chain_uid.clone(), &vec![v1, v2])
+            .unwrap();
+
+        let resp = get_validators(&deps.as_ref()).unwrap();
+        assert_eq!(resp.validators.len(), 2);
+        // All for same chain
+        assert!(resp.validators.iter().all(|v| v.chain_uid == chain_uid));
+    }
+}

--- a/contracts/common/euclid-relayer/src/testing/fixtures.rs
+++ b/contracts/common/euclid-relayer/src/testing/fixtures.rs
@@ -1,0 +1,30 @@
+#[cfg(test)]
+pub mod test_fixtures {
+    use crate::state::VALIDATORS;
+    use crate::testing::helpers::{init, make_validator, test_chain_uid, MockDeps};
+    use cosmwasm_std::testing::mock_dependencies;
+    use rstest::fixture;
+
+    /// A fresh `MockDeps` with the contract instantiated.
+    #[fixture]
+    pub fn initialized_deps() -> MockDeps {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+        deps
+    }
+
+    /// A `MockDeps` with the contract instantiated and one validator registered.
+    #[fixture]
+    pub fn deps_with_validator() -> MockDeps {
+        let mut deps = mock_dependencies();
+        init(&mut deps);
+
+        let (validator, _sk) =
+            make_validator("2268A9118C1681EC6A649F01886995DE55E90C7E71B0BC5E409C551B92FF7369");
+        let chain_uid = test_chain_uid();
+        VALIDATORS
+            .save(deps.as_mut().storage, chain_uid, &vec![validator])
+            .unwrap();
+        deps
+    }
+}

--- a/contracts/common/euclid-relayer/src/testing/helpers.rs
+++ b/contracts/common/euclid-relayer/src/testing/helpers.rs
@@ -1,0 +1,171 @@
+use crate::contract::instantiate;
+use cosmwasm_std::testing::{message_info, mock_env, MockQuerier};
+use cosmwasm_std::{to_json_binary, Binary, Response};
+use euclid::chain::ChainUid;
+use k256::ecdsa::SigningKey;
+use k256::elliptic_curve::NonZeroScalar;
+use relayer::msgs::{
+    InstantiateMsg, MetaTransaction, MetaTransactionData, Validator, ValidatorSignature,
+};
+use sha2::{Digest, Sha256};
+use std::str::FromStr;
+
+pub type MockDeps = cosmwasm_std::OwnedDeps<
+    cosmwasm_std::MemoryStorage,
+    cosmwasm_std::testing::MockApi,
+    MockQuerier,
+>;
+
+// -------------------------------------------------------------------
+// Fixed test-key (same as in packages/relayer/src/verify.rs tests)
+// -------------------------------------------------------------------
+
+const TEST_SIGNING_KEY_HEX: &str =
+    "2268A9118C1681EC6A649F01886995DE55E90C7E71B0BC5E409C551B92FF7369";
+
+pub fn get_signer_key() -> (SigningKey, Binary) {
+    let scalar = NonZeroScalar::from_str(TEST_SIGNING_KEY_HEX).unwrap();
+    let secret_key = SigningKey::from(scalar);
+    let pub_key = Binary::from(
+        secret_key
+            .verifying_key()
+            .to_encoded_point(true)
+            .as_bytes()
+            .to_vec(),
+    );
+    (secret_key, pub_key)
+}
+
+/// Sign `msg` with the test signing key and return (signature, pubkey).
+pub fn sign_message(msg: &str) -> (Binary, Binary) {
+    let digest = Sha256::new().chain_update(msg.as_bytes());
+    let (secret_key, pub_key) = get_signer_key();
+    let (sig, _) = secret_key.sign_digest_recoverable(digest).unwrap();
+    (Binary::from(sig.to_bytes().as_slice()), pub_key)
+}
+
+/// Produce the string that the relayer hashes/signs:
+///   `{data},{expiry},{chain_uid}`
+pub fn expiry_call_data(data: &str, expiry: u64, chain_uid: &str) -> String {
+    format!(
+        "{data},{expiry},{chain_uid}",
+        data = data,
+        expiry = expiry,
+        chain_uid = chain_uid
+    )
+}
+
+// -------------------------------------------------------------------
+// Address constants
+// -------------------------------------------------------------------
+
+pub const TEST_CHAIN_UID: &str = "testchain";
+
+// -------------------------------------------------------------------
+// init helper
+// -------------------------------------------------------------------
+
+pub fn init(deps: &mut MockDeps) -> Response {
+    let (_, pub_key) = get_signer_key();
+    let msg = InstantiateMsg {
+        message_signer: Validator {
+            pubkey: pub_key,
+            address: "signer_address".to_string(),
+        },
+        signature_threshold: 1,
+    };
+    let sender = deps.api.addr_make("sender");
+    let info = message_info(&sender, &[]);
+    instantiate(deps.as_mut(), mock_env(), info, msg).unwrap()
+}
+
+pub fn test_chain_uid() -> ChainUid {
+    ChainUid::create(TEST_CHAIN_UID.to_string()).unwrap()
+}
+
+/// Build a validator + its signing helper from a private-key hex string.
+pub fn make_validator(signing_key_hex: &str) -> (Validator, SigningKey) {
+    let scalar = NonZeroScalar::from_str(signing_key_hex).unwrap();
+    let sk = SigningKey::from(scalar);
+    let pub_key = Binary::from(
+        sk.verifying_key()
+            .to_encoded_point(true)
+            .as_bytes()
+            .to_vec(),
+    );
+    let validator = Validator {
+        pubkey: pub_key,
+        address: format!("validator_{}", signing_key_hex.get(0..8).unwrap_or("x")),
+    };
+    (validator, sk)
+}
+
+/// Sign the relayer expiry call data with a validator's signing key.
+pub fn sign_validator_message(
+    sk: &SigningKey,
+    data: &str,
+    expiry: u64,
+    chain_uid: &str,
+) -> ValidatorSignature {
+    let payload = expiry_call_data(data, expiry, chain_uid);
+    let digest = Sha256::new().chain_update(payload.as_bytes());
+    let (sig, _) = sk.sign_digest_recoverable(digest).unwrap();
+    let pub_key = Binary::from(
+        sk.verifying_key()
+            .to_encoded_point(true)
+            .as_bytes()
+            .to_vec(),
+    );
+    ValidatorSignature {
+        pubkey: pub_key,
+        signature: Binary::from(sig.to_bytes().as_slice()),
+        expiry,
+    }
+}
+
+/// Build a complete valid `MetaTransaction` that will pass all checks.
+pub fn make_valid_meta_transaction(
+    deps: &mut MockDeps,
+    nonce: &str,
+    target: &str,
+    validator_sk: &SigningKey,
+    expiry: u64,
+    chain_uid_str: &str,
+) -> MetaTransaction {
+    let meta_data = MetaTransactionData {
+        target: cosmwasm_std::Addr::unchecked(target),
+        call_data: to_json_binary(&"dummy").unwrap(),
+        nonce: nonce.to_string(),
+    };
+    let data_str = cosmwasm_std::to_json_string(&meta_data).unwrap();
+
+    // Sign with the admin signer key
+    let admin_payload = expiry_call_data(&data_str, expiry, chain_uid_str);
+    let (admin_sig, _) = sign_message(&admin_payload);
+
+    // Register the validator for this chain first
+    let chain_uid = ChainUid::create(chain_uid_str.to_string()).unwrap();
+    let validator = Validator {
+        pubkey: Binary::from(
+            validator_sk
+                .verifying_key()
+                .to_encoded_point(true)
+                .as_bytes()
+                .to_vec(),
+        ),
+        address: "test_validator".to_string(),
+    };
+    crate::state::VALIDATORS
+        .save(deps.as_mut().storage, chain_uid, &vec![validator])
+        .unwrap();
+
+    let validator_sig = sign_validator_message(validator_sk, &data_str, expiry, chain_uid_str);
+
+    MetaTransaction {
+        data: data_str,
+        expiry,
+        admin_signature: admin_sig,
+        validator_signatures: vec![validator_sig],
+        chain_uid: ChainUid::create(chain_uid_str.to_string()).unwrap(),
+    }
+}

--- a/contracts/common/euclid-relayer/src/testing/mod.rs
+++ b/contracts/common/euclid-relayer/src/testing/mod.rs
@@ -1,0 +1,3 @@
+pub mod fixtures;
+#[cfg(test)]
+pub mod helpers;


### PR DESCRIPTION
## Summary

- Adds comprehensive unit tests for the `euclid-relayer` contract (`contracts/common/euclid-relayer`)
- Tests cover `execute_update_state`, `execute_update_admin`, `execute_add_validator`, `execute_remove_validator`, `execute_relay`, and query handlers
- Introduces a `testing/` module with shared fixtures and helpers (key generation, signing, `init`, `make_valid_meta_transaction`)

## Test plan

- [ ] `cargo test -p euclid-relayer` passes with all new tests green
- [ ] No regressions in other packages (`cargo test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)