### PR TITLE
chore: code cleanup — dead code, clone/dep hygiene, reply-ID docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2289,7 +2289,6 @@ version = "0.2.2"
 dependencies = [
  "cosmwasm-schema 2.2.2",
  "cosmwasm-std 2.2.2",
- "cw-multi-test",
  "cw-orch",
  "cw-storage-plus 2.0.0",
  "cw2 2.0.0",

--- a/contracts/hub/router/src/ibc/ack_and_timeout.rs
+++ b/contracts/hub/router/src/ibc/ack_and_timeout.rs
@@ -112,7 +112,7 @@ pub fn ibc_ack_release_escrow(
     ));
     let pending_release_voucher = PENDING_RELEASE_VOUCHER.load(deps.storage, tx_id.clone())?;
     PENDING_RELEASE_VOUCHER.remove(deps.storage, tx_id);
-    let virtual_balance_address = VIRTUAL_BALANCE_CONTRACT.load(deps.storage)?.to_string();
+    let virtual_balance_address = VIRTUAL_BALANCE_CONTRACT.load(deps.storage)?;
     match res {
         AcknowledgementMsg::Ok(data) => {
             let mut response = response

--- a/contracts/hub/router/src/ibc/receive/token.rs
+++ b/contracts/hub/router/src/ibc/receive/token.rs
@@ -50,7 +50,6 @@ pub fn ibc_execute_register_denom(
         chain_uid: sender.chain_uid.clone(),
         token_type: token.token_type.clone(),
     });
-    println!("Register Denom Token Key: {:?}", token.token);
     TOKEN_DENOMS.save(deps.storage, token.token.clone(), &token_denoms)?;
 
     let ack: AcknowledgementMsg<RegisterDenomResponse> =
@@ -120,7 +119,7 @@ pub fn ibc_execute_deposit_token(
     env: Env,
     msg: RouterCrossChainDepositTokenExecuteMsg,
 ) -> Result<Response, ContractError> {
-    let sender = msg.clone().sender;
+    let sender = msg.sender.clone();
 
     // Add token 1 in escrow balance
     let token_escrow_key = (msg.asset_in.token.to_string(), sender.chain_uid.clone());
@@ -210,7 +209,7 @@ pub fn ibc_execute_transfer_virtual_balance(
     env: Env,
     msg: RouterCrossChainTransferVoucherExecuteMsg,
 ) -> Result<Response, ContractError> {
-    let sender = msg.clone().sender;
+    let sender = msg.sender.clone();
 
     let response = execute_transfer_voucher(
         deps,

--- a/contracts/liquidity/lp_token/Cargo.toml
+++ b/contracts/liquidity/lp_token/Cargo.toml
@@ -40,7 +40,6 @@ schemars = { workspace = true }
 serde = { workspace = true, default-features = false, features = ["derive"] }
 thiserror = { workspace = true }
 euclid = { workspace = true }
-cw-orch = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-cw-multi-test = { workspace = true }
+cw-orch = { workspace = true }

--- a/packages/euclid/src/error.rs
+++ b/packages/euclid/src/error.rs
@@ -7,8 +7,6 @@ use cosmwasm_std::{
 use cw20_base::ContractError as Cw20ContractError;
 use thiserror::Error;
 
-#[derive(Error, Debug)]
-pub enum Never {}
 #[derive(Error, Debug, PartialEq)]
 pub enum ContractError {
     #[error("{0}")]

--- a/packages/euclid_ibc/src/factory_ibc.rs
+++ b/packages/euclid_ibc/src/factory_ibc.rs
@@ -64,6 +64,10 @@ impl FactoryCrossChainExecuteMsg {
                 let factory_msg = factory::ExecuteMsg::NativeReceiveCallback {
                     msg: to_json_binary(self)?,
                 };
+                // Clamp the counter to the reserved range (2001–3000); equivalent to
+                // the wrap-around in router_ibc.rs but expressed as a clamp.
+                // The `ensure!` below is the hard guard: if the slot is still occupied
+                // (i.e. all 1 000 slots are in-flight simultaneously), the call errors.
                 let mut count = NATIVE_CROSS_CHAIN_MSG_REPLY_QUEUE_COUNT
                     .load(deps.storage)
                     .unwrap_or(NATIVE_CROSS_CHAIN_MSG_REPLY_QUEUE_RANGE.0);

--- a/packages/euclid_ibc/src/router_ibc.rs
+++ b/packages/euclid_ibc/src/router_ibc.rs
@@ -114,12 +114,14 @@ impl RouterCrossChainExecuteMsg {
                     msg: to_json_binary(self)?,
                     chain_uid: chain_uid.clone(),
                 };
-                // Get the current count of the queue
+                // Advance the counter within the reserved range (2001–3000).
+                // When it exceeds 3000, wrap back to 2001 for slot reuse.
+                // The `ensure!` below is the hard guard: if the slot is still occupied
+                // (i.e. all 1 000 slots are in-flight simultaneously), the call errors.
                 let mut reply_id = NATIVE_CROSS_CHAIN_MSG_REPLY_QUEUE_COUNT
                     .load(deps.storage)
                     .unwrap_or(NATIVE_CROSS_CHAIN_MSG_REPLY_QUEUE_RANGE.0);
 
-                // Wrap around the reply ID range
                 if reply_id > NATIVE_CROSS_CHAIN_MSG_REPLY_QUEUE_RANGE.1 {
                     reply_id = NATIVE_CROSS_CHAIN_MSG_REPLY_QUEUE_RANGE.0;
                 }

--- a/packages/euclid_ibc/src/state.rs
+++ b/packages/euclid_ibc/src/state.rs
@@ -20,5 +20,10 @@ pub const NATIVE_CROSS_CHAIN_PENDING_PACKET_SENDER: Map<u64, Addr> =
 pub const NATIVE_CROSS_CHAIN_MSG_REPLY_QUEUE_COUNT: Item<u64> =
     Item::new("native_cross_chain_original_msg_reply_queue_count");
 
-// Range of reply IDS reserved for native cross chain messages
+// Reply IDs 2001–3000 are reserved for native cross-chain messages (1 000 concurrent slots).
+// The counter advances by 1 per use and wraps back to 2001 once it exceeds 3000.
+// Wrap-around is best-effort reuse: a slot may still be occupied after a full cycle.
+// The `ensure!` guard in the allocation path is the hard safety check — callers that
+// exhaust all 1 000 in-flight slots simultaneously will receive a "Reply ID is already
+// in use" / "Msg Queue is full" error until earlier replies are processed and slots freed.
 pub const NATIVE_CROSS_CHAIN_MSG_REPLY_QUEUE_RANGE: (u64, u64) = (2001, 3000);

--- a/packages/forwarding/src/msgs/errors_old.rs
+++ b/packages/forwarding/src/msgs/errors_old.rs
@@ -6,8 +6,6 @@ use cosmwasm_std::{
 };
 use thiserror::Error;
 
-#[derive(Error, Debug)]
-pub enum Never {}
 #[derive(Error, Debug, PartialEq)]
 pub enum ContractError {
     #[error("{0}")]


### PR DESCRIPTION
## Summary

- **1a** Remove `println!` in `ibc/receive/token.rs` that leaked token keys to node logs in production
- **1c** Document the native cross-chain reply-ID reserved range (2001–3000), wrap-around behaviour, and `ensure!` collision guard in `euclid_ibc/src/state.rs`, `router_ibc.rs`, and `factory_ibc.rs`
- **3b** Move `cw-orch` in `lp_token` from `[dependencies]` → `[target.'cfg(not(target_arch = "wasm32"))'.dependencies]` (was compiled into the wasm binary unnecessarily); remove unused `cw-multi-test` (all usages in `integration_tests.rs` are commented out)
- **5a** Fix `msg.clone().sender` → `msg.sender.clone()` in two `ibc/receive/token.rs` handlers (cloned the entire struct just to extract one field); load `virtual_balance_address` as `Addr` in `ack_and_timeout.rs` to remove a redundant `.to_string()` on an already-`String` value
- **5c** Delete unused `Never` error enum from `packages/euclid/src/error.rs` and `packages/forwarding/src/msgs/errors_old.rs`

## Test plan

- [ ] `cargo test` — all tests pass (verified locally before push)
- [ ] `cargo clippy --all-targets --all-features` — no new warnings
- [ ] Confirm `lp_token` wasm build no longer pulls in `cw-orch` at link time

🤖 Generated with [Claude Code](https://claude.ai/claude-code)