### PR TITLE
test(clp): add out-of-range position integration tests

### DIFF
--- a/tests-integration/src/tests_reusable/clp/authorization.rs
+++ b/tests-integration/src/tests_reusable/clp/authorization.rs
@@ -7,20 +7,14 @@ use euclid::msgs::cross_chain_config::CrossChainConfig;
 use euclid::msgs::factory::msg::QueryMsgFns as FactoryQueryMsgFns;
 use rstest::rstest;
 
+use super::utils::first_position_id;
 use crate::helpers::factory::{
-    add_concentrated_liquidity, create_concentrated_pool, list_position_ids,
-    remove_concentrated_liquidity,
+    add_concentrated_liquidity, create_concentrated_pool, remove_concentrated_liquidity,
 };
 use crate::tests_reusable::concentrated_create_pool::{pair_with_amounts, setup_concentrated_env};
 use crate::tests_reusable::concentrated_swap::execute_concentrated_swap;
 use crate::tests_reusable::constants::{FACTORY_CHAIN_ID_IBC, FACTORY_CHAIN_ID_LOCAL};
 use crate::tests_reusable::factory_register::FactorySetupMode;
-
-fn first_position_id(factory: &factory::FactoryContract<cw_orch::mock::MockBase>) -> Uint128 {
-    let ids = list_position_ids(factory).unwrap();
-    assert!(!ids.is_empty(), "expected at least one position");
-    Uint128::new(ids[0].parse::<u128>().unwrap())
-}
 
 #[cfg(test)]
 mod tests {

--- a/tests-integration/src/tests_reusable/clp/mod.rs
+++ b/tests-integration/src/tests_reusable/clp/mod.rs
@@ -1,6 +1,7 @@
 #![cfg(not(target_arch = "wasm32"))]
 
 pub mod authorization;
+pub mod out_of_range;
 pub mod pending_and_race;
 pub mod position_id;
 pub mod position_lifecycle;

--- a/tests-integration/src/tests_reusable/clp/mod.rs
+++ b/tests-integration/src/tests_reusable/clp/mod.rs
@@ -1,6 +1,7 @@
 #![cfg(not(target_arch = "wasm32"))]
 
 pub mod authorization;
+pub mod one_sided;
 pub mod out_of_range;
 pub mod pending_and_race;
 pub mod position_id;

--- a/tests-integration/src/tests_reusable/clp/one_sided.rs
+++ b/tests-integration/src/tests_reusable/clp/one_sided.rs
@@ -1,0 +1,445 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+use cosmwasm_std::{Addr, Uint128};
+use cw_orch::prelude::*;
+use euclid::msgs::router::query::QueryMsgFns as RouterQueryMsgFns;
+use euclid::msgs::vlp::concentrated::msg::{
+    PositionResponse, QueryMsg as ConcentratedQueryMsg, Slot0Response,
+};
+use rstest::rstest;
+
+use crate::helpers::chains::get_concentrated_vlp;
+use crate::helpers::factory::{
+    add_concentrated_liquidity, create_concentrated_pool, list_position_ids,
+    remove_concentrated_liquidity,
+};
+use crate::tests_reusable::concentrated_create_pool::{pair_with_amounts, setup_concentrated_env};
+use crate::tests_reusable::factory_register::FactorySetupMode;
+
+fn last_position_id(factory: &factory::FactoryContract<cw_orch::mock::MockBase>) -> Uint128 {
+    let ids = list_position_ids(factory).unwrap();
+    assert!(!ids.is_empty(), "expected at least one position");
+    Uint128::new(ids.last().unwrap().parse::<u128>().unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Position below current tick needs only token_1. Providing token_0 = 1
+    /// (dust, to satisfy escrow) with max slippage should succeed and
+    /// effectively use only token_1.
+    #[rstest]
+    fn test_one_sided_below_tick_only_token_1(
+        #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
+        mode: FactorySetupMode,
+    ) {
+        let factory_chain_id = mode.factory_chain_id();
+        let (_interchain, factory, router, token_a, token_b) =
+            setup_concentrated_env(mode, factory_chain_id);
+        let pair = pair_with_amounts(&token_a, &token_b, 30_000, 30_000);
+        let pool_key = create_concentrated_pool(&factory, &router, pair, 500, 10, 100).unwrap();
+
+        let vlp_addr = Addr::unchecked(router.get_vlp_by_pool_key(pool_key.clone()).unwrap().vlp);
+        let vlp = get_concentrated_vlp(router.environment(), &vlp_addr);
+        let slot0: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+
+        let lower = ((slot0.tick - 500) / 10) * 10;
+        let upper = ((slot0.tick - 100) / 10) * 10;
+
+        let add_resp = add_concentrated_liquidity(
+            &factory,
+            &router,
+            pair_with_amounts(&token_a, &token_b, 1, 10_000),
+            pool_key.clone(),
+            lower,
+            upper,
+            None,
+            10_000,
+        )
+        .unwrap();
+
+        assert!(!add_resp.liquidity_delta.is_zero(), "should mint liquidity");
+        assert_eq!(
+            add_resp.used_token_1,
+            Uint128::zero(),
+            "token_0 should not be used for below-tick position",
+        );
+        assert!(
+            add_resp.used_token_2 > Uint128::zero(),
+            "token_1 should be used for below-tick position",
+        );
+    }
+
+    /// Position above current tick needs only token_0. Providing token_1 = 1
+    /// (dust, to satisfy escrow) with max slippage should succeed and
+    /// effectively use only token_0.
+    #[rstest]
+    fn test_one_sided_above_tick_only_token_0(
+        #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
+        mode: FactorySetupMode,
+    ) {
+        let factory_chain_id = mode.factory_chain_id();
+        let (_interchain, factory, router, token_a, token_b) =
+            setup_concentrated_env(mode, factory_chain_id);
+        let pair = pair_with_amounts(&token_a, &token_b, 30_000, 30_000);
+        let pool_key = create_concentrated_pool(&factory, &router, pair, 500, 10, 100).unwrap();
+
+        let vlp_addr = Addr::unchecked(router.get_vlp_by_pool_key(pool_key.clone()).unwrap().vlp);
+        let vlp = get_concentrated_vlp(router.environment(), &vlp_addr);
+        let slot0: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+
+        let lower = ((slot0.tick + 100) / 10) * 10;
+        let upper = ((slot0.tick + 500) / 10) * 10;
+
+        let add_resp = add_concentrated_liquidity(
+            &factory,
+            &router,
+            pair_with_amounts(&token_a, &token_b, 10_000, 1),
+            pool_key.clone(),
+            lower,
+            upper,
+            None,
+            10_000,
+        )
+        .unwrap();
+
+        assert!(!add_resp.liquidity_delta.is_zero(), "should mint liquidity");
+        assert!(
+            add_resp.used_token_1 > Uint128::zero(),
+            "token_0 should be used for above-tick position",
+        );
+        assert_eq!(
+            add_resp.used_token_2,
+            Uint128::zero(),
+            "token_1 should not be used for above-tick position",
+        );
+    }
+
+    /// Escrow rejects zero-amount coins, so providing exactly 0 for one token
+    /// in an OOR add should fail at the factory/escrow level.
+    #[rstest]
+    fn test_one_sided_zero_amount_rejected_by_escrow(
+        #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
+        mode: FactorySetupMode,
+    ) {
+        let factory_chain_id = mode.factory_chain_id();
+        let (_interchain, factory, router, token_a, token_b) =
+            setup_concentrated_env(mode, factory_chain_id);
+        let pair = pair_with_amounts(&token_a, &token_b, 30_000, 30_000);
+        let pool_key = create_concentrated_pool(&factory, &router, pair, 500, 10, 100).unwrap();
+
+        let vlp_addr = Addr::unchecked(router.get_vlp_by_pool_key(pool_key.clone()).unwrap().vlp);
+        let vlp = get_concentrated_vlp(router.environment(), &vlp_addr);
+        let slot0: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+
+        let lower = ((slot0.tick - 500) / 10) * 10;
+        let upper = ((slot0.tick - 100) / 10) * 10;
+
+        let err = add_concentrated_liquidity(
+            &factory,
+            &router,
+            pair_with_amounts(&token_a, &token_b, 0, 10_000),
+            pool_key,
+            lower,
+            upper,
+            None,
+            10_000,
+        );
+        assert!(
+            err.is_err(),
+            "zero-amount token should be rejected by escrow",
+        );
+    }
+
+    /// Providing both tokens for a below-tick position with tight slippage
+    /// should fail because token_0 is entirely unused.
+    #[rstest]
+    fn test_one_sided_below_tick_both_tokens_tight_slippage_fails(
+        #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
+        mode: FactorySetupMode,
+    ) {
+        let factory_chain_id = mode.factory_chain_id();
+        let (_interchain, factory, router, token_a, token_b) =
+            setup_concentrated_env(mode, factory_chain_id);
+        let pair = pair_with_amounts(&token_a, &token_b, 30_000, 30_000);
+        let pool_key = create_concentrated_pool(&factory, &router, pair, 500, 10, 100).unwrap();
+
+        let vlp_addr = Addr::unchecked(router.get_vlp_by_pool_key(pool_key.clone()).unwrap().vlp);
+        let vlp = get_concentrated_vlp(router.environment(), &vlp_addr);
+        let slot0: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+
+        let lower = ((slot0.tick - 500) / 10) * 10;
+        let upper = ((slot0.tick - 100) / 10) * 10;
+
+        let err = add_concentrated_liquidity(
+            &factory,
+            &router,
+            pair_with_amounts(&token_a, &token_b, 5_000, 5_000),
+            pool_key,
+            lower,
+            upper,
+            None,
+            100,
+        );
+        assert!(
+            err.is_err(),
+            "below-tick position with both tokens and tight slippage should fail",
+        );
+    }
+
+    /// Providing both tokens for an above-tick position with tight slippage
+    /// should fail because token_1 is entirely unused.
+    #[rstest]
+    fn test_one_sided_above_tick_both_tokens_tight_slippage_fails(
+        #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
+        mode: FactorySetupMode,
+    ) {
+        let factory_chain_id = mode.factory_chain_id();
+        let (_interchain, factory, router, token_a, token_b) =
+            setup_concentrated_env(mode, factory_chain_id);
+        let pair = pair_with_amounts(&token_a, &token_b, 30_000, 30_000);
+        let pool_key = create_concentrated_pool(&factory, &router, pair, 500, 10, 100).unwrap();
+
+        let vlp_addr = Addr::unchecked(router.get_vlp_by_pool_key(pool_key.clone()).unwrap().vlp);
+        let vlp = get_concentrated_vlp(router.environment(), &vlp_addr);
+        let slot0: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+
+        let lower = ((slot0.tick + 100) / 10) * 10;
+        let upper = ((slot0.tick + 500) / 10) * 10;
+
+        let err = add_concentrated_liquidity(
+            &factory,
+            &router,
+            pair_with_amounts(&token_a, &token_b, 5_000, 5_000),
+            pool_key,
+            lower,
+            upper,
+            None,
+            100,
+        );
+        assert!(
+            err.is_err(),
+            "above-tick position with both tokens and tight slippage should fail",
+        );
+    }
+
+    /// Providing both tokens with max slippage (100%) should succeed for OOR
+    /// positions — unused token is fully refunded.
+    #[rstest]
+    fn test_one_sided_below_tick_both_tokens_max_slippage_succeeds(
+        #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
+        mode: FactorySetupMode,
+    ) {
+        let factory_chain_id = mode.factory_chain_id();
+        let (_interchain, factory, router, token_a, token_b) =
+            setup_concentrated_env(mode, factory_chain_id);
+        let pair = pair_with_amounts(&token_a, &token_b, 30_000, 30_000);
+        let pool_key = create_concentrated_pool(&factory, &router, pair, 500, 10, 100).unwrap();
+
+        let vlp_addr = Addr::unchecked(router.get_vlp_by_pool_key(pool_key.clone()).unwrap().vlp);
+        let vlp = get_concentrated_vlp(router.environment(), &vlp_addr);
+        let slot0: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+
+        let lower = ((slot0.tick - 500) / 10) * 10;
+        let upper = ((slot0.tick - 100) / 10) * 10;
+
+        let add_resp = add_concentrated_liquidity(
+            &factory,
+            &router,
+            pair_with_amounts(&token_a, &token_b, 5_000, 5_000),
+            pool_key,
+            lower,
+            upper,
+            None,
+            10_000,
+        )
+        .unwrap();
+
+        assert!(!add_resp.liquidity_delta.is_zero());
+        assert_eq!(add_resp.used_token_1, Uint128::zero());
+        assert!(add_resp.used_token_2 > Uint128::zero());
+    }
+
+    /// One-sided position (with dust on unused side) can be fully removed.
+    #[rstest]
+    fn test_one_sided_position_full_remove(
+        #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
+        mode: FactorySetupMode,
+    ) {
+        let factory_chain_id = mode.factory_chain_id();
+        let (_interchain, factory, router, token_a, token_b) =
+            setup_concentrated_env(mode, factory_chain_id);
+        let pair = pair_with_amounts(&token_a, &token_b, 30_000, 30_000);
+        let pool_key = create_concentrated_pool(&factory, &router, pair, 500, 10, 100).unwrap();
+
+        let vlp_addr = Addr::unchecked(router.get_vlp_by_pool_key(pool_key.clone()).unwrap().vlp);
+        let vlp = get_concentrated_vlp(router.environment(), &vlp_addr);
+        let slot0: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+
+        let lower = ((slot0.tick + 100) / 10) * 10;
+        let upper = ((slot0.tick + 500) / 10) * 10;
+
+        add_concentrated_liquidity(
+            &factory,
+            &router,
+            pair_with_amounts(&token_a, &token_b, 10_000, 1),
+            pool_key.clone(),
+            lower,
+            upper,
+            None,
+            10_000,
+        )
+        .unwrap();
+
+        let pos_id = last_position_id(&factory);
+        let pos: PositionResponse = vlp
+            .query(&ConcentratedQueryMsg::Position {
+                position_id: pos_id,
+            })
+            .unwrap();
+        assert!(!pos.liquidity.is_zero());
+
+        remove_concentrated_liquidity(&factory, &router, pool_key, pos_id, pos.liquidity).unwrap();
+
+        let pos_result: Result<PositionResponse, _> =
+            vlp.query(&ConcentratedQueryMsg::Position {
+                position_id: pos_id,
+            });
+        assert!(
+            pos_result.is_err(),
+            "one-sided position should be deleted after full removal",
+        );
+    }
+
+    /// Adding more liquidity to existing one-sided position with dust on
+    /// unused side should succeed.
+    #[rstest]
+    fn test_one_sided_add_to_existing_position(
+        #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
+        mode: FactorySetupMode,
+    ) {
+        let factory_chain_id = mode.factory_chain_id();
+        let (_interchain, factory, router, token_a, token_b) =
+            setup_concentrated_env(mode, factory_chain_id);
+        let pair = pair_with_amounts(&token_a, &token_b, 30_000, 30_000);
+        let pool_key = create_concentrated_pool(&factory, &router, pair, 500, 10, 100).unwrap();
+
+        let vlp_addr = Addr::unchecked(router.get_vlp_by_pool_key(pool_key.clone()).unwrap().vlp);
+        let vlp = get_concentrated_vlp(router.environment(), &vlp_addr);
+        let slot0: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+
+        let lower = ((slot0.tick - 500) / 10) * 10;
+        let upper = ((slot0.tick - 100) / 10) * 10;
+
+        add_concentrated_liquidity(
+            &factory,
+            &router,
+            pair_with_amounts(&token_a, &token_b, 1, 5_000),
+            pool_key.clone(),
+            lower,
+            upper,
+            None,
+            10_000,
+        )
+        .unwrap();
+
+        let pos_id = last_position_id(&factory);
+        let pos_before: PositionResponse = vlp
+            .query(&ConcentratedQueryMsg::Position {
+                position_id: pos_id,
+            })
+            .unwrap();
+
+        let add_resp = add_concentrated_liquidity(
+            &factory,
+            &router,
+            pair_with_amounts(&token_a, &token_b, 1, 5_000),
+            pool_key,
+            lower,
+            upper,
+            Some(pos_id),
+            10_000,
+        )
+        .unwrap();
+
+        assert!(!add_resp.liquidity_delta.is_zero());
+        assert_eq!(add_resp.used_token_1, Uint128::zero());
+
+        let pos_after: PositionResponse = vlp
+            .query(&ConcentratedQueryMsg::Position {
+                position_id: pos_id,
+            })
+            .unwrap();
+        assert_eq!(
+            pos_after.liquidity,
+            pos_before.liquidity + add_resp.liquidity_delta,
+        );
+
+        let ids = list_position_ids(&factory).unwrap();
+        let oor_count = ids
+            .iter()
+            .filter(|id| id.as_str() == pos_id.to_string())
+            .count();
+        assert_eq!(oor_count, 1, "should still be same single position");
+    }
+
+    /// Providing mainly the wrong token for tick direction with tight slippage
+    /// should fail. Below tick needs token_1; providing lots of token_0 with
+    /// tight slippage fails because token_0 is 100% unused. Same for above.
+    #[rstest]
+    fn test_one_sided_wrong_token_tight_slippage_fails(
+        #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
+        mode: FactorySetupMode,
+    ) {
+        let factory_chain_id = mode.factory_chain_id();
+        let (_interchain, factory, router, token_a, token_b) =
+            setup_concentrated_env(mode, factory_chain_id);
+        let pair = pair_with_amounts(&token_a, &token_b, 30_000, 30_000);
+        let pool_key = create_concentrated_pool(&factory, &router, pair, 500, 10, 100).unwrap();
+
+        let vlp_addr = Addr::unchecked(router.get_vlp_by_pool_key(pool_key.clone()).unwrap().vlp);
+        let vlp = get_concentrated_vlp(router.environment(), &vlp_addr);
+        let slot0: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+
+        // Below tick needs token_1. Provide heavy token_0 + small token_1,
+        // tight slippage — token_0 fully unused → slippage error
+        let lower = ((slot0.tick - 500) / 10) * 10;
+        let upper = ((slot0.tick - 100) / 10) * 10;
+
+        let err = add_concentrated_liquidity(
+            &factory,
+            &router,
+            pair_with_amounts(&token_a, &token_b, 10_000, 1_000),
+            pool_key.clone(),
+            lower,
+            upper,
+            None,
+            100,
+        );
+        assert!(
+            err.is_err(),
+            "below-tick: heavy wrong token + tight slippage should fail",
+        );
+
+        // Above tick needs token_0. Provide heavy token_1 + small token_0,
+        // tight slippage — token_1 fully unused → slippage error
+        let lower_above = ((slot0.tick + 100) / 10) * 10;
+        let upper_above = ((slot0.tick + 500) / 10) * 10;
+
+        let err = add_concentrated_liquidity(
+            &factory,
+            &router,
+            pair_with_amounts(&token_a, &token_b, 1_000, 10_000),
+            pool_key,
+            lower_above,
+            upper_above,
+            None,
+            100,
+        );
+        assert!(
+            err.is_err(),
+            "above-tick: heavy wrong token + tight slippage should fail",
+        );
+    }
+}

--- a/tests-integration/src/tests_reusable/clp/one_sided.rs
+++ b/tests-integration/src/tests_reusable/clp/one_sided.rs
@@ -302,10 +302,9 @@ mod tests {
 
         remove_concentrated_liquidity(&factory, &router, pool_key, pos_id, pos.liquidity).unwrap();
 
-        let pos_result: Result<PositionResponse, _> =
-            vlp.query(&ConcentratedQueryMsg::Position {
-                position_id: pos_id,
-            });
+        let pos_result: Result<PositionResponse, _> = vlp.query(&ConcentratedQueryMsg::Position {
+            position_id: pos_id,
+        });
         assert!(
             pos_result.is_err(),
             "one-sided position should be deleted after full removal",

--- a/tests-integration/src/tests_reusable/clp/one_sided.rs
+++ b/tests-integration/src/tests_reusable/clp/one_sided.rs
@@ -8,6 +8,7 @@ use euclid::msgs::vlp::concentrated::msg::{
 };
 use rstest::rstest;
 
+use super::utils::last_position_id;
 use crate::helpers::chains::get_concentrated_vlp;
 use crate::helpers::factory::{
     add_concentrated_liquidity, create_concentrated_pool, list_position_ids,
@@ -15,12 +16,6 @@ use crate::helpers::factory::{
 };
 use crate::tests_reusable::concentrated_create_pool::{pair_with_amounts, setup_concentrated_env};
 use crate::tests_reusable::factory_register::FactorySetupMode;
-
-fn last_position_id(factory: &factory::FactoryContract<cw_orch::mock::MockBase>) -> Uint128 {
-    let ids = list_position_ids(factory).unwrap();
-    assert!(!ids.is_empty(), "expected at least one position");
-    Uint128::new(ids.last().unwrap().parse::<u128>().unwrap())
-}
 
 #[cfg(test)]
 mod tests {

--- a/tests-integration/src/tests_reusable/clp/out_of_range.rs
+++ b/tests-integration/src/tests_reusable/clp/out_of_range.rs
@@ -1,0 +1,615 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+use cosmwasm_std::{Addr, Uint128, Uint256};
+use cw_orch::prelude::*;
+use euclid::cross_chain_user::CrossChainUser;
+use euclid::msgs::factory::msg::QueryMsgFns as FactoryQueryMsgFns;
+use euclid::msgs::router::query::QueryMsgFns as RouterQueryMsgFns;
+use euclid::msgs::virtual_balance::msg::QueryMsgFns as VirtualBalanceQueryMsgFns;
+use euclid::msgs::vlp::concentrated::msg::{
+    PositionResponse, QueryMsg as ConcentratedQueryMsg, Slot0Response,
+};
+use euclid::voucher::BalanceKey;
+use rstest::rstest;
+
+use crate::helpers::chains::{get_concentrated_vlp, get_virtual_balance};
+use crate::helpers::factory::{
+    add_concentrated_liquidity, collect_concentrated_fees, create_concentrated_pool,
+    list_position_ids, remove_concentrated_liquidity,
+};
+use crate::tests_reusable::concentrated_create_pool::{pair_with_amounts, setup_concentrated_env};
+use crate::tests_reusable::concentrated_swap::execute_concentrated_swap;
+use crate::tests_reusable::factory_register::FactorySetupMode;
+
+fn first_position_id(factory: &factory::FactoryContract<cw_orch::mock::MockBase>) -> Uint128 {
+    let ids = list_position_ids(factory).unwrap();
+    assert!(!ids.is_empty(), "expected at least one position");
+    Uint128::new(ids[0].parse::<u128>().unwrap())
+}
+
+fn last_position_id(factory: &factory::FactoryContract<cw_orch::mock::MockBase>) -> Uint128 {
+    let ids = list_position_ids(factory).unwrap();
+    assert!(!ids.is_empty(), "expected at least one position");
+    Uint128::new(ids.last().unwrap().parse::<u128>().unwrap())
+}
+
+fn sender(factory: &factory::FactoryContract<cw_orch::mock::MockBase>) -> CrossChainUser {
+    CrossChainUser::new(
+        factory.get_state().unwrap().chain_uid,
+        factory.environment().sender.to_string(),
+    )
+}
+
+fn voucher_balance(
+    factory: &factory::FactoryContract<cw_orch::mock::MockBase>,
+    router: &router::RouterContract<cw_orch::mock::MockBase>,
+    token_id: &str,
+) -> Uint128 {
+    let virtual_balance = get_virtual_balance(
+        router.environment(),
+        &router.get_state().unwrap().virtual_balance_address,
+    );
+    virtual_balance
+        .get_balance(BalanceKey {
+            cross_chain_user: sender(factory),
+            token_id: token_id.to_string(),
+        })
+        .unwrap()
+        .amount
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[rstest]
+    fn test_add_position_below_range_does_not_change_active_liquidity(
+        #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
+        mode: FactorySetupMode,
+    ) {
+        let factory_chain_id = mode.factory_chain_id();
+        let (_interchain, factory, router, token_a, token_b) =
+            setup_concentrated_env(mode, factory_chain_id);
+        let pair = pair_with_amounts(&token_a, &token_b, 30_000, 30_000);
+        let pool_key = create_concentrated_pool(&factory, &router, pair, 500, 10, 100).unwrap();
+
+        let vlp_addr = Addr::unchecked(router.get_vlp_by_pool_key(pool_key.clone()).unwrap().vlp);
+        let vlp = get_concentrated_vlp(router.environment(), &vlp_addr);
+        let slot0_before: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+
+        // Position entirely below current tick
+        let lower = ((slot0_before.tick - 300) / 10) * 10;
+        let upper = ((slot0_before.tick - 100) / 10) * 10;
+        assert!(
+            upper <= slot0_before.tick,
+            "position must be below current tick"
+        );
+
+        add_concentrated_liquidity(
+            &factory,
+            &router,
+            pair_with_amounts(&token_a, &token_b, 5_000, 5_000),
+            pool_key,
+            lower,
+            upper,
+            None,
+            10_000,
+        )
+        .unwrap();
+
+        let slot0_after: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+        assert_eq!(
+            slot0_after.liquidity, slot0_before.liquidity,
+            "active liquidity must not change when adding out-of-range position below",
+        );
+    }
+
+    #[rstest]
+    fn test_add_position_above_range_does_not_change_active_liquidity(
+        #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
+        mode: FactorySetupMode,
+    ) {
+        let factory_chain_id = mode.factory_chain_id();
+        let (_interchain, factory, router, token_a, token_b) =
+            setup_concentrated_env(mode, factory_chain_id);
+        let pair = pair_with_amounts(&token_a, &token_b, 30_000, 30_000);
+        let pool_key = create_concentrated_pool(&factory, &router, pair, 500, 10, 100).unwrap();
+
+        let vlp_addr = Addr::unchecked(router.get_vlp_by_pool_key(pool_key.clone()).unwrap().vlp);
+        let vlp = get_concentrated_vlp(router.environment(), &vlp_addr);
+        let slot0_before: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+
+        // Position entirely above current tick
+        let lower = ((slot0_before.tick + 100) / 10) * 10;
+        let upper = ((slot0_before.tick + 300) / 10) * 10;
+        assert!(
+            lower > slot0_before.tick,
+            "position must be above current tick"
+        );
+
+        add_concentrated_liquidity(
+            &factory,
+            &router,
+            pair_with_amounts(&token_a, &token_b, 5_000, 5_000),
+            pool_key,
+            lower,
+            upper,
+            None,
+            10_000,
+        )
+        .unwrap();
+
+        let slot0_after: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+        assert_eq!(
+            slot0_after.liquidity, slot0_before.liquidity,
+            "active liquidity must not change when adding out-of-range position above",
+        );
+    }
+
+    #[rstest]
+    fn test_out_of_range_position_earns_no_fees(
+        #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
+        mode: FactorySetupMode,
+    ) {
+        let factory_chain_id = mode.factory_chain_id();
+        let (_interchain, factory, router, token_a, token_b) =
+            setup_concentrated_env(mode, factory_chain_id);
+        let pair = pair_with_amounts(&token_a, &token_b, 50_000, 50_000);
+        let pool_key = create_concentrated_pool(&factory, &router, pair, 500, 10, 100).unwrap();
+
+        let vlp_addr = Addr::unchecked(router.get_vlp_by_pool_key(pool_key.clone()).unwrap().vlp);
+        let vlp = get_concentrated_vlp(router.environment(), &vlp_addr);
+        let slot0: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+
+        // Add position far below current tick
+        let lower = ((slot0.tick - 500) / 10) * 10;
+        let upper = ((slot0.tick - 300) / 10) * 10;
+
+        add_concentrated_liquidity(
+            &factory,
+            &router,
+            pair_with_amounts(&token_a, &token_b, 10_000, 10_000),
+            pool_key.clone(),
+            lower,
+            upper,
+            None,
+            10_000,
+        )
+        .unwrap();
+
+        let oor_position_id = last_position_id(&factory);
+
+        // Execute swaps that stay within the in-range position
+        for _ in 0..3 {
+            execute_concentrated_swap(
+                &factory,
+                &router,
+                pool_key.clone(),
+                token_a.clone(),
+                token_b.token.clone(),
+                Uint128::new(2_000),
+            );
+            execute_concentrated_swap(
+                &factory,
+                &router,
+                pool_key.clone(),
+                token_b.clone(),
+                token_a.token.clone(),
+                Uint128::new(2_000),
+            );
+        }
+
+        // Out-of-range position should have zero tokens owed
+        let pos: PositionResponse = vlp
+            .query(&ConcentratedQueryMsg::Position {
+                position_id: oor_position_id,
+            })
+            .unwrap();
+        assert_eq!(
+            pos.tokens_owed_0,
+            Uint128::zero(),
+            "out-of-range position should have zero tokens_owed_0",
+        );
+        assert_eq!(
+            pos.tokens_owed_1,
+            Uint128::zero(),
+            "out-of-range position should have zero tokens_owed_1",
+        );
+
+        // Global fee growth should have increased from the swaps
+        let slot0_after: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+        assert!(
+            slot0_after.fee_growth_global_0_x128 > Uint256::zero()
+                || slot0_after.fee_growth_global_1_x128 > Uint256::zero(),
+            "swaps should have generated global fee growth",
+        );
+    }
+
+    #[rstest]
+    fn test_swap_into_out_of_range_position_activates_it(
+        #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
+        mode: FactorySetupMode,
+    ) {
+        let factory_chain_id = mode.factory_chain_id();
+        let (_interchain, factory, router, token_a, token_b) =
+            setup_concentrated_env(mode, factory_chain_id);
+        let pair = pair_with_amounts(&token_a, &token_b, 50_000, 50_000);
+        let pool_key = create_concentrated_pool(&factory, &router, pair, 500, 10, 100).unwrap();
+
+        let vlp_addr = Addr::unchecked(router.get_vlp_by_pool_key(pool_key.clone()).unwrap().vlp);
+        let vlp = get_concentrated_vlp(router.environment(), &vlp_addr);
+        let slot0: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+        let active_liq_before = slot0.liquidity;
+
+        // Wide OOR position below current tick so a moderate swap lands inside
+        let lower = ((slot0.tick - 10_000) / 10) * 10;
+        let upper = ((slot0.tick - 10) / 10) * 10;
+
+        let add_resp = add_concentrated_liquidity(
+            &factory,
+            &router,
+            pair_with_amounts(&token_a, &token_b, 20_000, 20_000),
+            pool_key.clone(),
+            lower,
+            upper,
+            None,
+            10_000,
+        )
+        .unwrap();
+        assert!(!add_resp.liquidity_delta.is_zero());
+
+        let slot0_mid: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+        assert_eq!(slot0_mid.liquidity, active_liq_before);
+
+        // Small swap to nudge tick down past upper bound of OOR position
+        execute_concentrated_swap(
+            &factory,
+            &router,
+            pool_key.clone(),
+            token_a.clone(),
+            token_b.token.clone(),
+            Uint128::new(5_000),
+        );
+
+        let slot0_after: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+
+        assert!(
+            slot0_after.tick < upper,
+            "swap should push tick below OOR upper bound: tick={}, upper={}",
+            slot0_after.tick,
+            upper,
+        );
+        assert!(
+            slot0_after.tick >= lower,
+            "tick should remain above OOR lower bound: tick={}, lower={}",
+            slot0_after.tick,
+            lower,
+        );
+        assert!(
+            slot0_after.liquidity > active_liq_before,
+            "active liquidity should increase when tick enters out-of-range position: \
+             before={}, after={}, tick={}",
+            active_liq_before,
+            slot0_after.liquidity,
+            slot0_after.tick,
+        );
+    }
+
+    #[rstest]
+    fn test_remove_liquidity_from_out_of_range_position(
+        #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
+        mode: FactorySetupMode,
+    ) {
+        let factory_chain_id = mode.factory_chain_id();
+        let (_interchain, factory, router, token_a, token_b) =
+            setup_concentrated_env(mode, factory_chain_id);
+        let pair = pair_with_amounts(&token_a, &token_b, 30_000, 30_000);
+        let pool_key = create_concentrated_pool(&factory, &router, pair, 500, 10, 100).unwrap();
+
+        let vlp_addr = Addr::unchecked(router.get_vlp_by_pool_key(pool_key.clone()).unwrap().vlp);
+        let vlp = get_concentrated_vlp(router.environment(), &vlp_addr);
+        let slot0: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+
+        // Add position above current tick
+        let lower = ((slot0.tick + 100) / 10) * 10;
+        let upper = ((slot0.tick + 300) / 10) * 10;
+
+        add_concentrated_liquidity(
+            &factory,
+            &router,
+            pair_with_amounts(&token_a, &token_b, 10_000, 10_000),
+            pool_key.clone(),
+            lower,
+            upper,
+            None,
+            10_000,
+        )
+        .unwrap();
+
+        let oor_id = last_position_id(&factory);
+        let pos: PositionResponse = vlp
+            .query(&ConcentratedQueryMsg::Position {
+                position_id: oor_id,
+            })
+            .unwrap();
+        let liq = pos.liquidity;
+        assert!(!liq.is_zero());
+
+        let active_before: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+
+        // Partial remove from out-of-range position
+        let half = Uint128::new(liq.u128() / 2);
+        remove_concentrated_liquidity(&factory, &router, pool_key.clone(), oor_id, half).unwrap();
+
+        let active_after: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+        assert_eq!(
+            active_after.liquidity, active_before.liquidity,
+            "removing from out-of-range position must not change active liquidity",
+        );
+
+        let pos_after: PositionResponse = vlp
+            .query(&ConcentratedQueryMsg::Position {
+                position_id: oor_id,
+            })
+            .unwrap();
+        assert_eq!(
+            pos_after.liquidity,
+            liq - half,
+            "position liquidity should decrease by removed amount",
+        );
+
+        // Full remove of remaining
+        remove_concentrated_liquidity(&factory, &router, pool_key, oor_id, pos_after.liquidity)
+            .unwrap();
+
+        let pos_result: Result<PositionResponse, _> = vlp.query(&ConcentratedQueryMsg::Position {
+            position_id: oor_id,
+        });
+        assert!(
+            pos_result.is_err(),
+            "out-of-range position should be deleted after full removal",
+        );
+    }
+
+    #[rstest]
+    fn test_add_to_existing_out_of_range_position_keeps_active_liquidity(
+        #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
+        mode: FactorySetupMode,
+    ) {
+        let factory_chain_id = mode.factory_chain_id();
+        let (_interchain, factory, router, token_a, token_b) =
+            setup_concentrated_env(mode, factory_chain_id);
+        let pair = pair_with_amounts(&token_a, &token_b, 30_000, 30_000);
+        let pool_key = create_concentrated_pool(&factory, &router, pair, 500, 10, 100).unwrap();
+
+        let vlp_addr = Addr::unchecked(router.get_vlp_by_pool_key(pool_key.clone()).unwrap().vlp);
+        let vlp = get_concentrated_vlp(router.environment(), &vlp_addr);
+        let slot0: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+
+        // Create out-of-range position below
+        let lower = ((slot0.tick - 400) / 10) * 10;
+        let upper = ((slot0.tick - 200) / 10) * 10;
+
+        add_concentrated_liquidity(
+            &factory,
+            &router,
+            pair_with_amounts(&token_a, &token_b, 5_000, 5_000),
+            pool_key.clone(),
+            lower,
+            upper,
+            None,
+            10_000,
+        )
+        .unwrap();
+
+        let oor_id = last_position_id(&factory);
+        let pos_before: PositionResponse = vlp
+            .query(&ConcentratedQueryMsg::Position {
+                position_id: oor_id,
+            })
+            .unwrap();
+        let active_before: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+
+        // Add more to the same OOR position
+        let add_resp = add_concentrated_liquidity(
+            &factory,
+            &router,
+            pair_with_amounts(&token_a, &token_b, 5_000, 5_000),
+            pool_key,
+            lower,
+            upper,
+            Some(oor_id),
+            10_000,
+        )
+        .unwrap();
+        assert!(!add_resp.liquidity_delta.is_zero());
+
+        let active_after: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+        assert_eq!(
+            active_after.liquidity, active_before.liquidity,
+            "adding to existing out-of-range position must not change active liquidity",
+        );
+
+        let pos_after: PositionResponse = vlp
+            .query(&ConcentratedQueryMsg::Position {
+                position_id: oor_id,
+            })
+            .unwrap();
+        assert_eq!(
+            pos_after.liquidity,
+            pos_before.liquidity + add_resp.liquidity_delta,
+            "position liquidity should increase by add delta",
+        );
+
+        let ids = list_position_ids(&factory).unwrap();
+        assert!(
+            ids.iter().any(|id| id == &oor_id.to_string()),
+            "position ID should remain the same after adding to existing",
+        );
+    }
+
+    #[rstest]
+    fn test_collect_fees_on_out_of_range_position_returns_zero(
+        #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
+        mode: FactorySetupMode,
+    ) {
+        let factory_chain_id = mode.factory_chain_id();
+        let (_interchain, factory, router, token_a, token_b) =
+            setup_concentrated_env(mode, factory_chain_id);
+        let pair = pair_with_amounts(&token_a, &token_b, 50_000, 50_000);
+        let pool_key = create_concentrated_pool(&factory, &router, pair, 500, 10, 100).unwrap();
+
+        let vlp_addr = Addr::unchecked(router.get_vlp_by_pool_key(pool_key.clone()).unwrap().vlp);
+        let vlp = get_concentrated_vlp(router.environment(), &vlp_addr);
+        let slot0: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+
+        // Add position far above current tick
+        let lower = ((slot0.tick + 200) / 10) * 10;
+        let upper = ((slot0.tick + 400) / 10) * 10;
+
+        add_concentrated_liquidity(
+            &factory,
+            &router,
+            pair_with_amounts(&token_a, &token_b, 10_000, 10_000),
+            pool_key.clone(),
+            lower,
+            upper,
+            None,
+            10_000,
+        )
+        .unwrap();
+
+        let oor_id = last_position_id(&factory);
+
+        // Swap back and forth (stays in range of initial position, never reaches OOR)
+        for _ in 0..3 {
+            execute_concentrated_swap(
+                &factory,
+                &router,
+                pool_key.clone(),
+                token_a.clone(),
+                token_b.token.clone(),
+                Uint128::new(3_000),
+            );
+            execute_concentrated_swap(
+                &factory,
+                &router,
+                pool_key.clone(),
+                token_b.clone(),
+                token_a.token.clone(),
+                Uint128::new(3_000),
+            );
+        }
+
+        let before_0 = voucher_balance(&factory, &router, &token_a.token.to_string());
+        let before_1 = voucher_balance(&factory, &router, &token_b.token.to_string());
+
+        collect_concentrated_fees(&factory, &router, pool_key, oor_id, sender(&factory)).unwrap();
+
+        let after_0 = voucher_balance(&factory, &router, &token_a.token.to_string());
+        let after_1 = voucher_balance(&factory, &router, &token_b.token.to_string());
+
+        assert_eq!(
+            after_0, before_0,
+            "out-of-range position should collect zero fees for token_a",
+        );
+        assert_eq!(
+            after_1, before_1,
+            "out-of-range position should collect zero fees for token_b",
+        );
+    }
+
+    #[rstest]
+    fn test_position_earns_fees_only_after_tick_enters_range(
+        #[values(FactorySetupMode::Native, FactorySetupMode::Ibc, FactorySetupMode::Evm)]
+        mode: FactorySetupMode,
+    ) {
+        let factory_chain_id = mode.factory_chain_id();
+        let (_interchain, factory, router, token_a, token_b) =
+            setup_concentrated_env(mode, factory_chain_id);
+        let pair = pair_with_amounts(&token_a, &token_b, 50_000, 50_000);
+        let pool_key = create_concentrated_pool(&factory, &router, pair, 500, 10, 100).unwrap();
+
+        let vlp_addr = Addr::unchecked(router.get_vlp_by_pool_key(pool_key.clone()).unwrap().vlp);
+        let vlp = get_concentrated_vlp(router.environment(), &vlp_addr);
+        let slot0: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+
+        // Wide OOR position below current tick
+        let lower = ((slot0.tick - 10_000) / 10) * 10;
+        let upper = ((slot0.tick - 10) / 10) * 10;
+
+        add_concentrated_liquidity(
+            &factory,
+            &router,
+            pair_with_amounts(&token_a, &token_b, 20_000, 20_000),
+            pool_key.clone(),
+            lower,
+            upper,
+            None,
+            10_000,
+        )
+        .unwrap();
+
+        let oor_id = last_position_id(&factory);
+
+        // Small swap in opposite direction — stays in range, OOR earns nothing
+        execute_concentrated_swap(
+            &factory,
+            &router,
+            pool_key.clone(),
+            token_b.clone(),
+            token_a.token.clone(),
+            Uint128::new(1_000),
+        );
+
+        let pos_before_entry: PositionResponse = vlp
+            .query(&ConcentratedQueryMsg::Position {
+                position_id: oor_id,
+            })
+            .unwrap();
+        assert_eq!(pos_before_entry.tokens_owed_0, Uint128::zero());
+        assert_eq!(pos_before_entry.tokens_owed_1, Uint128::zero());
+
+        // Controlled swap to push tick down into OOR range
+        execute_concentrated_swap(
+            &factory,
+            &router,
+            pool_key.clone(),
+            token_a.clone(),
+            token_b.token.clone(),
+            Uint128::new(5_000),
+        );
+
+        let slot0_after_big: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
+        assert!(
+            slot0_after_big.tick >= lower && slot0_after_big.tick < upper,
+            "tick should land inside OOR position range: tick={}, range=[{}, {})",
+            slot0_after_big.tick,
+            lower,
+            upper,
+        );
+
+        // Swap within OOR position's range to generate fees for it
+        execute_concentrated_swap(
+            &factory,
+            &router,
+            pool_key.clone(),
+            token_b.clone(),
+            token_a.token.clone(),
+            Uint128::new(2_000),
+        );
+
+        let before_0 = voucher_balance(&factory, &router, &token_a.token.to_string());
+        let before_1 = voucher_balance(&factory, &router, &token_b.token.to_string());
+
+        collect_concentrated_fees(&factory, &router, pool_key, oor_id, sender(&factory)).unwrap();
+
+        let after_0 = voucher_balance(&factory, &router, &token_a.token.to_string());
+        let after_1 = voucher_balance(&factory, &router, &token_b.token.to_string());
+
+        assert!(
+            after_0 > before_0 || after_1 > before_1,
+            "position should earn fees after tick moves into its range",
+        );
+    }
+}

--- a/tests-integration/src/tests_reusable/clp/out_of_range.rs
+++ b/tests-integration/src/tests_reusable/clp/out_of_range.rs
@@ -2,17 +2,14 @@
 
 use cosmwasm_std::{Addr, Uint128, Uint256};
 use cw_orch::prelude::*;
-use euclid::cross_chain_user::CrossChainUser;
-use euclid::msgs::factory::msg::QueryMsgFns as FactoryQueryMsgFns;
 use euclid::msgs::router::query::QueryMsgFns as RouterQueryMsgFns;
-use euclid::msgs::virtual_balance::msg::QueryMsgFns as VirtualBalanceQueryMsgFns;
 use euclid::msgs::vlp::concentrated::msg::{
     PositionResponse, QueryMsg as ConcentratedQueryMsg, Slot0Response,
 };
-use euclid::voucher::BalanceKey;
 use rstest::rstest;
 
-use crate::helpers::chains::{get_concentrated_vlp, get_virtual_balance};
+use super::utils::{last_position_id, sender, voucher_balance};
+use crate::helpers::chains::get_concentrated_vlp;
 use crate::helpers::factory::{
     add_concentrated_liquidity, collect_concentrated_fees, create_concentrated_pool,
     list_position_ids, remove_concentrated_liquidity,
@@ -21,42 +18,7 @@ use crate::tests_reusable::concentrated_create_pool::{pair_with_amounts, setup_c
 use crate::tests_reusable::concentrated_swap::execute_concentrated_swap;
 use crate::tests_reusable::factory_register::FactorySetupMode;
 
-fn first_position_id(factory: &factory::FactoryContract<cw_orch::mock::MockBase>) -> Uint128 {
-    let ids = list_position_ids(factory).unwrap();
-    assert!(!ids.is_empty(), "expected at least one position");
-    Uint128::new(ids[0].parse::<u128>().unwrap())
-}
-
-fn last_position_id(factory: &factory::FactoryContract<cw_orch::mock::MockBase>) -> Uint128 {
-    let ids = list_position_ids(factory).unwrap();
-    assert!(!ids.is_empty(), "expected at least one position");
-    Uint128::new(ids.last().unwrap().parse::<u128>().unwrap())
-}
-
-fn sender(factory: &factory::FactoryContract<cw_orch::mock::MockBase>) -> CrossChainUser {
-    CrossChainUser::new(
-        factory.get_state().unwrap().chain_uid,
-        factory.environment().sender.to_string(),
-    )
-}
-
-fn voucher_balance(
-    factory: &factory::FactoryContract<cw_orch::mock::MockBase>,
-    router: &router::RouterContract<cw_orch::mock::MockBase>,
-    token_id: &str,
-) -> Uint128 {
-    let virtual_balance = get_virtual_balance(
-        router.environment(),
-        &router.get_state().unwrap().virtual_balance_address,
-    );
-    virtual_balance
-        .get_balance(BalanceKey {
-            cross_chain_user: sender(factory),
-            token_id: token_id.to_string(),
-        })
-        .unwrap()
-        .amount
-}
+const TICK_SPACING: i64 = 10;
 
 #[cfg(test)]
 mod tests {
@@ -78,8 +40,8 @@ mod tests {
         let slot0_before: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
 
         // Position entirely below current tick
-        let lower = ((slot0_before.tick - 300) / 10) * 10;
-        let upper = ((slot0_before.tick - 100) / 10) * 10;
+        let lower = ((slot0_before.tick - 300) / TICK_SPACING) * TICK_SPACING;
+        let upper = ((slot0_before.tick - 100) / TICK_SPACING) * TICK_SPACING;
         assert!(
             upper <= slot0_before.tick,
             "position must be below current tick"
@@ -120,8 +82,8 @@ mod tests {
         let slot0_before: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
 
         // Position entirely above current tick
-        let lower = ((slot0_before.tick + 100) / 10) * 10;
-        let upper = ((slot0_before.tick + 300) / 10) * 10;
+        let lower = ((slot0_before.tick + 100) / TICK_SPACING) * TICK_SPACING;
+        let upper = ((slot0_before.tick + 300) / TICK_SPACING) * TICK_SPACING;
         assert!(
             lower > slot0_before.tick,
             "position must be above current tick"
@@ -162,8 +124,8 @@ mod tests {
         let slot0: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
 
         // Add position far below current tick
-        let lower = ((slot0.tick - 500) / 10) * 10;
-        let upper = ((slot0.tick - 300) / 10) * 10;
+        let lower = ((slot0.tick - 500) / TICK_SPACING) * TICK_SPACING;
+        let upper = ((slot0.tick - 300) / TICK_SPACING) * TICK_SPACING;
 
         add_concentrated_liquidity(
             &factory,
@@ -242,8 +204,8 @@ mod tests {
         let active_liq_before = slot0.liquidity;
 
         // Wide OOR position below current tick so a moderate swap lands inside
-        let lower = ((slot0.tick - 10_000) / 10) * 10;
-        let upper = ((slot0.tick - 10) / 10) * 10;
+        let lower = ((slot0.tick - 10_000) / TICK_SPACING) * TICK_SPACING;
+        let upper = ((slot0.tick - 10) / TICK_SPACING) * TICK_SPACING;
 
         let add_resp = add_concentrated_liquidity(
             &factory,
@@ -311,8 +273,8 @@ mod tests {
         let slot0: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
 
         // Add position above current tick
-        let lower = ((slot0.tick + 100) / 10) * 10;
-        let upper = ((slot0.tick + 300) / 10) * 10;
+        let lower = ((slot0.tick + 100) / TICK_SPACING) * TICK_SPACING;
+        let upper = ((slot0.tick + 300) / TICK_SPACING) * TICK_SPACING;
 
         add_concentrated_liquidity(
             &factory,
@@ -387,8 +349,8 @@ mod tests {
         let slot0: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
 
         // Create out-of-range position below
-        let lower = ((slot0.tick - 400) / 10) * 10;
-        let upper = ((slot0.tick - 200) / 10) * 10;
+        let lower = ((slot0.tick - 400) / TICK_SPACING) * TICK_SPACING;
+        let upper = ((slot0.tick - 200) / TICK_SPACING) * TICK_SPACING;
 
         add_concentrated_liquidity(
             &factory,
@@ -464,8 +426,8 @@ mod tests {
         let slot0: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
 
         // Add position far above current tick
-        let lower = ((slot0.tick + 200) / 10) * 10;
-        let upper = ((slot0.tick + 400) / 10) * 10;
+        let lower = ((slot0.tick + 200) / TICK_SPACING) * TICK_SPACING;
+        let upper = ((slot0.tick + 400) / TICK_SPACING) * TICK_SPACING;
 
         add_concentrated_liquidity(
             &factory,
@@ -535,8 +497,8 @@ mod tests {
         let slot0: Slot0Response = vlp.query(&ConcentratedQueryMsg::Slot0 {}).unwrap();
 
         // Wide OOR position below current tick
-        let lower = ((slot0.tick - 10_000) / 10) * 10;
-        let upper = ((slot0.tick - 10) / 10) * 10;
+        let lower = ((slot0.tick - 10_000) / TICK_SPACING) * TICK_SPACING;
+        let upper = ((slot0.tick - 10) / TICK_SPACING) * TICK_SPACING;
 
         add_concentrated_liquidity(
             &factory,

--- a/tests-integration/src/tests_reusable/clp/pending_and_race.rs
+++ b/tests-integration/src/tests_reusable/clp/pending_and_race.rs
@@ -29,12 +29,7 @@ use crate::tests_reusable::factory_register::FactorySetupMode;
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn first_position_id(factory: &factory::FactoryContract<cw_orch::mock::MockBase>) -> Uint128 {
-        let ids = list_position_ids(factory).unwrap();
-        assert!(!ids.is_empty(), "expected at least one position");
-        Uint128::new(ids[0].parse::<u128>().unwrap())
-    }
+    use crate::tests_reusable::clp::utils::first_position_id;
 
     fn position_liquidity_from_vlp(
         _factory: &factory::FactoryContract<cw_orch::mock::MockBase>,

--- a/tests-integration/src/tests_reusable/clp/position_id.rs
+++ b/tests-integration/src/tests_reusable/clp/position_id.rs
@@ -6,6 +6,7 @@ use euclid::msgs::router::query::QueryMsgFns as RouterQueryMsgFns;
 use euclid::msgs::vlp::concentrated::msg::{PositionResponse, QueryMsg as ConcentratedQueryMsg};
 use rstest::rstest;
 
+use super::utils::first_position_id;
 use crate::helpers::chains::get_concentrated_vlp;
 use crate::helpers::factory::{
     add_concentrated_liquidity, create_concentrated_pool, get_position_token, list_position_ids,
@@ -16,12 +17,6 @@ use crate::tests_reusable::constants::{
     FACTORY_CHAIN_ID_EVM, FACTORY_CHAIN_ID_IBC, FACTORY_CHAIN_ID_LOCAL,
 };
 use crate::tests_reusable::factory_register::FactorySetupMode;
-
-fn first_position_id(factory: &factory::FactoryContract<cw_orch::mock::MockBase>) -> Uint128 {
-    let ids = list_position_ids(factory).unwrap();
-    assert!(!ids.is_empty(), "expected at least one position");
-    Uint128::new(ids[0].parse::<u128>().unwrap())
-}
 
 #[cfg(test)]
 mod tests {

--- a/tests-integration/src/tests_reusable/clp/position_lifecycle.rs
+++ b/tests-integration/src/tests_reusable/clp/position_lifecycle.rs
@@ -9,6 +9,7 @@ use euclid::msgs::vlp::concentrated::msg::{
 use rstest::rstest;
 use std::collections::HashSet;
 
+use super::utils::{first_position_id, last_position_id};
 use crate::helpers::chains::get_concentrated_vlp;
 use crate::helpers::factory::{
     add_concentrated_liquidity, create_concentrated_pool, get_position_token, list_position_ids,
@@ -20,12 +21,6 @@ use crate::tests_reusable::constants::{
     FACTORY_CHAIN_ID_EVM, FACTORY_CHAIN_ID_IBC, FACTORY_CHAIN_ID_LOCAL,
 };
 use crate::tests_reusable::factory_register::FactorySetupMode;
-
-fn first_position_id(factory: &factory::FactoryContract<cw_orch::mock::MockBase>) -> Uint128 {
-    let ids = list_position_ids(factory).unwrap();
-    assert!(!ids.is_empty(), "expected at least one position");
-    Uint128::new(ids[0].parse::<u128>().unwrap())
-}
 
 #[cfg(test)]
 mod tests {
@@ -269,10 +264,7 @@ mod tests {
         )
         .unwrap();
 
-        let position_id = {
-            let ids = list_position_ids(&factory).unwrap();
-            Uint128::new(ids.last().unwrap().parse::<u128>().unwrap())
-        };
+        let position_id = last_position_id(&factory);
         let pos: PositionResponse = vlp
             .query(&ConcentratedQueryMsg::Position { position_id })
             .unwrap();

--- a/tests-integration/src/tests_reusable/clp/utils.rs
+++ b/tests-integration/src/tests_reusable/clp/utils.rs
@@ -1,4 +1,13 @@
 use cosmwasm_std::Uint128;
+use cw_orch::prelude::*;
+use euclid::cross_chain_user::CrossChainUser;
+use euclid::msgs::factory::msg::QueryMsgFns as FactoryQueryMsgFns;
+use euclid::msgs::router::query::QueryMsgFns as RouterQueryMsgFns;
+use euclid::msgs::virtual_balance::msg::QueryMsgFns as VirtualBalanceQueryMsgFns;
+use euclid::voucher::BalanceKey;
+
+use crate::helpers::chains::get_virtual_balance;
+use crate::helpers::factory::list_position_ids;
 
 pub fn price_to_tick(price: f64) -> i64 {
     (price.ln() / 1.0001_f64.ln()).floor() as i64
@@ -6,4 +15,45 @@ pub fn price_to_tick(price: f64) -> i64 {
 
 pub fn pair_to_tick(amount_a: Uint128, amount_b: Uint128) -> i64 {
     price_to_tick(amount_b.u128() as f64 / amount_a.u128() as f64)
+}
+
+pub fn first_position_id(factory: &factory::FactoryContract<cw_orch::mock::MockBase>) -> Uint128 {
+    let ids = list_position_ids(factory).unwrap();
+    assert!(!ids.is_empty(), "expected at least one position");
+    Uint128::new(ids[0].parse::<u128>().unwrap())
+}
+
+pub fn last_position_id(factory: &factory::FactoryContract<cw_orch::mock::MockBase>) -> Uint128 {
+    let ids = list_position_ids(factory).unwrap();
+    let max_id = ids
+        .iter()
+        .filter_map(|s| s.parse::<u128>().ok())
+        .max()
+        .expect("expected at least one position");
+    Uint128::new(max_id)
+}
+
+pub fn sender(factory: &factory::FactoryContract<cw_orch::mock::MockBase>) -> CrossChainUser {
+    CrossChainUser::new(
+        factory.get_state().unwrap().chain_uid,
+        factory.environment().sender.to_string(),
+    )
+}
+
+pub fn voucher_balance(
+    factory: &factory::FactoryContract<cw_orch::mock::MockBase>,
+    router: &router::RouterContract<cw_orch::mock::MockBase>,
+    token_id: &str,
+) -> Uint128 {
+    let virtual_balance = get_virtual_balance(
+        router.environment(),
+        &router.get_state().unwrap().virtual_balance_address,
+    );
+    virtual_balance
+        .get_balance(BalanceKey {
+            cross_chain_user: sender(factory),
+            token_id: token_id.to_string(),
+        })
+        .unwrap()
+        .amount
 }


### PR DESCRIPTION
# Pull Request

## Description

Add integration tests for concentrated liquidity positions that are outside the active tick range. Tests cover: active liquidity invariance on add/remove of OOR positions, zero fee accrual for OOR positions, tick crossing activation, and fee collection behavior before and after tick re-entry.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor/Chore

## Related Issue

N/A

## Testing

Steps to test:

1. `cargo test -p tests-integration out_of_range`
2. All 26 test cases should pass (7 test functions × 3 chain modes: Native, IBC, EVM)

## Checklist

- [x] Self-review completed
- [x] Tests added/updated (if applicable)
- [ ] Documentation updated (if applicable)

## Screenshots (if applicable)

N/A

## Additional Notes

Tests added in `tests-integration/src/tests_reusable/clp/out_of_range.rs`:

- `test_add_position_below_range_does_not_change_active_liquidity`
- `test_add_position_above_range_does_not_change_active_liquidity`
- `test_out_of_range_position_earns_no_fees`
- `test_swap_into_out_of_range_position_activates_it`
- `test_remove_liquidity_from_out_of_range_position`
- `test_add_to_existing_out_of_range_position_keeps_active_liquidity`
- `test_collect_fees_on_out_of_range_position_returns_zero`
- `test_position_earns_fees_only_after_tick_enters_range`