### PR TITLE
refactor: rename lp_allocation to liquidity_delta for CLP

### DIFF
--- a/contracts/hub/router/src/ibc/receive/pool.rs
+++ b/contracts/hub/router/src/ibc/receive/pool.rs
@@ -573,7 +573,7 @@ pub fn ibc_execute_remove_concentrated_liquidity(
             sender: msg.sender,
             pool_key: msg.pool_key,
             position_id: msg.position_id,
-            liquidity_delta: msg.lp_allocation,
+            liquidity_delta: msg.liquidity_delta,
             tx_id: msg.tx_id,
         });
 

--- a/contracts/hub/router/src/reply.rs
+++ b/contracts/hub/router/src/reply.rs
@@ -13,7 +13,7 @@ use euclid::{
     msgs::{
         self,
         vlp::base::{
-            ConcentratedPoolCreationResponse, PoolCreationResponse,
+            ConcentratedPoolCreationResponse, PoolCreationResponse, VlpAddLiquidityResponse,
             VlpConcentratedAddLiquidityResponse, VlpConcentratedCollectFeesResponse,
             VlpConcentratedCollectProtocolFeesResponse, VlpConcentratedRemoveLiquidityResponse,
             VlpRemoveLiquidityResponse, VlpSwapResponse,
@@ -230,14 +230,12 @@ pub fn on_add_liquidity_reply(deps: DepsMut, msg: Reply) -> Result<Response, Con
                 from_json::<VlpConcentratedAddLiquidityResponse>(data.clone())
             {
                 let mut res = Response::new();
-                if CONCENTRATED_FUNDS_INFO.may_load(deps.storage)?.is_some() {
-                    CONCENTRATED_FUNDS_INFO.remove(deps.storage);
-                }
+                // Remove funds info if it exists
+                CONCENTRATED_FUNDS_INFO.remove(deps.storage);
                 let ack = AcknowledgementMsg::Ok(ConcentratedAddLiquidityResponse {
                     pool_key: liquidity_response.pool_key.clone(),
                     position_id: liquidity_response.position_id,
                     liquidity_delta: liquidity_response.liquidity_delta,
-                    mint_lp_tokens: liquidity_response.liquidity_delta,
                     vlp_address: liquidity_response.vlp_address.clone(),
                     tx_id: liquidity_response.tx_id.clone(),
                     sender: liquidity_response.sender.clone(),
@@ -249,29 +247,22 @@ pub fn on_add_liquidity_reply(deps: DepsMut, msg: Reply) -> Result<Response, Con
                     .add_attribute("liquidity", format!("{liquidity_response:?}")));
             }
 
-            let liquidity_response: AddLiquidityResponse = from_json(data)?;
+            let liquidity_response: VlpAddLiquidityResponse = from_json(data)?;
 
             let mut res = Response::new();
-            let funds = FUNDS_INFO.may_load(deps.storage)?;
-            match funds {
-                Some(_) => {
-                    let pool_response = PoolCreationResponse {
-                        mint_lp_tokens: liquidity_response.mint_lp_tokens,
-                        vlp_contract: liquidity_response.vlp_address.clone(),
-                        tx_id: liquidity_response.tx_id.clone(),
-                        sender: liquidity_response.sender.clone(),
-                    };
-                    FUNDS_INFO.remove(deps.storage);
+            // Remove funds info if it exists
+            FUNDS_INFO.remove(deps.storage);
 
-                    let ack = AcknowledgementMsg::Ok(pool_response);
-                    res = res.set_data(to_json_binary(&ack)?);
-                }
-                None => {
-                    let ack: AcknowledgementMsg<AddLiquidityResponse> =
-                        AcknowledgementMsg::Ok(liquidity_response.clone());
-                    res = res.set_data(to_json_binary(&ack)?);
-                }
-            }
+            let add_liquidity_response = AddLiquidityResponse {
+                mint_lp_tokens: liquidity_response.mint_lp_tokens,
+                vlp_address: liquidity_response.vlp_address.clone(),
+                tx_id: liquidity_response.tx_id.clone(),
+                sender: liquidity_response.sender.clone(),
+            };
+
+            let ack: AcknowledgementMsg<AddLiquidityResponse> =
+                AcknowledgementMsg::Ok(add_liquidity_response.clone());
+            res = res.set_data(to_json_binary(&ack)?);
 
             Ok(res
                 .add_attribute("action", "reply_add_liquidity")
@@ -626,8 +617,13 @@ mod tests {
         chain::ChainUid,
         cross_chain_user::CrossChainUser,
         liquidity::AddLiquidityResponse,
-        msgs::vlp::base::{PoolCreationResponse, VlpRemoveLiquidityResponse, VlpSwapResponse},
-        token::{Pair, PairWithDenomAndAmount, Token, TokenType, TokenWithDenomAndAmount},
+        msgs::vlp::base::{
+            PoolCreationResponse, VlpAddLiquidityResponse, VlpRemoveLiquidityResponse,
+            VlpSwapResponse,
+        },
+        token::{
+            Pair, PairWithAmount, PairWithDenomAndAmount, Token, TokenType, TokenWithDenomAndAmount,
+        },
     };
     use euclid_ibc::router_ibc::{
         RouterCrossChainRemoveLiquidityExecuteMsg, RouterCrossChainSwapExecuteMsg,
@@ -844,8 +840,9 @@ mod tests {
     // on_add_liquidity_reply — plain add-liquidity path (no FUNDS_INFO)
     // -----------------------------------------------------------------------
 
-    fn make_add_liquidity_response() -> AddLiquidityResponse {
-        AddLiquidityResponse {
+    fn make_add_liquidity_response(pair_with_amount: PairWithAmount) -> VlpAddLiquidityResponse {
+        VlpAddLiquidityResponse {
+            liquidity_added: pair_with_amount,
             mint_lp_tokens: Uint128::new(500),
             vlp_address: "vlp_contract".to_string(),
             tx_id: "tx-add-liq-1".to_string(),
@@ -860,7 +857,16 @@ mod tests {
     fn test_add_liquidity_reply_no_funds_info_returns_add_liq_ack() {
         let mut deps = initialized();
 
-        let liq_response = make_add_liquidity_response();
+        let pair = Pair::new(
+            Token::create("aaa".to_string()).unwrap(),
+            Token::create("bbb".to_string()).unwrap(),
+        )
+        .unwrap();
+
+        let liq_response = make_add_liquidity_response(
+            pair.get_pair_with_amount(Uint128::new(100), Uint128::new(200))
+                .unwrap(),
+        );
         let inner_json = cosmwasm_std::to_json_binary(&liq_response).unwrap();
         let proto_bytes = encode_execute_response(&inner_json);
         let reply = ok_reply(ADD_LIQUIDITY_REPLY_ID, proto_bytes);
@@ -881,7 +887,7 @@ mod tests {
     }
 
     #[test]
-    fn test_add_liquidity_reply_with_funds_info_builds_pool_creation_ack_and_clears_funds_info() {
+    fn test_add_liquidity_reply_with_funds_info_builds_add_liquidity_ack_and_clears_funds_info() {
         let mut deps = initialized();
 
         // Seed FUNDS_INFO (simulates pool-creation path)
@@ -900,10 +906,11 @@ mod tests {
             },
         };
         FUNDS_INFO
-            .save(deps.as_mut().storage, &(pair_with_denom, 50u64))
+            .save(deps.as_mut().storage, &(pair_with_denom.clone(), 50u64))
             .unwrap();
 
-        let liq_response = make_add_liquidity_response();
+        let liq_response =
+            make_add_liquidity_response(pair_with_denom.get_pair_with_amount().unwrap());
         let inner_json = cosmwasm_std::to_json_binary(&liq_response).unwrap();
         let proto_bytes = encode_execute_response(&inner_json);
         let reply = ok_reply(ADD_LIQUIDITY_REPLY_ID, proto_bytes);
@@ -1209,7 +1216,6 @@ mod tests {
         PoolCreationResponse {
             vlp_contract: vlp_address.to_string(),
             tx_id: tx_id.to_string(),
-            mint_lp_tokens: Uint128::new(1000),
             sender: CrossChainUser::new(
                 ChainUid::create("chain1".to_string()).unwrap(),
                 "user1".to_string(),

--- a/contracts/hub/router/src/reply.rs
+++ b/contracts/hub/router/src/reply.rs
@@ -233,7 +233,6 @@ pub fn on_add_liquidity_reply(deps: DepsMut, msg: Reply) -> Result<Response, Con
                 // Remove funds info if it exists
                 CONCENTRATED_FUNDS_INFO.remove(deps.storage);
                 let ack = AcknowledgementMsg::Ok(ConcentratedAddLiquidityResponse {
-                    pool_key: liquidity_response.pool_key.clone(),
                     position_id: liquidity_response.position_id,
                     liquidity_delta: liquidity_response.liquidity_delta,
                     vlp_address: liquidity_response.vlp_address.clone(),

--- a/contracts/liquidity/factory/src/contract.rs
+++ b/contracts/liquidity/factory/src/contract.rs
@@ -259,7 +259,7 @@ pub fn execute(
         ExecuteMsg::RemoveConcentratedLiquidity {
             pool_key,
             position_id,
-            lp_allocation,
+            liquidity_delta,
             recipient,
             cross_chain_config,
         } => {
@@ -272,7 +272,7 @@ pub fn execute(
                 sender,
                 pool_key,
                 position_id,
-                lp_allocation,
+                liquidity_delta,
                 recipient,
                 cross_chain_config,
             )

--- a/contracts/liquidity/factory/src/execute/pool.rs
+++ b/contracts/liquidity/factory/src/execute/pool.rs
@@ -720,7 +720,7 @@ pub fn remove_concentrated_liquidity_request(
     sender: CrossChainUser,
     pool_key: euclid::msgs::vlp::base::PoolKey,
     position_id: Uint128,
-    lp_allocation: Uint128,
+    liquidity_delta: Uint128,
     recipient: CrossChainUser,
     cross_chain_config: CrossChainConfig,
 ) -> Result<Response, ContractError> {
@@ -733,7 +733,10 @@ pub fn remove_concentrated_liquidity_request(
             .has(deps.storage, (sender_addr.clone(), tx_id.clone())),
         ContractError::TxAlreadyExist {}
     );
-    ensure!(!lp_allocation.is_zero(), ContractError::ZeroAssetAmount {});
+    ensure!(
+        !liquidity_delta.is_zero(),
+        ContractError::ZeroAssetAmount {}
+    );
 
     // position_meta is loaded for the pool_key structural check below.
     // position_meta.owner is NOT used for authorization here — the NFT contract
@@ -771,7 +774,7 @@ pub fn remove_concentrated_liquidity_request(
         sender: sender_addr.clone(),
         pool_key: pool_key.clone(),
         position_id: position_id.u128(),
-        lp_allocation,
+        liquidity_delta,
     };
 
     PENDING_CONCENTRATED_REMOVE_LIQUIDITY.save(
@@ -786,7 +789,7 @@ pub fn remove_concentrated_liquidity_request(
             sender,
             pool_key,
             position_id,
-            lp_allocation,
+            liquidity_delta,
             recipient,
             tx_id: tx_id.clone(),
         },

--- a/contracts/liquidity/factory/src/ibc/ack_and_timeout.rs
+++ b/contracts/liquidity/factory/src/ibc/ack_and_timeout.rs
@@ -346,7 +346,7 @@ fn ack_concentrated_pool_creation(
                 data.position_id.u128(),
                 &crate::state::ConcentratedPositionMetadata {
                     owner: sender.clone(),
-                    pool_key: data.pool_key.clone(),
+                    pool_key: existing_req.pool_key.clone(),
                     liquidity: data.liquidity_delta,
                     vlp_address: data.vlp_address.clone(),
                 },
@@ -706,18 +706,17 @@ fn ack_add_concentrated_liquidity(
             let existing_meta = POSITION_ID_TO_METADATA.may_load(deps.storage, position_id)?;
             match existing_meta {
                 Some(mut meta) => {
-                    // IBC acks carry no info.sender, so we cannot do a live NFT
+                                     // IBC acks carry no info.sender, so we cannot do a live NFT
                     // ownership query here. meta.owner is the address that was
                     // recorded when the metadata was first written on mint, and
                     // sender is recovered from the pending request — together they
                     // confirm this ack belongs to the original requester.
                     ensure!(meta.owner == sender, ContractError::Unauthorized {});
                     ensure!(
-                        meta.pool_key == data.pool_key,
+                        meta.pool_key == liquidity_info.pool_key,
                         ContractError::new("Pool key mismatch")
                     );
                     meta.liquidity = meta.liquidity.checked_add(data.liquidity_delta)?;
-                    meta.vlp_address = data.vlp_address.clone();
                     POSITION_ID_TO_METADATA.save(deps.storage, position_id, &meta)?;
                 }
                 None => {
@@ -726,7 +725,7 @@ fn ack_add_concentrated_liquidity(
                         position_id,
                         &crate::state::ConcentratedPositionMetadata {
                             owner: sender.clone(),
-                            pool_key: data.pool_key.clone(),
+                            pool_key: liquidity_info.pool_key.clone(),
                             liquidity: data.liquidity_delta,
                             vlp_address: data.vlp_address.clone(),
                         },
@@ -1227,8 +1226,9 @@ mod tests {
 
     use crate::reply::{ESCROW_INSTANTIATE_REPLY_ID, NFT_MINT_REPLY_ID};
     use crate::state::{
-        ConcentratedAddLiquidityRequest, ADMIN, PENDING_CONCENTRATED_ADD_LIQUIDITY,
-        PENDING_DEPOSIT_TOKEN, STATE, TOKEN_TO_ESCROW,
+        ConcentratedAddLiquidityRequest, ConcentratedPositionMetadata, ADMIN,
+        PENDING_CONCENTRATED_ADD_LIQUIDITY, PENDING_DEPOSIT_TOKEN, POSITION_ID_TO_METADATA, STATE,
+        TOKEN_TO_ESCROW,
     };
 
     struct EscrowAckCase {
@@ -1347,7 +1347,6 @@ mod tests {
             }
 
             let ack_data = ConcentratedAddLiquidityResponse {
-                pool_key,
                 position_id: Uint128::new(1),
                 liquidity_delta: Uint128::new(500),
                 vlp_address: "vlp_contract".to_string(),
@@ -1391,5 +1390,130 @@ mod tests {
                 case.name
             );
         }
+    }
+
+    #[test]
+    fn ack_add_concentrated_liquidity_rejects_mismatched_metadata_owner() {
+        let mut deps = mock_dependencies();
+        let sender = deps.api.addr_make("sender");
+        let other_owner = deps.api.addr_make("other_owner");
+        let tx_id = "tx_owner_mismatch".to_string();
+        let token_a = Token::create("tokena".to_string()).unwrap();
+        let token_b = Token::create("tokenb".to_string()).unwrap();
+        let pair = euclid::token::Pair::new(token_a.clone(), token_b.clone()).unwrap();
+
+        STATE
+            .save(
+                deps.as_mut().storage,
+                &crate::state::State {
+                    router_contract: "router".to_string(),
+                    relayer_contract: Addr::unchecked("relayer"),
+                    escrow_code_id: 42,
+                    lp_code_id: 2,
+                    position_token_code_id: 3,
+                    chain_uid: ChainUid::create("testchain".to_string()).unwrap(),
+                    is_native: false,
+                },
+            )
+            .unwrap();
+        ADMIN
+            .save(
+                deps.as_mut().storage,
+                &EuclidAdmin::default(Addr::unchecked("admin")),
+            )
+            .unwrap();
+        POSITION_TOKEN_CONTRACT
+            .save(deps.as_mut().storage, &Addr::unchecked("position_token"))
+            .unwrap();
+
+        let pool_key = PoolKey {
+            pair,
+            pool_type: PoolType::Concentrated {
+                fee_tier_bps: 3000,
+                tick_spacing: 60,
+            },
+        };
+
+        // Pending request has `sender` as the requester
+        PENDING_CONCENTRATED_ADD_LIQUIDITY
+            .save(
+                deps.as_mut().storage,
+                (sender.clone(), tx_id.clone()),
+                &ConcentratedAddLiquidityRequest {
+                    tx_id: tx_id.clone(),
+                    sender: sender.clone(),
+                    pair_info: PairWithDenomAndAmount {
+                        token_1: TokenWithDenomAndAmount {
+                            token: token_a.clone(),
+                            amount: Uint128::new(1000),
+                            token_type: TokenType::Native {
+                                denom: "utokena".to_string(),
+                            },
+                        },
+                        token_2: TokenWithDenomAndAmount {
+                            token: token_b.clone(),
+                            amount: Uint128::new(2000),
+                            token_type: TokenType::Native {
+                                denom: "utokenb".to_string(),
+                            },
+                        },
+                    },
+                    pool_key: pool_key.clone(),
+                    lower_tick_index: -600,
+                    upper_tick_index: 600,
+                    position_id: Some(1u128),
+                },
+            )
+            .unwrap();
+
+        // Pre-existing metadata with a *different* owner
+        POSITION_ID_TO_METADATA
+            .save(
+                deps.as_mut().storage,
+                1u128,
+                &ConcentratedPositionMetadata {
+                    owner: other_owner.clone(),
+                    pool_key: pool_key.clone(),
+                    liquidity: Uint128::new(500),
+                    vlp_address: "vlp_contract".to_string(),
+                },
+            )
+            .unwrap();
+
+        // Seed both escrows so escrow handling doesn't interfere
+        for (tok, addr) in [("tokena", "escrow_a"), ("tokenb", "escrow_b")] {
+            TOKEN_TO_ESCROW
+                .save(
+                    deps.as_mut().storage,
+                    Token::create(tok.to_string()).unwrap(),
+                    &Addr::unchecked(addr),
+                )
+                .unwrap();
+        }
+
+        let ack_data = ConcentratedAddLiquidityResponse {
+            position_id: Uint128::new(1),
+            liquidity_delta: Uint128::new(300),
+            vlp_address: "vlp_contract".to_string(),
+            tx_id: tx_id.clone(),
+            sender: CrossChainUser::new(
+                ChainUid::create("testchain".to_string()).unwrap(),
+                sender.to_string(),
+            ),
+        };
+
+        let err = ack_add_concentrated_liquidity(
+            deps.as_mut(),
+            AcknowledgementMsg::Ok(ack_data),
+            sender.to_string(),
+            tx_id,
+            false,
+        )
+        .unwrap_err();
+
+        assert!(
+            matches!(err, ContractError::Unauthorized {}),
+            "expected Unauthorized, got: {err:?}"
+        );
     }
 }

--- a/contracts/liquidity/factory/src/ibc/ack_and_timeout.rs
+++ b/contracts/liquidity/factory/src/ibc/ack_and_timeout.rs
@@ -706,7 +706,7 @@ fn ack_add_concentrated_liquidity(
             let existing_meta = POSITION_ID_TO_METADATA.may_load(deps.storage, position_id)?;
             match existing_meta {
                 Some(mut meta) => {
-                                     // IBC acks carry no info.sender, so we cannot do a live NFT
+                    // IBC acks carry no info.sender, so we cannot do a live NFT
                     // ownership query here. meta.owner is the address that was
                     // recorded when the metadata was first written on mint, and
                     // sender is recovered from the pending request — together they

--- a/contracts/liquidity/factory/src/ibc/ack_and_timeout.rs
+++ b/contracts/liquidity/factory/src/ibc/ack_and_timeout.rs
@@ -52,7 +52,7 @@ pub fn reusable_internal_ack_call(
     match msg {
         RouterCrossChainExecuteMsg::RequestPoolCreation { tx_id, sender, .. } => {
             // Process acknowledgment for pool creation
-            let res: AcknowledgementMsg<PoolCreationResponse> = from_json(ack)?;
+            let res: AcknowledgementMsg<AddLiquidityResponse> = from_json(ack)?;
 
             ack_pool_creation(deps.branch(), env, sender.address, res, tx_id, is_native)
         }
@@ -165,7 +165,7 @@ fn ack_pool_creation(
     deps: DepsMut,
     env: Env,
     sender: String,
-    res: AcknowledgementMsg<PoolCreationResponse>,
+    res: AcknowledgementMsg<AddLiquidityResponse>,
     tx_id: String,
     is_native: bool,
 ) -> Result<Response, ContractError> {
@@ -190,13 +190,13 @@ fn ack_pool_creation(
             PAIR_TO_VLP.save(
                 deps.storage,
                 existing_req.pair_info.get_pair()?.get_tupple(),
-                &data.vlp_contract.clone(),
+                &data.vlp_address.clone(),
             )?;
             // Prepare response
             let mut res = Response::new()
                 .add_attribute("tx_id", tx_id)
                 .add_attribute("method", "pool_creation")
-                .add_attribute("vlp", data.vlp_contract.clone());
+                .add_attribute("vlp", data.vlp_address.clone());
             // Collects PairInfo into a vector of Token Info for easy iteration
             let tokens = existing_req.pair_info.get_vec_token_info();
             for token in tokens {
@@ -249,7 +249,7 @@ fn ack_pool_creation(
                     }],
                     mint: lp_token_instantiate_data.mint,
                     marketing: lp_token_instantiate_data.marketing,
-                    vlp: data.vlp_contract.clone(),
+                    vlp: data.vlp_address.clone(),
                     factory: env.contract.address,
                     token_pair: existing_req.pair_info.get_pair()?,
                 })?,
@@ -257,7 +257,11 @@ fn ack_pool_creation(
                 label: "cw20".to_string(),
             });
             // Save lp shares against vlp address
-            VLP_TO_LP_SHARES.save(deps.storage, data.vlp_contract, &data.mint_lp_tokens.into())?;
+            VLP_TO_LP_SHARES.save(
+                deps.storage,
+                data.vlp_address.clone(),
+                &data.mint_lp_tokens.into(),
+            )?;
 
             Ok(res.add_submessage(SubMsg {
                 id: LP_INSTANTIATE_REPLY_ID,
@@ -1346,7 +1350,6 @@ mod tests {
                 pool_key,
                 position_id: Uint128::new(1),
                 liquidity_delta: Uint128::new(500),
-                mint_lp_tokens: Uint128::zero(),
                 vlp_address: "vlp_contract".to_string(),
                 tx_id: tx_id.clone(),
                 sender: CrossChainUser::new(

--- a/contracts/liquidity/factory/src/state.rs
+++ b/contracts/liquidity/factory/src/state.rs
@@ -144,7 +144,7 @@ pub struct ConcentratedRemoveLiquidityRequest {
     pub sender: Addr,
     pub pool_key: PoolKey,
     pub position_id: u128,
-    pub lp_allocation: cosmwasm_std::Uint128,
+    pub liquidity_delta: cosmwasm_std::Uint128,
 }
 pub const PENDING_CONCENTRATED_REMOVE_LIQUIDITY: Map<
     (Addr, String),

--- a/packages/euclid/src/liquidity.rs
+++ b/packages/euclid/src/liquidity.rs
@@ -43,12 +43,11 @@ pub struct RemoveLiquidityResponse {
 #[cw_serde]
 pub struct ConcentratedAddLiquidityResponse {
     pub pool_key: PoolKey,
-    pub position_id: Uint128,
-    pub liquidity_delta: Uint128,
-    pub mint_lp_tokens: Uint128,
     pub vlp_address: String,
     pub tx_id: String,
     pub sender: CrossChainUser,
+    pub position_id: Uint128,
+    pub liquidity_delta: Uint128,
 }
 
 #[cw_serde]

--- a/packages/euclid/src/liquidity.rs
+++ b/packages/euclid/src/liquidity.rs
@@ -42,7 +42,6 @@ pub struct RemoveLiquidityResponse {
 
 #[cw_serde]
 pub struct ConcentratedAddLiquidityResponse {
-    pub pool_key: PoolKey,
     pub vlp_address: String,
     pub tx_id: String,
     pub sender: CrossChainUser,

--- a/packages/euclid/src/msgs/factory/msg.rs
+++ b/packages/euclid/src/msgs/factory/msg.rs
@@ -98,7 +98,7 @@ pub enum ExecuteMsg {
     RemoveConcentratedLiquidity {
         pool_key: PoolKey,
         position_id: Uint128,
-        lp_allocation: Uint128,
+        liquidity_delta: Uint128,
         recipient: CrossChainUser,
         cross_chain_config: CrossChainConfig,
     },

--- a/packages/euclid/src/msgs/vlp/base.rs
+++ b/packages/euclid/src/msgs/vlp/base.rs
@@ -137,16 +137,15 @@ pub struct GetSwapQueryResponse {
 pub struct PoolCreationResponse {
     pub vlp_contract: String,
     pub tx_id: String,
-    pub mint_lp_tokens: Uint128,
     pub sender: CrossChainUser,
 }
 
 #[cw_serde]
 pub struct ConcentratedPoolCreationResponse {
+    pub pool_key: PoolKey,
     pub vlp_contract: String,
     pub tx_id: String,
     pub sender: CrossChainUser,
-    pub pool_key: PoolKey,
 }
 
 #[cw_serde]

--- a/packages/euclid_ibc/src/router_ibc.rs
+++ b/packages/euclid_ibc/src/router_ibc.rs
@@ -225,7 +225,7 @@ pub struct RouterCrossChainConcentratedRemoveLiquidityExecuteMsg {
     pub sender: CrossChainUser,
     pub pool_key: PoolKey,
     pub position_id: Uint128,
-    pub lp_allocation: Uint128,
+    pub liquidity_delta: Uint128,
     pub recipient: CrossChainUser,
     pub tx_id: String,
 }

--- a/packages/pool/src/pool_functions.rs
+++ b/packages/pool/src/pool_functions.rs
@@ -8,8 +8,8 @@ use euclid::{
     liquidity::AddLiquidityResponse,
     msgs::vlp::{
         base::{
-            GetSwapQueryResponse, PoolConfig, State, VlpRemoveLiquidityResponse, VlpSwapMsg,
-            VlpSwapResponse, NEXT_SWAP_REPLY_ID,
+            GetSwapQueryResponse, PoolConfig, State, VlpAddLiquidityResponse,
+            VlpRemoveLiquidityResponse, VlpSwapMsg, VlpSwapResponse, NEXT_SWAP_REPLY_ID,
         },
         stable::msg::DEFAULT_AMP_FACTOR,
     },
@@ -234,7 +234,6 @@ pub fn register_pool(
     let ack = PoolCreationResponse {
         vlp_contract: env.contract.address.to_string(),
         tx_id: tx_id.clone(),
-        mint_lp_tokens: Uint128::zero(),
         sender: sender.clone(),
     };
 
@@ -490,7 +489,8 @@ pub fn add_liquidity(
     // Add current balance to SNAPSHOT MAP
 
     // Prepare Liquidity Response
-    let liquidity_response = AddLiquidityResponse {
+    let liquidity_response = VlpAddLiquidityResponse {
+        liquidity_added: liquidity.clone(),
         mint_lp_tokens: lp_allocation,
         vlp_address: env.contract.address.to_string(),
         tx_id: tx_id.clone(),

--- a/tests-integration/src/helpers/factory.rs
+++ b/tests-integration/src/helpers/factory.rs
@@ -349,7 +349,7 @@ pub fn remove_concentrated_liquidity(
     router: &RouterContract<MockBase>,
     pool_key: PoolKey,
     position_id: Uint128,
-    lp_allocation: Uint128,
+    liquidity_delta: Uint128,
 ) -> Result<(), CwOrchError> {
     let state = factory.get_state()?;
     let sender = CrossChainUser::new(state.chain_uid, factory.environment().sender.to_string());
@@ -358,7 +358,7 @@ pub fn remove_concentrated_liquidity(
         &euclid::msgs::factory::ExecuteMsg::RemoveConcentratedLiquidity {
             pool_key,
             position_id,
-            lp_allocation,
+            liquidity_delta,
             recipient: sender,
             cross_chain_config: CrossChainConfig::default(),
         },


### PR DESCRIPTION
# Pull Request

## Description

Renames `lp_allocation` to `liquidity_delta` across the concentrated liquidity pool (CLP) remove liquidity path. The CP/Stable pools use fungible LP tokens, so `lp_allocation` is semantically correct there. However, concentrated liquidity positions use raw liquidity units (L) within a tick range, making `liquidity_delta` the accurate name. Also includes VlpResponse enhancement with optional `pool_key` for concentrated pools.

## Type of Change

- [x] Refactor/Chore

## Related Issue

N/A

## Testing

Steps to test:

1. `cargo clippy --all-targets --all-features`
2. `cargo test -p factory`
3. `cargo test -p router`

## Checklist

- [x] Self-review completed
- [x] Tests added/updated (if applicable)
- [x] Documentation updated (if applicable)

## Additional Notes

The rename spans the full CLP remove liquidity flow: factory ExecuteMsg, factory state (`ConcentratedRemoveLiquidityRequest`), factory execute logic, IBC cross-chain message (`RouterCrossChainConcentratedRemoveLiquidityExecuteMsg`), router IBC receive handler, and integration test helpers. Non-concentrated (CP/Stable) paths retain `lp_allocation` unchanged.