### PR TITLE
feat: include pool_key in VlpResponse for concentrated pools

### DIFF
--- a/contracts/hub/router/src/query.rs
+++ b/contracts/hub/router/src/query.rs
@@ -60,6 +60,7 @@ pub fn query_all_vlps(
                 vlp: v.1.to_string(),
                 token_1: Token::create(v.0 .0)?,
                 token_2: Token::create(v.0 .1)?,
+                pool_key: None,
             })
         })
         .collect::<Result<_, ContractError>>()?;
@@ -70,12 +71,19 @@ pub fn query_all_vlps(
         .take(limit.unwrap_or(10) as usize)
         .map(|v| {
             let v = v?;
-            let (token_1, token_2, _, _) = PoolKey::parse_map_key(&v.0)
+            let (token_1, token_2, fee_tier_bps, tick_spacing) = PoolKey::parse_map_key(&v.0)
                 .ok_or(ContractError::new("invalid concentrated pool key in state"))?;
             Ok(VlpResponse {
                 vlp: v.1.to_string(),
-                token_1: Token::create(token_1)?,
-                token_2: Token::create(token_2)?,
+                token_1: Token::create(token_1.clone())?,
+                token_2: Token::create(token_2.clone())?,
+                pool_key: Some(PoolKey {
+                    pair: Pair::new(Token::create(token_1)?, Token::create(token_2)?)?,
+                    pool_type: PoolType::Concentrated {
+                        fee_tier_bps,
+                        tick_spacing,
+                    },
+                }),
             })
         })
         .collect();
@@ -92,6 +100,7 @@ pub fn query_vlp(deps: Deps, pair: Pair) -> Result<Binary, ContractError> {
         vlp: vlp.to_string(),
         token_1: Token::create(key.0)?,
         token_2: Token::create(key.1)?,
+        pool_key: None,
     })?)
 }
 

--- a/packages/euclid/src/msgs/router/query.rs
+++ b/packages/euclid/src/msgs/router/query.rs
@@ -81,6 +81,7 @@ pub struct VlpResponse {
     pub vlp: String,
     pub token_1: Token,
     pub token_2: Token,
+    pub pool_key: Option<PoolKey>,
 }
 
 #[cw_serde]


### PR DESCRIPTION
# Pull Request

## Description

Adds an optional `pool_key` field to `VlpResponse` so that callers can distinguish between constant product and concentrated pool VLPs. For concentrated pools, the response now includes the full `PoolKey` with fee tier and tick spacing. Constant product VLPs return `None`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor/Chore

## Related Issue

N/A

## Testing

Steps to test:

1. Query `all_vlps` and verify concentrated pool entries include a populated `pool_key`
2. Query `all_vlps` and verify constant product pool entries have `pool_key: null`
3. Query a single VLP via `query_vlp` and verify `pool_key` is `null` (constant product path)

## Checklist

- [x] Self-review completed
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated (if applicable)

## Screenshots (if applicable)

N/A

## Additional Notes

N/A