### PR TITLE
ci: modernize CI workflows and add extended test pipeline

### DIFF
--- a/.github/workflows/Basic.yml
+++ b/.github/workflows/Basic.yml
@@ -24,6 +24,7 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          toolchain: 1.86.0
           cache: true
 
       - name: Run unit tests
@@ -39,6 +40,7 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          toolchain: 1.86.0
           components: rustfmt, clippy
           cache: true
 
@@ -57,6 +59,7 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          toolchain: 1.86.0
           target: wasm32-unknown-unknown
           cache: true
 

--- a/.github/workflows/Basic.yml
+++ b/.github/workflows/Basic.yml
@@ -1,4 +1,3 @@
-
 name: Basic
 
 on:
@@ -12,61 +11,56 @@ on:
       - development
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: basic-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
-          toolchain: stable
-          target: wasm32-unknown-unknown
-          override: true
+          cache: true
 
       - name: Run unit tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: unit-test
-          args: --locked
+        run: cargo unit-test --locked
         env:
           RUST_BACKTRACE: 1
-
-      - name: Compile WASM contract
-        uses: actions-rs/cargo@v1
-        with:
-          command: wasm
-          args: --locked
-        env:
-          RUSTFLAGS: "-C link-arg=-s"
 
   lints:
     name: Lints
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt, clippy
+          cache: true
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
+        run: cargo clippy -- -W clippy::pedantic
+
+  compile:
+    name: Compile WASM
+    needs: [test, lints]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          command: clippy
-          args: -- -W clippy::pedantic
+          target: wasm32-unknown-unknown
+          cache: true
+
+      - name: Compile WASM contracts
+        run: cargo wasm --locked
+        env:
+          RUSTFLAGS: "-C link-arg=-s"

--- a/.github/workflows/Basic.yml
+++ b/.github/workflows/Basic.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.86.0
+          rustflags: ""
           cache: true
 
       - name: Run unit tests
@@ -42,6 +43,7 @@ jobs:
         with:
           toolchain: 1.86.0
           components: rustfmt, clippy
+          rustflags: ""
           cache: true
 
       - name: Run cargo fmt
@@ -61,6 +63,7 @@ jobs:
         with:
           toolchain: 1.86.0
           target: wasm32-unknown-unknown
+          rustflags: ""
           cache: true
 
       - name: Compile WASM contracts

--- a/.github/workflows/extended-tests.yml
+++ b/.github/workflows/extended-tests.yml
@@ -20,6 +20,7 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          toolchain: 1.86.0
           cache: true
 
       - name: Run fuzz tests
@@ -35,6 +36,7 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          toolchain: 1.86.0
           cache: true
 
       - name: Run full decimals tests

--- a/.github/workflows/extended-tests.yml
+++ b/.github/workflows/extended-tests.yml
@@ -1,0 +1,43 @@
+name: Extended Tests
+
+on:
+  push:
+    branches:
+      - main
+      - development
+  workflow_dispatch:
+
+concurrency:
+  group: extended-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fuzz:
+    name: Fuzz Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: true
+
+      - name: Run fuzz tests
+        run: cargo test -p tests-fuzz --locked
+        env:
+          RUST_BACKTRACE: 1
+
+  full-decimals:
+    name: Full Decimals Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: true
+
+      - name: Run full decimals tests
+        run: cargo test -p tests-integration --features full_decimals --locked
+        env:
+          RUST_BACKTRACE: 1

--- a/.github/workflows/extended-tests.yml
+++ b/.github/workflows/extended-tests.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.86.0
+          rustflags: ""
           cache: true
 
       - name: Run fuzz tests
@@ -37,6 +38,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.86.0
+          rustflags: ""
           cache: true
 
       - name: Run full decimals tests

--- a/.github/workflows/proto-gen.yml
+++ b/.github/workflows/proto-gen.yml
@@ -65,32 +65,3 @@ jobs:
         run: buf push proto --label "${{ github.sha }}" --label "${{ steps.vars.outputs.short_sha }}" --label "${{ github.ref_name }}"
         env:
           BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
-
-      # Notify consumer repos on main/development only
-      - name: Trigger frontend codegen
-        if: steps.diff.outputs.changed == 'true' && (github.ref_name == 'main' || github.ref_name == 'development')
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.CROSS_REPO_PAT }}
-          repository: EuclidProtocol/euclid-frontend-monorepo
-          event-type: contract-types-updated
-          client-payload: >-
-            {
-              "sha": "${{ github.sha }}",
-              "short_sha": "${{ steps.vars.outputs.short_sha }}",
-              "branch": "${{ github.ref_name }}"
-            }
-
-      - name: Trigger backend codegen
-        if: steps.diff.outputs.changed == 'true' && (github.ref_name == 'main' || github.ref_name == 'development')
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.CROSS_REPO_PAT }}
-          repository: EuclidProtocol/euclid_api
-          event-type: contract-types-updated
-          client-payload: >-
-            {
-              "sha": "${{ github.sha }}",
-              "short_sha": "${{ steps.vars.outputs.short_sha }}",
-              "branch": "${{ github.ref_name }}"
-            }


### PR DESCRIPTION
# Pull Request

## Description

Modernize CI workflows by replacing deprecated actions-rs with actions-rust-lang/setup-rust-toolchain, restructure Basic.yml into a proper pipeline (lints + tests gate compilation), remove frontend/backend dispatch from proto-gen, and add extended-tests.yml for fuzz and full_decimals test suites.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor/Chore

## Related Issue

N/A

## Testing

Steps to test:

1. Verify Basic workflow triggers on PR and runs lints + tests in parallel
2. Verify compile job only runs after both lints and tests pass
3. Verify extended-tests workflow triggers on push to main/development and via manual dispatch
4. Verify proto-gen workflow no longer dispatches to frontend/backend repos

## Pre-PR Checklist

- [x] `cargo test` passes
- [x] `cargo test --features full_decimals` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test -p tests-fuzz` passes

## Checklist

- [x] Self-review completed
- [ ] Tests added/updated (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] CHANGELOG.md updated (if contracts or packages changed)

## Screenshots (if applicable)

N/A

## Additional Notes

- Replaced deprecated `actions-rs/toolchain@v1` and `actions-rs/cargo@v1` with `actions-rust-lang/setup-rust-toolchain@v1` and direct cargo commands
- Added concurrency groups to both workflows to cancel in-progress runs
- WASM compile job now depends on `[test, lints]` passing first