### PR TITLE
Fix: Escrow failure when creating new pool with 1 new token in CLP

### DIFF
--- a/contracts/liquidity/factory/src/ibc/ack_and_timeout.rs
+++ b/contracts/liquidity/factory/src/ibc/ack_and_timeout.rs
@@ -330,8 +330,11 @@ fn ack_concentrated_pool_creation(
                     continue;
                 }
 
-                let escrow_contract =
-                    TOKEN_TO_ESCROW.load(deps.storage, token_info.token.clone())?;
+                let escrow_contract = TOKEN_TO_ESCROW
+                    .load(deps.storage, token_info.token.clone())
+                    .map_err(|_| ContractError::TokenEscrowDoesNotExist {
+                        token: token_info.token.to_string(),
+                    })?;
                 let send_msg = token_info
                     .token_type
                     .create_escrow_msg(token_info.amount, escrow_contract)?;

--- a/contracts/liquidity/factory/src/ibc/ack_and_timeout.rs
+++ b/contracts/liquidity/factory/src/ibc/ack_and_timeout.rs
@@ -324,10 +324,6 @@ fn ack_concentrated_pool_creation(
                 &data.vlp_address,
             )?;
 
-            let state = STATE.load(deps.storage)?;
-            let admins = ADMIN.load(deps.storage)?;
-            let escrow_code_id = state.escrow_code_id;
-
             let mut res = Response::new();
             for token_info in existing_req.pair_info.get_vec_token_info() {
                 if token_info.token_type.is_voucher() {
@@ -345,6 +341,9 @@ fn ack_concentrated_pool_creation(
                         res = res.add_message(send_msg);
                     }
                     None => {
+                        let state = STATE.load(deps.storage)?;
+                        let admins = ADMIN.load(deps.storage)?;
+                        let escrow_code_id = state.escrow_code_id;
                         let init_msg = CosmosMsg::Wasm(WasmMsg::Instantiate {
                             admin: Some(admins.migration_admin.clone().into_string()),
                             code_id: escrow_code_id,

--- a/contracts/liquidity/factory/src/ibc/ack_and_timeout.rs
+++ b/contracts/liquidity/factory/src/ibc/ack_and_timeout.rs
@@ -324,21 +324,51 @@ fn ack_concentrated_pool_creation(
                 &data.vlp_address,
             )?;
 
+            let state = STATE.load(deps.storage)?;
+            let admins = ADMIN.load(deps.storage)?;
+            let escrow_code_id = state.escrow_code_id;
+
             let mut res = Response::new();
             for token_info in existing_req.pair_info.get_vec_token_info() {
                 if token_info.token_type.is_voucher() {
                     continue;
                 }
 
-                let escrow_contract = TOKEN_TO_ESCROW
-                    .load(deps.storage, token_info.token.clone())
-                    .map_err(|_| ContractError::TokenEscrowDoesNotExist {
-                        token: token_info.token.to_string(),
-                    })?;
-                let send_msg = token_info
-                    .token_type
-                    .create_escrow_msg(token_info.amount, escrow_contract)?;
-                res = res.add_message(send_msg);
+                let escrow_contract =
+                    TOKEN_TO_ESCROW.may_load(deps.storage, token_info.token.clone())?;
+
+                match escrow_contract {
+                    Some(address) => {
+                        let send_msg = token_info
+                            .token_type
+                            .create_escrow_msg(token_info.amount, address)?;
+                        res = res.add_message(send_msg);
+                    }
+                    None => {
+                        let init_msg = CosmosMsg::Wasm(WasmMsg::Instantiate {
+                            admin: Some(admins.migration_admin.clone().into_string()),
+                            code_id: escrow_code_id,
+                            msg: to_json_binary(&EscrowInstantiateMsg {
+                                token_id: token_info.clone().token,
+                                allowed_denom: Some(token_info.clone().token_type),
+                            })?,
+                            funds: vec![],
+                            label: "escrow".to_string(),
+                        });
+                        PENDING_DEPOSIT_TOKEN.save(
+                            deps.storage,
+                            token_info.clone().token,
+                            &token_info,
+                        )?;
+                        res = res.add_submessage(SubMsg {
+                            id: ESCROW_INSTANTIATE_REPLY_ID,
+                            msg: init_msg,
+                            gas_limit: None,
+                            reply_on: ReplyOn::Always,
+                            payload: Binary::default(),
+                        });
+                    }
+                }
             }
 
             let position_token_contract = POSITION_TOKEN_CONTRACT

--- a/packages/euclid/src/error.rs
+++ b/packages/euclid/src/error.rs
@@ -190,6 +190,9 @@ pub enum ContractError {
     #[error("EscrowDoesNotExist")]
     EscrowDoesNotExist {},
 
+    #[error("Token EscrowDoesNotExist: {token}")]
+    TokenEscrowDoesNotExist { token: String },
+
     #[error("EscrowAlreadyExists")]
     EscrowAlreadyExists {},
 

--- a/tests-integration/src/helpers/factory.rs
+++ b/tests-integration/src/helpers/factory.rs
@@ -17,7 +17,6 @@ use euclid::msgs::escrow::QueryMsgFns as EscrowQueryMsgFns;
 use euclid::msgs::factory::msg::ExecuteMsgFns as FactoryExecuteMsgFns;
 use euclid::msgs::factory::msg::QueryMsgFns as FactoryQueryMsgFns;
 use euclid::msgs::factory::ExecuteSwapRequest;
-use euclid::msgs::lp_token::msg::ExecuteMsgFns as LpTokenExecuteMsgFns;
 use euclid::msgs::router::query::QueryMsgFns as RouterQueryMsgFns;
 use euclid::msgs::virtual_balance::msg::QueryMsgFns as VirtualBalanceQueryMsgFns;
 use euclid::msgs::vlp::base::{PoolConfig, PoolKey, PoolType};
@@ -184,13 +183,48 @@ pub fn faucet(
             funds.push(coin(amount, denom));
         }
         TokenType::Smart { contract_address } => {
+            // Mint cw20 tokens to the recipient. Callers are responsible for
+            // granting allowance to the factory (or using the cw20 Send hook)
+            // when they need the factory to pull these tokens.
             let cw20 = LpTokenContract::new(chain.clone());
             cw20.set_address(&Addr::unchecked(contract_address));
-            // Increase allowance
-            cw20.increase_allowance(amount, address, None).unwrap();
+            cw20.execute(
+                &euclid::msgs::lp_token::msg::ExecuteMsg::Mint {
+                    recipient: address.to_string(),
+                    amount: Uint128::new(amount),
+                },
+                &[],
+            )
+            .unwrap();
         }
         _ => {}
     };
+}
+
+/// For each `TokenType::Smart` in `pair_with_denom`, granted an allowance to
+/// the factory contract equal to the requested amount, executed as the current
+/// chain sender. Native/voucher tokens are skipped.
+pub fn approve_factory_for_smart_tokens(
+    factory: &FactoryContract<MockBase>,
+    pair_with_denom: &PairWithDenomAndAmount,
+) -> Result<(), CwOrchError> {
+    let chain = factory.environment();
+    let factory_addr = factory.address()?.to_string();
+    for token in pair_with_denom.get_vec_token_info() {
+        if let TokenType::Smart { contract_address } = token.token_type {
+            let cw20 = LpTokenContract::new(chain.clone());
+            cw20.set_address(&Addr::unchecked(contract_address));
+            cw20.execute(
+                &euclid::msgs::lp_token::msg::ExecuteMsg::IncreaseAllowance {
+                    spender: factory_addr.clone(),
+                    amount: token.amount,
+                    expires: None,
+                },
+                &[],
+            )?;
+        }
+    }
+    Ok(())
 }
 
 pub fn create_pool(
@@ -286,6 +320,7 @@ pub fn create_concentrated_pool_with_tick(
             &mut funds,
         );
     }
+    approve_factory_for_smart_tokens(factory, &pair_with_denom)?;
     let tx_response = factory.execute(
         &euclid::msgs::factory::ExecuteMsg::RequestConcentratedPoolCreation {
             pair_with_denom_and_amount: pair_with_denom.clone(),
@@ -336,6 +371,7 @@ pub fn add_concentrated_liquidity(
             &mut funds,
         );
     }
+    approve_factory_for_smart_tokens(factory, &pair_with_denom)?;
 
     let tx_response = factory.execute(
         &euclid::msgs::factory::ExecuteMsg::AddConcentratedLiquidity {

--- a/tests-integration/src/tests_reusable/concentrated_create_pool.rs
+++ b/tests-integration/src/tests_reusable/concentrated_create_pool.rs
@@ -20,7 +20,7 @@ use crate::tests_reusable::constants::{
     FACTORY_CHAIN_ID_IBC, FACTORY_CHAIN_ID_LOCAL, ROUTER_CHAIN_ID,
 };
 use crate::tests_reusable::factory_register::{setup_factory_with_mode, FactorySetupMode};
-use crate::tests_reusable::factory_register_denom::register_denom;
+use crate::tests_reusable::factory_register_denom::{deregister_denom, register_denom};
 
 pub fn setup_concentrated_env(
     mode: FactorySetupMode,
@@ -220,6 +220,29 @@ fn test_create_pool_with_both_tokens_unregistered_rejected(
     assert!(
         err_str.contains("Atleast one token must already be registered"),
         "expected both-new-tokens error, got: {err_str}",
+    );
+}
+
+#[rstest]
+#[case(FactorySetupMode::Native, FACTORY_CHAIN_ID_LOCAL)]
+#[case(FactorySetupMode::Ibc, FACTORY_CHAIN_ID_IBC)]
+fn test_create_pool_with_disallowed_token_rejected(
+    #[case] mode: FactorySetupMode,
+    #[case] factory_chain_id: &str,
+) {
+    let (_interchain, factory, router, token_a, token_b) =
+        setup_concentrated_env(mode, factory_chain_id);
+
+    // Deregister token_b — escrow still exists but denom is now disallowed
+    deregister_denom(&factory, &router, token_b.clone()).unwrap();
+
+    let pair = pair_with_amounts(&token_a, &token_b, 20_000, 20_000);
+    let err = create_concentrated_pool(&factory, &router, pair, 500, 10, 100)
+        .expect_err("pool creation with a disallowed token must be rejected on factory call");
+    let err_str = err.root().to_string();
+    assert!(
+        err_str.contains("UnsupportedDenomination"),
+        "expected UnsupportedDenomination error, got: {err_str}",
     );
 }
 

--- a/tests-integration/src/tests_reusable/concentrated_create_pool.rs
+++ b/tests-integration/src/tests_reusable/concentrated_create_pool.rs
@@ -4,7 +4,6 @@ use cosmwasm_std::Uint128;
 use cw_orch::{mock::MockBase, prelude::*};
 use cw_orch_interchain::mock::MockInterchainEnv;
 use cw_orch_interchain::prelude::InterchainEnv;
-use euclid::error::ContractError;
 use euclid::msgs::cross_chain_config::CrossChainConfig;
 use euclid::msgs::factory::msg::QueryMsgFns as FactoryQueryMsgFns;
 use euclid::msgs::router::query::QueryMsgFns as RouterQueryMsgFns;
@@ -156,7 +155,7 @@ fn test_create_two_fee_tiers_same_pair_with_initial_tick(
 #[rstest]
 #[case(FactorySetupMode::Native, FACTORY_CHAIN_ID_LOCAL)]
 #[case(FactorySetupMode::Ibc, FACTORY_CHAIN_ID_IBC)]
-fn test_create_pool_with_unregistered_token_rejected(
+fn test_create_pool_with_unregistered_token_passes_and_creates_escrow(
     #[case] mode: FactorySetupMode,
     #[case] factory_chain_id: &str,
 ) {
@@ -180,6 +179,47 @@ fn test_create_pool_with_unregistered_token_rejected(
     assert!(
         escrow.denoms.contains(&token_c.token_type),
         "new token denom must be registered in its escrow after pool creation",
+    );
+}
+
+#[rstest]
+#[case(FactorySetupMode::Native, FACTORY_CHAIN_ID_LOCAL)]
+#[case(FactorySetupMode::Ibc, FACTORY_CHAIN_ID_IBC)]
+fn test_create_pool_with_both_tokens_unregistered_rejected(
+    #[case] mode: FactorySetupMode,
+    #[case] factory_chain_id: &str,
+) {
+    let sender = "sender_for_all_chains";
+    let mut chains = vec![(ROUTER_CHAIN_ID, sender)];
+    if factory_chain_id != ROUTER_CHAIN_ID {
+        chains.push((factory_chain_id, sender));
+    }
+    let interchain = MockInterchainEnv::new(chains);
+    let router_chain = interchain.get_chain(ROUTER_CHAIN_ID).unwrap();
+    let router = setup_router(&router_chain, vec![factory_chain_id]).unwrap();
+    // Intentionally do not register any tokens
+    let factory = setup_factory_with_mode(&interchain, factory_chain_id, &router, mode).unwrap();
+
+    let token_x = TokenWithDenom {
+        token: Token::create("conc.token.x".to_string()).unwrap(),
+        token_type: TokenType::Native {
+            denom: "conc.token.x".to_string(),
+        },
+    };
+    let token_y = TokenWithDenom {
+        token: Token::create("conc.token.y".to_string()).unwrap(),
+        token_type: TokenType::Native {
+            denom: "conc.token.y".to_string(),
+        },
+    };
+
+    let pair = pair_with_amounts(&token_x, &token_y, 20_000, 20_000);
+    let err = create_concentrated_pool(&factory, &router, pair, 500, 10, 100)
+        .expect_err("pool creation with both tokens unregistered must fail");
+    let err_str = err.root().to_string();
+    assert!(
+        err_str.contains("Atleast one token must already be registered"),
+        "expected both-new-tokens error, got: {err_str}",
     );
 }
 

--- a/tests-integration/src/tests_reusable/concentrated_create_pool.rs
+++ b/tests-integration/src/tests_reusable/concentrated_create_pool.rs
@@ -4,6 +4,7 @@ use cosmwasm_std::Uint128;
 use cw_orch::{mock::MockBase, prelude::*};
 use cw_orch_interchain::mock::MockInterchainEnv;
 use cw_orch_interchain::prelude::InterchainEnv;
+use euclid::error::ContractError;
 use euclid::msgs::cross_chain_config::CrossChainConfig;
 use euclid::msgs::factory::msg::QueryMsgFns as FactoryQueryMsgFns;
 use euclid::msgs::router::query::QueryMsgFns as RouterQueryMsgFns;
@@ -150,6 +151,36 @@ fn test_create_two_fee_tiers_same_pair_with_initial_tick(
     let router_500 = router.get_vlp_by_pool_key(pool_key_500).unwrap();
     let router_3000 = router.get_vlp_by_pool_key(pool_key_3000).unwrap();
     assert_ne!(router_500.vlp, router_3000.vlp);
+}
+
+#[rstest]
+#[case(FactorySetupMode::Native, FACTORY_CHAIN_ID_LOCAL)]
+#[case(FactorySetupMode::Ibc, FACTORY_CHAIN_ID_IBC)]
+fn test_create_pool_with_unregistered_token_rejected(
+    #[case] mode: FactorySetupMode,
+    #[case] factory_chain_id: &str,
+) {
+    let (_interchain, factory, router, token_a, _token_b) =
+        setup_concentrated_env(mode, factory_chain_id);
+
+    // token_c is never registered via register_denom
+    let token_c = TokenWithDenom {
+        token: Token::create("conc.token.c".to_string()).unwrap(),
+        token_type: TokenType::Native {
+            denom: "conc.token.c".to_string(),
+        },
+    };
+
+    let pair = pair_with_amounts(&token_a, &token_c, 20_000, 20_000);
+    let result = create_concentrated_pool(&factory, &router, pair, 500, 10, 100);
+    result.expect("pool creation with only 1 unregistered token should succeed");
+    let escrow = factory
+        .get_escrow(token_c.token.to_string())
+        .expect("escrow for the new token must be created by pool creation ACK");
+    assert!(
+        escrow.denoms.contains(&token_c.token_type),
+        "new token denom must be registered in its escrow after pool creation",
+    );
 }
 
 #[rstest]

--- a/tests-integration/src/tests_reusable/concentrated_create_pool.rs
+++ b/tests-integration/src/tests_reusable/concentrated_create_pool.rs
@@ -1,14 +1,17 @@
 #![cfg(not(target_arch = "wasm32"))]
 
 use cosmwasm_std::Uint128;
+use cw20::{Cw20Coin, MinterResponse};
 use cw_orch::{mock::MockBase, prelude::*};
 use cw_orch_interchain::mock::MockInterchainEnv;
 use cw_orch_interchain::prelude::InterchainEnv;
 use euclid::msgs::cross_chain_config::CrossChainConfig;
 use euclid::msgs::factory::msg::QueryMsgFns as FactoryQueryMsgFns;
+use euclid::msgs::lp_token::msg::InstantiateMsg as LpTokenInstantiateMsg;
 use euclid::msgs::router::query::QueryMsgFns as RouterQueryMsgFns;
-use euclid::token::{PairWithDenomAndAmount, Token, TokenType, TokenWithDenom};
+use euclid::token::{Pair, PairWithDenomAndAmount, Token, TokenType, TokenWithDenom};
 use factory::FactoryContract;
+use lp_token::LpTokenContract;
 use router::RouterContract;
 use rstest::rstest;
 
@@ -17,20 +20,19 @@ use crate::helpers::factory::{
     concentrated_pool_key, create_concentrated_pool, create_concentrated_pool_with_tick, faucet,
 };
 use crate::tests_reusable::constants::{
-    FACTORY_CHAIN_ID_IBC, FACTORY_CHAIN_ID_LOCAL, ROUTER_CHAIN_ID,
+    FACTORY_CHAIN_ID_EVM, FACTORY_CHAIN_ID_IBC, FACTORY_CHAIN_ID_LOCAL, ROUTER_CHAIN_ID,
 };
 use crate::tests_reusable::factory_register::{setup_factory_with_mode, FactorySetupMode};
 use crate::tests_reusable::factory_register_denom::{deregister_denom, register_denom};
 
-pub fn setup_concentrated_env(
+/// Sets up the interchain, router, and factory without registering any tokens.
+pub fn setup_concentrated_base(
     mode: FactorySetupMode,
     factory_chain_id: &str,
 ) -> (
     MockInterchainEnv,
     FactoryContract<MockBase>,
     RouterContract<MockBase>,
-    TokenWithDenom,
-    TokenWithDenom,
 ) {
     let sender = "sender_for_all_chains";
     let mut chains = vec![(ROUTER_CHAIN_ID, sender)];
@@ -41,23 +43,131 @@ pub fn setup_concentrated_env(
     let router_chain = interchain.get_chain(ROUTER_CHAIN_ID).unwrap();
     let router = setup_router(&router_chain, vec![factory_chain_id]).unwrap();
     let factory = setup_factory_with_mode(&interchain, factory_chain_id, &router, mode).unwrap();
+    (interchain, factory, router)
+}
 
-    let token_a = TokenWithDenom {
-        token: Token::create("conc.token.a".to_string()).unwrap(),
-        token_type: TokenType::Native {
-            denom: "conc.token.a".to_string(),
+/// Deploys a CW20 contract and returns a `TokenWithDenom` backed by it.
+pub fn make_smart_token(factory: &FactoryContract<MockBase>, token_id: &str) -> TokenWithDenom {
+    let chain = factory.environment();
+    let sender = chain.sender.to_string();
+    let cw20 = LpTokenContract::new(chain.clone());
+    cw20.upload().unwrap();
+
+    let token = Token::create(token_id.to_string()).unwrap();
+    let aux = Token::create(format!("{token_id}.aux")).unwrap();
+    let token_pair = Pair::new(token.clone(), aux).unwrap();
+
+    cw20.instantiate(
+        &LpTokenInstantiateMsg {
+            name: format!("{token_id}_cw20"),
+            symbol: "CLP".to_string(),
+            decimals: 6,
+            initial_balances: vec![Cw20Coin {
+                address: sender,
+                amount: Uint128::new(1_000_000_000),
+            }],
+            mint: Some(MinterResponse {
+                minter: chain.sender.to_string(),
+                cap: None,
+            }),
+            marketing: None,
+            vlp: chain.addr_make("dummy_vlp").to_string(),
+            factory: chain.addr_make("dummy_factory"),
+            token_pair,
         },
-    };
-    let token_b = TokenWithDenom {
-        token: Token::create("conc.token.b".to_string()).unwrap(),
-        token_type: TokenType::Native {
-            denom: "conc.token.b".to_string(),
+        None,
+        &[],
+    )
+    .unwrap();
+
+    TokenWithDenom {
+        token,
+        token_type: TokenType::Smart {
+            contract_address: cw20.address().unwrap().to_string(),
         },
-    };
-    register_denom(&factory, &router, token_a.clone()).unwrap();
-    register_denom(&factory, &router, token_b.clone()).unwrap();
+    }
+}
+
+/// Build a `TokenWithDenom` for the given kind literal.
+///
+/// `kind` is one of `"native"`, `"smart"`, or `"voucher"`. `token_id` is the
+/// logical token identifier; for `native` it is also used as the denom, for
+/// `smart` a CW20 contract is deployed, and for `voucher` the token type is
+/// the hub voucher variant with the token_id as its identifier.
+pub fn make_token(
+    factory: &FactoryContract<MockBase>,
+    token_id: &str,
+    kind: &str,
+) -> TokenWithDenom {
+    match kind {
+        "native" => TokenWithDenom {
+            token: Token::create(token_id.to_string()).unwrap(),
+            token_type: TokenType::Native {
+                denom: token_id.to_string(),
+            },
+        },
+        "smart" => make_smart_token(factory, token_id),
+        "voucher" => TokenWithDenom {
+            token: Token::create(token_id.to_string()).unwrap(),
+            token_type: TokenType::Voucher {},
+        },
+        other => panic!("unknown token kind: {other}"),
+    }
+}
+
+/// Full setup with both tokens defaulting to `native` (backward-compatible).
+pub fn setup_concentrated_env(
+    mode: FactorySetupMode,
+    factory_chain_id: &str,
+) -> (
+    MockInterchainEnv,
+    FactoryContract<MockBase>,
+    RouterContract<MockBase>,
+    TokenWithDenom,
+    TokenWithDenom,
+) {
+    setup_concentrated_env_ext(mode, factory_chain_id, "native", "native")
+}
+
+/// Full setup parameterised by each token's kind (`"native"`, `"smart"`, or
+/// `"voucher"`). Each token is registered on the factory/router so pool
+/// creation sees them as existing tokens.
+pub fn setup_concentrated_env_ext(
+    mode: FactorySetupMode,
+    factory_chain_id: &str,
+    token_a_kind: &str,
+    token_b_kind: &str,
+) -> (
+    MockInterchainEnv,
+    FactoryContract<MockBase>,
+    RouterContract<MockBase>,
+    TokenWithDenom,
+    TokenWithDenom,
+) {
+    let (interchain, factory, router) = setup_concentrated_base(mode, factory_chain_id);
+
+    let token_a = make_token(&factory, "conc.token.a", token_a_kind);
+    let token_b = make_token(&factory, "conc.token.b", token_b_kind);
+
+    // Voucher tokens live on the hub's virtual balance; there is no factory
+    // escrow to register. Only register non-voucher tokens.
+    if !token_a.token_type.is_voucher() {
+        register_denom(&factory, &router, token_a.clone()).unwrap();
+    }
+    if !token_b.token_type.is_voucher() {
+        register_denom(&factory, &router, token_b.clone()).unwrap();
+    }
 
     (interchain, factory, router, token_a, token_b)
+}
+
+/// Maps a `FactorySetupMode` to the canonical factory chain id used in tests.
+pub fn chain_id_for_mode(mode: FactorySetupMode) -> &'static str {
+    match mode {
+        FactorySetupMode::Native => FACTORY_CHAIN_ID_LOCAL,
+        FactorySetupMode::Ibc => FACTORY_CHAIN_ID_IBC,
+        FactorySetupMode::Evm => FACTORY_CHAIN_ID_EVM,
+    }
 }
 
 pub fn pair_with_amounts(
@@ -72,15 +182,21 @@ pub fn pair_with_amounts(
     }
 }
 
+// Each rstest below uses `#[values]` on chain mode and each token kind,
+// yielding the full cartesian product of chain type (Native/Ibc/Evm) × token
+// kinds (native/smart). Voucher inputs are not exercised here: they require
+// the token to already exist on some chain (via a prior deposit or pool op),
+// which is out of scope for pool-creation tests.
+
 #[rstest]
-#[case(FactorySetupMode::Native, FACTORY_CHAIN_ID_LOCAL)]
-#[case(FactorySetupMode::Ibc, FACTORY_CHAIN_ID_IBC)]
 fn test_create_two_fee_tiers_same_pair(
-    #[case] mode: FactorySetupMode,
-    #[case] factory_chain_id: &str,
+    #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
+    mode: FactorySetupMode,
+    #[values("native", "smart")] token_a_kind: &str,
+    #[values("native", "smart")] token_b_kind: &str,
 ) {
     let (_interchain, factory, router, token_a, token_b) =
-        setup_concentrated_env(mode, factory_chain_id);
+        setup_concentrated_env_ext(mode, chain_id_for_mode(mode), token_a_kind, token_b_kind);
 
     let pair = pair_with_amounts(&token_a, &token_b, 20_000, 20_000);
     let pool_key_500 = create_concentrated_pool(&factory, &router, pair.clone(), 500, 10, 100)
@@ -101,14 +217,14 @@ fn test_create_two_fee_tiers_same_pair(
 }
 
 #[rstest]
-#[case(FactorySetupMode::Native, FACTORY_CHAIN_ID_LOCAL)]
-#[case(FactorySetupMode::Ibc, FACTORY_CHAIN_ID_IBC)]
 fn test_create_two_fee_tiers_same_pair_with_initial_tick(
-    #[case] mode: FactorySetupMode,
-    #[case] factory_chain_id: &str,
+    #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
+    mode: FactorySetupMode,
+    #[values("native", "smart")] token_a_kind: &str,
+    #[values("native", "smart")] token_b_kind: &str,
 ) {
     let (_interchain, factory, router, token_a, token_b) =
-        setup_concentrated_env(mode, factory_chain_id);
+        setup_concentrated_env_ext(mode, chain_id_for_mode(mode), token_a_kind, token_b_kind);
 
     let (amount_a, amount_b) = (10_000_000_u128, 100_000_000_u128);
     let pair = pair_with_amounts(&token_a, &token_b, amount_a, amount_b);
@@ -153,26 +269,24 @@ fn test_create_two_fee_tiers_same_pair_with_initial_tick(
 }
 
 #[rstest]
-#[case(FactorySetupMode::Native, FACTORY_CHAIN_ID_LOCAL)]
-#[case(FactorySetupMode::Ibc, FACTORY_CHAIN_ID_IBC)]
 fn test_create_pool_with_unregistered_token_passes_and_creates_escrow(
-    #[case] mode: FactorySetupMode,
-    #[case] factory_chain_id: &str,
+    #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
+    mode: FactorySetupMode,
+    #[values("native", "smart")] token_a_kind: &str,
+    #[values("native", "smart")] token_c_kind: &str,
 ) {
+    // token_a is registered via setup; the second slot is reused for token_c,
+    // which we intentionally do NOT register, so pool creation must lazily
+    // create its escrow on ACK.
     let (_interchain, factory, router, token_a, _token_b) =
-        setup_concentrated_env(mode, factory_chain_id);
+        setup_concentrated_env_ext(mode, chain_id_for_mode(mode), token_a_kind, "native");
 
-    // token_c is never registered via register_denom
-    let token_c = TokenWithDenom {
-        token: Token::create("conc.token.c".to_string()).unwrap(),
-        token_type: TokenType::Native {
-            denom: "conc.token.c".to_string(),
-        },
-    };
+    let token_c = make_token(&factory, "conc.token.c", token_c_kind);
 
     let pair = pair_with_amounts(&token_a, &token_c, 20_000, 20_000);
-    let result = create_concentrated_pool(&factory, &router, pair, 500, 10, 100);
-    result.expect("pool creation with only 1 unregistered token should succeed");
+    create_concentrated_pool(&factory, &router, pair, 500, 10, 100)
+        .expect("pool creation with only 1 unregistered token should succeed");
+
     let escrow = factory
         .get_escrow(token_c.token.to_string())
         .expect("escrow for the new token must be created by pool creation ACK");
@@ -183,35 +297,17 @@ fn test_create_pool_with_unregistered_token_passes_and_creates_escrow(
 }
 
 #[rstest]
-#[case(FactorySetupMode::Native, FACTORY_CHAIN_ID_LOCAL)]
-#[case(FactorySetupMode::Ibc, FACTORY_CHAIN_ID_IBC)]
 fn test_create_pool_with_both_tokens_unregistered_rejected(
-    #[case] mode: FactorySetupMode,
-    #[case] factory_chain_id: &str,
+    #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
+    mode: FactorySetupMode,
+    #[values("native", "smart")] token_x_kind: &str,
+    #[values("native", "smart")] token_y_kind: &str,
 ) {
-    let sender = "sender_for_all_chains";
-    let mut chains = vec![(ROUTER_CHAIN_ID, sender)];
-    if factory_chain_id != ROUTER_CHAIN_ID {
-        chains.push((factory_chain_id, sender));
-    }
-    let interchain = MockInterchainEnv::new(chains);
-    let router_chain = interchain.get_chain(ROUTER_CHAIN_ID).unwrap();
-    let router = setup_router(&router_chain, vec![factory_chain_id]).unwrap();
     // Intentionally do not register any tokens
-    let factory = setup_factory_with_mode(&interchain, factory_chain_id, &router, mode).unwrap();
+    let (_interchain, factory, router) = setup_concentrated_base(mode, chain_id_for_mode(mode));
 
-    let token_x = TokenWithDenom {
-        token: Token::create("conc.token.x".to_string()).unwrap(),
-        token_type: TokenType::Native {
-            denom: "conc.token.x".to_string(),
-        },
-    };
-    let token_y = TokenWithDenom {
-        token: Token::create("conc.token.y".to_string()).unwrap(),
-        token_type: TokenType::Native {
-            denom: "conc.token.y".to_string(),
-        },
-    };
+    let token_x = make_token(&factory, "conc.token.x", token_x_kind);
+    let token_y = make_token(&factory, "conc.token.y", token_y_kind);
 
     let pair = pair_with_amounts(&token_x, &token_y, 20_000, 20_000);
     let err = create_concentrated_pool(&factory, &router, pair, 500, 10, 100)
@@ -224,14 +320,14 @@ fn test_create_pool_with_both_tokens_unregistered_rejected(
 }
 
 #[rstest]
-#[case(FactorySetupMode::Native, FACTORY_CHAIN_ID_LOCAL)]
-#[case(FactorySetupMode::Ibc, FACTORY_CHAIN_ID_IBC)]
 fn test_create_pool_with_disallowed_token_rejected(
-    #[case] mode: FactorySetupMode,
-    #[case] factory_chain_id: &str,
+    #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
+    mode: FactorySetupMode,
+    #[values("native", "smart")] token_a_kind: &str,
+    #[values("native", "smart")] token_b_kind: &str,
 ) {
     let (_interchain, factory, router, token_a, token_b) =
-        setup_concentrated_env(mode, factory_chain_id);
+        setup_concentrated_env_ext(mode, chain_id_for_mode(mode), token_a_kind, token_b_kind);
 
     // Deregister token_b — escrow still exists but denom is now disallowed
     deregister_denom(&factory, &router, token_b.clone()).unwrap();
@@ -247,14 +343,14 @@ fn test_create_pool_with_disallowed_token_rejected(
 }
 
 #[rstest]
-#[case(FactorySetupMode::Native, FACTORY_CHAIN_ID_LOCAL)]
-#[case(FactorySetupMode::Ibc, FACTORY_CHAIN_ID_IBC)]
 fn test_create_pool_invalid_spacing_rejected(
-    #[case] mode: FactorySetupMode,
-    #[case] factory_chain_id: &str,
+    #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
+    mode: FactorySetupMode,
+    #[values("native", "smart")] token_a_kind: &str,
+    #[values("native", "smart")] token_b_kind: &str,
 ) {
     let (_interchain, factory, _router, token_a, token_b) =
-        setup_concentrated_env(mode, factory_chain_id);
+        setup_concentrated_env_ext(mode, chain_id_for_mode(mode), token_a_kind, token_b_kind);
     let pair = pair_with_amounts(&token_a, &token_b, 10_000, 10_000);
 
     let mut funds = vec![];

--- a/tests-integration/src/tests_reusable/concentrated_create_pool.rs
+++ b/tests-integration/src/tests_reusable/concentrated_create_pool.rs
@@ -5,17 +5,21 @@ use cw20::{Cw20Coin, MinterResponse};
 use cw_orch::{mock::MockBase, prelude::*};
 use cw_orch_interchain::mock::MockInterchainEnv;
 use cw_orch_interchain::prelude::InterchainEnv;
+use euclid::chain::ChainUid;
+use euclid::cross_chain_user::CrossChainUser;
 use euclid::msgs::cross_chain_config::CrossChainConfig;
 use euclid::msgs::factory::msg::QueryMsgFns as FactoryQueryMsgFns;
 use euclid::msgs::lp_token::msg::InstantiateMsg as LpTokenInstantiateMsg;
 use euclid::msgs::router::query::QueryMsgFns as RouterQueryMsgFns;
+use euclid::msgs::virtual_balance::msg::{ExecuteMint, ExecuteMsg as VirtualBalanceExecuteMsg};
 use euclid::token::{Pair, PairWithDenomAndAmount, Token, TokenType, TokenWithDenom};
+use euclid::voucher::BalanceKey;
 use factory::FactoryContract;
 use lp_token::LpTokenContract;
 use router::RouterContract;
 use rstest::rstest;
 
-use crate::helpers::chains::setup_router;
+use crate::helpers::chains::{get_virtual_balance, setup_router};
 use crate::helpers::factory::{
     concentrated_pool_key, create_concentrated_pool, create_concentrated_pool_with_tick, faucet,
 };
@@ -131,7 +135,9 @@ pub fn setup_concentrated_env(
 
 /// Full setup parameterised by each token's kind (`"native"`, `"smart"`, or
 /// `"voucher"`). Each token is registered on the factory/router so pool
-/// creation sees them as existing tokens.
+/// creation sees them as existing tokens. For voucher tokens, a backing
+/// native denom is registered (so the router recognises the token id) and
+/// voucher balance is minted on the hub for the sender.
 pub fn setup_concentrated_env_ext(
     mode: FactorySetupMode,
     factory_chain_id: &str,
@@ -146,19 +152,69 @@ pub fn setup_concentrated_env_ext(
 ) {
     let (interchain, factory, router) = setup_concentrated_base(mode, factory_chain_id);
 
-    let token_a = make_token(&factory, "conc.token.a", token_a_kind);
-    let token_b = make_token(&factory, "conc.token.b", token_b_kind);
-
-    // Voucher tokens live on the hub's virtual balance; there is no factory
-    // escrow to register. Only register non-voucher tokens.
-    if !token_a.token_type.is_voucher() {
-        register_denom(&factory, &router, token_a.clone()).unwrap();
-    }
-    if !token_b.token_type.is_voucher() {
-        register_denom(&factory, &router, token_b.clone()).unwrap();
-    }
+    let token_a = prepare_token(&factory, &router, "conc.token.a", token_a_kind);
+    let token_b = prepare_token(&factory, &router, "conc.token.b", token_b_kind);
 
     (interchain, factory, router, token_a, token_b)
+}
+
+/// Build a token of the requested kind and perform any per-kind registration
+/// required for it to be usable in a pool-creation request.
+fn prepare_token(
+    factory: &FactoryContract<MockBase>,
+    router: &RouterContract<MockBase>,
+    token_id: &str,
+    kind: &str,
+) -> TokenWithDenom {
+    let token = make_token(factory, token_id, kind);
+    match kind {
+        "voucher" => {
+            // Router-side voucher validation requires the token to exist on at
+            // least one chain, so register a backing native denom on the
+            // factory chain. Then mint voucher balance on the hub so the
+            // sender can actually spend vouchers of this token.
+            let backing = TokenWithDenom {
+                token: token.token.clone(),
+                token_type: TokenType::Native {
+                    denom: token_id.to_string(),
+                },
+            };
+            register_denom(factory, router, backing).unwrap();
+            mint_voucher_balance(factory, router, &token.token, 1_000_000_000u128);
+        }
+        "native" | "smart" => {
+            register_denom(factory, router, token.clone()).unwrap();
+        }
+        _ => unreachable!("make_token already validated the kind"),
+    }
+    token
+}
+
+/// Mint `amount` of voucher balance for the factory sender on the hub's
+/// virtual balance contract. Only the router is authorised to mint, so the
+/// call is dispatched via a temporary `set_sender` override.
+fn mint_voucher_balance(
+    factory: &FactoryContract<MockBase>,
+    router: &RouterContract<MockBase>,
+    token: &Token,
+    amount: u128,
+) {
+    let factory_chain_uid = factory.get_state().unwrap().chain_uid;
+    let sender = factory.environment().sender.to_string();
+    let virtual_balance_address = router.get_state().unwrap().virtual_balance_address;
+    let mut vb = get_virtual_balance(router.environment(), &virtual_balance_address);
+    vb.set_sender(&router.address().unwrap());
+    vb.execute(
+        &VirtualBalanceExecuteMsg::Mint(ExecuteMint {
+            amount: Uint128::new(amount),
+            balance_key: BalanceKey {
+                cross_chain_user: CrossChainUser::new(factory_chain_uid, sender),
+                token_id: token.to_string(),
+            },
+        }),
+        &[],
+    )
+    .unwrap();
 }
 
 /// Maps a `FactorySetupMode` to the canonical factory chain id used in tests.
@@ -184,16 +240,16 @@ pub fn pair_with_amounts(
 
 // Each rstest below uses `#[values]` on chain mode and each token kind,
 // yielding the full cartesian product of chain type (Native/Ibc/Evm) × token
-// kinds (native/smart). Voucher inputs are not exercised here: they require
-// the token to already exist on some chain (via a prior deposit or pool op),
-// which is out of scope for pool-creation tests.
+// kinds. Tests restrict the kind list to combinations that are meaningful for
+// their scenario (e.g. voucher cannot represent the "new / unregistered" side
+// of a pool because the router requires voucher tokens to already be known).
 
 #[rstest]
 fn test_create_two_fee_tiers_same_pair(
     #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
     mode: FactorySetupMode,
-    #[values("native", "smart")] token_a_kind: &str,
-    #[values("native", "smart")] token_b_kind: &str,
+    #[values("native", "smart", "voucher")] token_a_kind: &str,
+    #[values("native", "smart", "voucher")] token_b_kind: &str,
 ) {
     let (_interchain, factory, router, token_a, token_b) =
         setup_concentrated_env_ext(mode, chain_id_for_mode(mode), token_a_kind, token_b_kind);
@@ -220,8 +276,8 @@ fn test_create_two_fee_tiers_same_pair(
 fn test_create_two_fee_tiers_same_pair_with_initial_tick(
     #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
     mode: FactorySetupMode,
-    #[values("native", "smart")] token_a_kind: &str,
-    #[values("native", "smart")] token_b_kind: &str,
+    #[values("native", "smart", "voucher")] token_a_kind: &str,
+    #[values("native", "smart", "voucher")] token_b_kind: &str,
 ) {
     let (_interchain, factory, router, token_a, token_b) =
         setup_concentrated_env_ext(mode, chain_id_for_mode(mode), token_a_kind, token_b_kind);
@@ -272,7 +328,10 @@ fn test_create_two_fee_tiers_same_pair_with_initial_tick(
 fn test_create_pool_with_unregistered_token_passes_and_creates_escrow(
     #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
     mode: FactorySetupMode,
-    #[values("native", "smart")] token_a_kind: &str,
+    // token_a is the registered side, so voucher is valid here.
+    #[values("native", "smart", "voucher")] token_a_kind: &str,
+    // token_c is the intentionally-new side; voucher is excluded because the
+    // router rejects voucher tokens that don't yet exist on any chain.
     #[values("native", "smart")] token_c_kind: &str,
 ) {
     // token_a is registered via setup; the second slot is reused for token_c,
@@ -346,8 +405,8 @@ fn test_create_pool_with_disallowed_token_rejected(
 fn test_create_pool_invalid_spacing_rejected(
     #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
     mode: FactorySetupMode,
-    #[values("native", "smart")] token_a_kind: &str,
-    #[values("native", "smart")] token_b_kind: &str,
+    #[values("native", "smart", "voucher")] token_a_kind: &str,
+    #[values("native", "smart", "voucher")] token_b_kind: &str,
 ) {
     let (_interchain, factory, _router, token_a, token_b) =
         setup_concentrated_env_ext(mode, chain_id_for_mode(mode), token_a_kind, token_b_kind);

--- a/tests-integration/src/tests_reusable/concentrated_failures.rs
+++ b/tests-integration/src/tests_reusable/concentrated_failures.rs
@@ -1,6 +1,6 @@
 #![cfg(not(target_arch = "wasm32"))]
 
-use cosmwasm_std::{Event, Uint128};
+use cosmwasm_std::{Addr, Event, Uint128};
 use cw_orch::prelude::*;
 use euclid::events::EUCLID_WRITE_ACKNOWLEDGEMENT_EVENT;
 use euclid::msgs::cross_chain_config::CrossChainConfig;
@@ -94,6 +94,17 @@ fn test_ack_error_rolls_back_pending() {
         );
     }
 
+    let chain = factory.environment();
+    let sender_addr = Addr::unchecked(chain.sender.as_str());
+    let balance_a_before = chain
+        .query_balance(&sender_addr, "conc.token.a")
+        .unwrap()
+        .u128();
+    let balance_b_before = chain
+        .query_balance(&sender_addr, "conc.token.b")
+        .unwrap()
+        .u128();
+
     let tx = factory
         .execute(
             &euclid::msgs::factory::ExecuteMsg::RequestConcentratedPoolCreation {
@@ -152,6 +163,24 @@ fn test_ack_error_rolls_back_pending() {
         .unwrap()
         .tokens;
     assert!(tokens.is_empty(), "error ack must not mint position NFT");
+
+    // Verify tokens refunded back to sender
+    let balance_a_after = chain
+        .query_balance(&sender_addr, "conc.token.a")
+        .unwrap()
+        .u128();
+    let balance_b_after = chain
+        .query_balance(&sender_addr, "conc.token.b")
+        .unwrap()
+        .u128();
+    assert_eq!(
+        balance_a_after, balance_a_before,
+        "token_a must be refunded to sender after error ack",
+    );
+    assert_eq!(
+        balance_b_after, balance_b_before,
+        "token_b must be refunded to sender after error ack",
+    );
 }
 
 #[test]

--- a/tests-integration/src/tests_reusable/factory_create_pool.rs
+++ b/tests-integration/src/tests_reusable/factory_create_pool.rs
@@ -35,19 +35,17 @@ pub fn create_pool(
             &mut funds,
         );
     }
-    let tx_response = factory
-        .request_pool_creation(
-            CrossChainConfig::default(),
-            6,
-            "LPSYMBOL".to_string(),
-            "LPSYMBOL".to_string(),
-            pair_with_denom.clone(),
-            pool_config,
-            slippage_tolerance_bps,
-            None,
-            &funds.to_vec(),
-        )
-        .unwrap();
+    let tx_response = factory.request_pool_creation(
+        CrossChainConfig::default(),
+        6,
+        "LPSYMBOL".to_string(),
+        "LPSYMBOL".to_string(),
+        pair_with_denom.clone(),
+        pool_config,
+        slippage_tolerance_bps,
+        None,
+        &funds.to_vec(),
+    )?;
     let factory_chain_uid = &factory.get_state().unwrap().chain_uid;
     relay_factory_router_factory(tx_response.events, factory, router, factory_chain_uid)?;
 
@@ -64,6 +62,56 @@ mod tests {
     use crate::tests_reusable::factory_register::setup_factory;
     use crate::tests_reusable::factory_register_denom::register_denom;
     use cosmwasm_std::Uint64;
+
+    #[rstest]
+    #[case::stable(PoolConfig::Stable { amp_factor: Some(Uint64::new(100)) }, FACTORY_CHAIN_ID_LOCAL)]
+    #[case::constant_product(PoolConfig::ConstantProduct {}, FACTORY_CHAIN_ID_LOCAL)]
+    #[case::stable(PoolConfig::Stable { amp_factor: Some(Uint64::new(100)) }, FACTORY_CHAIN_ID_IBC)]
+    #[case::constant_product(PoolConfig::ConstantProduct {}, FACTORY_CHAIN_ID_IBC)]
+    #[case::stable(PoolConfig::Stable { amp_factor: Some(Uint64::new(100)) }, FACTORY_CHAIN_ID_EVM)]
+    #[case::constant_product(PoolConfig::ConstantProduct {}, FACTORY_CHAIN_ID_EVM)]
+    fn test_create_pool_with_unregistered_token_should_pass_and_create_escrow(
+        #[case] pool_config: PoolConfig,
+        #[case] factory_chain_id: &str,
+    ) {
+        let sender = "sender_for_all_chains";
+        let interchain = setup_interchain(sender, factory_chain_id);
+        let router_chain = interchain.get_chain(ROUTER_CHAIN_ID).unwrap();
+        let router = setup_router(&router_chain, vec![factory_chain_id]).unwrap();
+        let factory = setup_factory(&interchain, factory_chain_id, &router).unwrap();
+
+        let token_a = TokenWithDenom {
+            token: Token::create("tokena".to_string()).unwrap(),
+            token_type: TokenType::Native {
+                denom: "tokena".to_string(),
+            },
+        };
+        // token_c is intentionally not pre-registered — the pool creation ACK should create its escrow
+        let token_c = TokenWithDenom {
+            token: Token::create("tokenc".to_string()).unwrap(),
+            token_type: TokenType::Native {
+                denom: "tokenc".to_string(),
+            },
+        };
+
+        register_denom(&factory, &router, token_a.clone()).unwrap();
+
+        let pair_with_denom = PairWithDenomAndAmount {
+            token_1: token_a.with_amount(Uint128::from(10_000u128)),
+            token_2: token_c.with_amount(Uint128::from(10_000u128)),
+        };
+
+        create_pool(&factory, &router, pair_with_denom, 500, pool_config)
+            .expect("pool creation with one new token must succeed");
+
+        let escrow = factory
+            .get_escrow(token_c.token.to_string())
+            .expect("escrow for the new token must be created by pool creation ACK");
+        assert!(
+            escrow.denoms.contains(&token_c.token_type),
+            "new token denom must be registered in its escrow after pool creation",
+        );
+    }
 
     #[rstest]
     #[case::stable(PoolConfig::Stable { amp_factor: Some(Uint64::new(100)) }, FACTORY_CHAIN_ID_LOCAL)]

--- a/tests-integration/src/tests_reusable/factory_create_pool.rs
+++ b/tests-integration/src/tests_reusable/factory_create_pool.rs
@@ -60,7 +60,7 @@ mod tests {
         FACTORY_CHAIN_ID_EVM, FACTORY_CHAIN_ID_IBC, FACTORY_CHAIN_ID_LOCAL, ROUTER_CHAIN_ID,
     };
     use crate::tests_reusable::factory_register::setup_factory;
-    use crate::tests_reusable::factory_register_denom::register_denom;
+    use crate::tests_reusable::factory_register_denom::{deregister_denom, register_denom};
     use cosmwasm_std::Uint64;
 
     #[rstest]
@@ -155,6 +155,55 @@ mod tests {
         assert!(
             err_str.contains("Atleast one token must already be registered"),
             "expected both-new-tokens error, got: {err_str}",
+        );
+    }
+
+    #[rstest]
+    #[case::stable(PoolConfig::Stable { amp_factor: Some(Uint64::new(100)) }, FACTORY_CHAIN_ID_LOCAL)]
+    #[case::constant_product(PoolConfig::ConstantProduct {}, FACTORY_CHAIN_ID_LOCAL)]
+    #[case::stable(PoolConfig::Stable { amp_factor: Some(Uint64::new(100)) }, FACTORY_CHAIN_ID_IBC)]
+    #[case::constant_product(PoolConfig::ConstantProduct {}, FACTORY_CHAIN_ID_IBC)]
+    #[case::stable(PoolConfig::Stable { amp_factor: Some(Uint64::new(100)) }, FACTORY_CHAIN_ID_EVM)]
+    #[case::constant_product(PoolConfig::ConstantProduct {}, FACTORY_CHAIN_ID_EVM)]
+    fn test_create_pool_with_disallowed_token_rejected(
+        #[case] pool_config: PoolConfig,
+        #[case] factory_chain_id: &str,
+    ) {
+        let sender = "sender_for_all_chains";
+        let interchain = setup_interchain(sender, factory_chain_id);
+        let router_chain = interchain.get_chain(ROUTER_CHAIN_ID).unwrap();
+        let router = setup_router(&router_chain, vec![factory_chain_id]).unwrap();
+        let factory = setup_factory(&interchain, factory_chain_id, &router).unwrap();
+
+        let token_a = TokenWithDenom {
+            token: Token::create("tokena".to_string()).unwrap(),
+            token_type: TokenType::Native {
+                denom: "tokena".to_string(),
+            },
+        };
+        let token_b = TokenWithDenom {
+            token: Token::create("tokenb".to_string()).unwrap(),
+            token_type: TokenType::Native {
+                denom: "tokenb".to_string(),
+            },
+        };
+
+        register_denom(&factory, &router, token_a.clone()).unwrap();
+        register_denom(&factory, &router, token_b.clone()).unwrap();
+        // Deregister token_b — escrow still exists but denom is now disallowed
+        deregister_denom(&factory, &router, token_b.clone()).unwrap();
+
+        let pair_with_denom = PairWithDenomAndAmount {
+            token_1: token_a.with_amount(Uint128::from(10_000u128)),
+            token_2: token_b.with_amount(Uint128::from(10_000u128)),
+        };
+
+        let err = create_pool(&factory, &router, pair_with_denom, 500, pool_config)
+            .expect_err("pool creation with a disallowed token must be rejected on factory call");
+        let err_str = err.root().to_string();
+        assert!(
+            err_str.contains("UnsupportedDenomination"),
+            "expected UnsupportedDenomination error, got: {err_str}",
         );
     }
 

--- a/tests-integration/src/tests_reusable/factory_create_pool.rs
+++ b/tests-integration/src/tests_reusable/factory_create_pool.rs
@@ -120,6 +120,51 @@ mod tests {
     #[case::constant_product(PoolConfig::ConstantProduct {}, FACTORY_CHAIN_ID_IBC)]
     #[case::stable(PoolConfig::Stable { amp_factor: Some(Uint64::new(100)) }, FACTORY_CHAIN_ID_EVM)]
     #[case::constant_product(PoolConfig::ConstantProduct {}, FACTORY_CHAIN_ID_EVM)]
+    fn test_create_pool_with_both_tokens_unregistered_rejected(
+        #[case] pool_config: PoolConfig,
+        #[case] factory_chain_id: &str,
+    ) {
+        let sender = "sender_for_all_chains";
+        let interchain = setup_interchain(sender, factory_chain_id);
+        let router_chain = interchain.get_chain(ROUTER_CHAIN_ID).unwrap();
+        let router = setup_router(&router_chain, vec![factory_chain_id]).unwrap();
+        let factory = setup_factory(&interchain, factory_chain_id, &router).unwrap();
+
+        // Neither token is registered
+        let token_x = TokenWithDenom {
+            token: Token::create("tokenx".to_string()).unwrap(),
+            token_type: TokenType::Native {
+                denom: "tokenx".to_string(),
+            },
+        };
+        let token_y = TokenWithDenom {
+            token: Token::create("tokeny".to_string()).unwrap(),
+            token_type: TokenType::Native {
+                denom: "tokeny".to_string(),
+            },
+        };
+
+        let pair_with_denom = PairWithDenomAndAmount {
+            token_1: token_x.with_amount(Uint128::from(10_000u128)),
+            token_2: token_y.with_amount(Uint128::from(10_000u128)),
+        };
+
+        let err = create_pool(&factory, &router, pair_with_denom, 500, pool_config)
+            .expect_err("pool creation with both tokens unregistered must fail");
+        let err_str = err.root().to_string();
+        assert!(
+            err_str.contains("Atleast one token must already be registered"),
+            "expected both-new-tokens error, got: {err_str}",
+        );
+    }
+
+    #[rstest]
+    #[case::stable(PoolConfig::Stable { amp_factor: Some(Uint64::new(100)) }, FACTORY_CHAIN_ID_LOCAL)]
+    #[case::constant_product(PoolConfig::ConstantProduct {}, FACTORY_CHAIN_ID_LOCAL)]
+    #[case::stable(PoolConfig::Stable { amp_factor: Some(Uint64::new(100)) }, FACTORY_CHAIN_ID_IBC)]
+    #[case::constant_product(PoolConfig::ConstantProduct {}, FACTORY_CHAIN_ID_IBC)]
+    #[case::stable(PoolConfig::Stable { amp_factor: Some(Uint64::new(100)) }, FACTORY_CHAIN_ID_EVM)]
+    #[case::constant_product(PoolConfig::ConstantProduct {}, FACTORY_CHAIN_ID_EVM)]
     fn test_create_pool(#[case] pool_config: PoolConfig, #[case] factory_chain_id: &str) {
         let sender = "sender_for_all_chains";
         let interchain = setup_interchain(sender, factory_chain_id);


### PR DESCRIPTION
## Description

Fixes a bug where CLP pool creation would fail when one of the pair tokens had no existing escrow, and adds comprehensive integration tests covering escrow-validation scenarios for both CLP and CP/Stable pools, now parameterised across chain mode and input token kind (including voucher).

**Root cause:** `ack_concentrated_pool_creation` used `TOKEN_TO_ESCROW.load` (hard failure) instead of `may_load`. When a pool is created with one registered and one new token, the ACK handler would error with `TokenEscrowDoesNotExist` rather than instantiating the missing escrow. CP/Stable's `ack_pool_creation` already handled this correctly.

**Fix:** Mirror `ack_pool_creation` in `ack_concentrated_pool_creation`: use `may_load`, send tokens to the escrow if it exists, otherwise instantiate a new one via `ESCROW_INSTANTIATE_REPLY_ID` with the deposit queued in `PENDING_DEPOSIT_TOKEN`.

**Tests added / updated (CLP):**

| Scenario | Expected | Token kinds | Generated cases |
|---|---|---|---|
| Two fee tiers on same pair | both registered, distinct VLPs | native / smart / voucher × native / smart / voucher | 27 + 27 |
| 1 registered + 1 new token | passes, creates escrow for new token | voucher on registered side, native / smart on new side | 18 |
| Both tokens unregistered | rejected at factory call | native / smart only | 12 |
| Escrow present but denom disallowed | rejected at factory call | native / smart only | 12 |
| Invalid fee-tier / tick-spacing | rejected at factory call | native / smart / voucher × native / smart / voucher | 27 |
| Pool creation error ACK | refunds tokens to sender | native | 1 |

Voucher is excluded from the rejection tests because it changes their failure modes (the router's voucher-existence check fires before the 'two new tokens' rule, and voucher tokens have no escrow for the disallowed check to apply to).

A `TokenEscrowDoesNotExist { token }` error variant was added to surface the token name in diagnostics.

**CP/Stable parity:** `test_create_pool_with_unregistered_token_should_pass_and_create_escrow`, `test_create_pool_with_both_tokens_unregistered_rejected`, and `test_create_pool_with_disallowed_token_rejected` were added across 6 cases each (stable / constant-product × Local / Ibc / Evm).

**Test infrastructure changes** (`tests-integration/src/helpers/factory.rs`, `tests-integration/src/tests_reusable/concentrated_create_pool.rs`):

- `faucet` for `TokenType::Smart` now mints cw20 tokens to the recipient. The previous behaviour set allowance with the sender as its own spender, which cw20 rejects. Minting is the correct semantic match for native's 'add balance' path.
- New `approve_factory_for_smart_tokens` helper grants sender-to-factory allowance for each smart token in a pair, invoked by `create_concentrated_pool_with_tick` and `add_concentrated_liquidity` before the factory is asked to pull those tokens via `TransferFrom`.
- New `prepare_token` / `mint_voucher_balance` helpers wire voucher support: a backing native denom is registered on the factory chain so the router's `TOKEN_DENOMS` has an entry for the token id, and voucher balance is minted on the hub's virtual_balance for the factory sender via a temporary `set_sender` override.
- CLP create-pool tests switched to rstest `#[values]` so that each test expresses its own kind matrix, with `chain_id_for_mode` collapsing the coupled mode / chain_id pair into a single derived argument.
- State loads in `ack_concentrated_pool_creation` are now scoped to the branch that actually needs them.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor/Chore

## Related Issue

N/A

## Testing

```
# Parameterised CLP create-pool suite (123 cases, all pass)
cargo test -p tests-integration concentrated_create_pool

# Escrow scenarios for CP/Stable (all pass)
cargo test -p tests-integration factory_create_pool

# Error ACK refunds tokens to sender (passes)
cargo test -p tests-integration test_ack_error_rolls_back_pending

# Full concentrated and factory swap / add-liquidity suites, no regressions
cargo test -p tests-integration concentrated
cargo test -p tests-integration factory_swap
cargo test -p tests-integration factory_add_liquidity
```

## Checklist

- [x] Self-review completed
- [x] Tests added/updated (if applicable)
- [ ] Documentation updated (if applicable)