### PR TITLE
refactor: centralize tick bounds in liquidity module

### DIFF
--- a/contracts/hub/concentrated_vlp/src/state.rs
+++ b/contracts/hub/concentrated_vlp/src/state.rs
@@ -17,13 +17,7 @@ pub const BALANCES: Map<Token, Uint128> = Map::new("balances");
 
 pub const POOL_KEY: Item<PoolKey> = Item::new("pool_key");
 
-/// Tick bounds derived from the Q64.96 fixed point representation of sqrt_price.
-/// price = 1.0001^tick, stored as sqrt_price_x96 = sqrt(1.0001^tick) * 2^96.
-/// MIN_TICK is the lowest tick whose sqrt_price_x96 remains non-zero (~2.94e-39 price).
-/// MAX_TICK is the highest tick that fits in Uint256 without overflow (~3.40e38 price).
-/// Any tick outside this range cannot be represented in the swap math.
-pub const MIN_TICK: i64 = -887272;
-pub const MAX_TICK: i64 = 887272;
+pub use euclid::liquidity::{MAX_TICK, MIN_TICK};
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
 pub struct Slot0 {

--- a/contracts/hub/router/src/ibc/receive/pool.rs
+++ b/contracts/hub/router/src/ibc/receive/pool.rs
@@ -5,6 +5,7 @@ use euclid::{
     error::ContractError,
     events::{register_denom_event, tx_event, TxType},
     fee::Fee,
+    liquidity::{MAX_TICK, MIN_TICK},
     msgs::{
         self,
         router::TokenDenom,
@@ -43,11 +44,6 @@ use crate::{
 };
 
 fn default_aligned_tick_bounds(tick_spacing: u64) -> (i64, i64) {
-    // Tick bounds from Q64.96 sqrt_price representation.
-    // MIN_TICK → smallest non-zero sqrt_price (~2.94e-39 price).
-    // MAX_TICK → largest sqrt_price fitting Uint256 (~3.40e38 price).
-    const MIN_TICK: i64 = -887_272;
-    const MAX_TICK: i64 = 887_272;
     let spacing = tick_spacing as i64;
     let lower = (MIN_TICK / spacing) * spacing;
     let lower = if lower < MIN_TICK {

--- a/contracts/liquidity/factory/src/execute/pool.rs
+++ b/contracts/liquidity/factory/src/execute/pool.rs
@@ -5,7 +5,7 @@ use euclid::{
     error::ContractError,
     events::tx_event,
     fee::BPS_100_PERCENT,
-    liquidity::{AddLiquidityRequest, RemoveLiquidityRequest},
+    liquidity::{AddLiquidityRequest, RemoveLiquidityRequest, MAX_TICK, MIN_TICK},
     msgs::{
         self,
         cross_chain_config::CrossChainConfig,
@@ -582,6 +582,10 @@ pub fn add_concentrated_liquidity_request(
     ensure!(
         lower_tick_index < upper_tick_index,
         ContractError::new("Invalid tick range")
+    );
+    ensure!(
+        lower_tick_index >= MIN_TICK && upper_tick_index <= MAX_TICK,
+        ContractError::new("Tick index out of bounds")
     );
     let tick_spacing = match pool_key.pool_type {
         PoolType::Concentrated { tick_spacing, .. } => tick_spacing,

--- a/packages/euclid/src/liquidity.rs
+++ b/packages/euclid/src/liquidity.rs
@@ -7,6 +7,13 @@ use crate::{
     token::{Pair, PairWithAmount, PairWithDenomAndAmount},
 };
 
+/// Tick bounds derived from the Q64.96 fixed-point representation of sqrt_price.
+/// price = 1.0001^tick, stored as sqrt_price_x96 = sqrt(1.0001^tick) * 2^96.
+/// MIN_TICK is the lowest tick whose sqrt_price_x96 remains non-zero (~2.94e-39 price).
+/// MAX_TICK is the highest tick that fits in Uint256 without overflow (~3.40e38 price).
+pub const MIN_TICK: i64 = -887_272;
+pub const MAX_TICK: i64 = 887_272;
+
 #[cw_serde]
 pub struct AddLiquidityRequest {
     pub sender: String,


### PR DESCRIPTION
## Description

Centralizes `MIN_TICK` and `MAX_TICK` constants into `packages/euclid/src/liquidity.rs` as the single source of truth. Previously these were duplicated as local constants in `concentrated_vlp/state.rs` and `router/ibc/receive/pool.rs`.

Also adds an early validation guard in the factory's `add_concentrated_liquidity_request` handler to reject tick indices outside the representable range before the request is forwarded cross-chain.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor/Chore

## Related Issue

N/A

## Testing

Steps to test:

1. `cargo test --lib` — all unit tests pass
2. Verify tick validation: submit a CLP add-liquidity request with `lower_tick_index < -887272` or `upper_tick_index > 887272` and confirm the factory returns `Tick index out of bounds`

## Checklist

- [x] Self-review completed
- [x] Tests added/updated (if applicable)
- [x] Documentation updated (if applicable)

## Additional Notes

The constants use underscore separators (`-887_272` / `887_272`) for readability, matching Rust numeric literal conventions.