### PR TITLE
ref: reorganize library feature for e2e testing suite

### DIFF
--- a/contracts/hub/cp_vlp/src/contract.rs
+++ b/contracts/hub/cp_vlp/src/contract.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
 
 #[cfg(not(feature = "library"))]
-use cosmwasm_std::{
-    entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, Uint256,
-};
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, Uint256};
 use cw2::set_contract_version;
 use euclid::{
     error::ContractError,

--- a/contracts/hub/cp_vlp/src/migrate.rs
+++ b/contracts/hub/cp_vlp/src/migrate.rs
@@ -1,4 +1,6 @@
-use cosmwasm_std::{ensure, entry_point, DepsMut, Env, Response};
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{ensure, DepsMut, Env, Response};
 use cw2::set_contract_version;
 use euclid::{
     error::ContractError,

--- a/contracts/hub/router/src/ibc/ack_and_timeout.rs
+++ b/contracts/hub/router/src/ibc/ack_and_timeout.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::to_json_binary;
-use cosmwasm_std::{from_json, Binary, CosmosMsg, DepsMut, Env, Response, Uint256, WasmMsg};
+use cosmwasm_std::{from_json, Binary, CosmosMsg, DepsMut, Env, Response, WasmMsg};
 use euclid::chain::{Chain, ChainType, ChainUid};
 use euclid::cross_chain_user::CrossChainUser;
 use euclid::error::ContractError;

--- a/contracts/hub/router/src/ibc/receive/pool.rs
+++ b/contracts/hub/router/src/ibc/receive/pool.rs
@@ -480,12 +480,12 @@ pub fn ibc_execute_single_sided_add_liquidity(
 
 #[cfg(test)]
 mod tests {
-    use cosmwasm_std::{Addr, Uint128, Uint256};
+    use cosmwasm_std::Uint256;
     use euclid::{
         chain::ChainUid,
         cross_chain_user::CrossChainUser,
         error::ContractError,
-        msgs::{router::TokenDenom, vlp::base::PoolConfig},
+        msgs::vlp::base::PoolConfig,
         token::{Pair, Token, TokenType},
     };
     use euclid_ibc::router_ibc::{
@@ -493,8 +493,8 @@ mod tests {
     };
 
     use crate::{
-        reply::{REMOVE_LIQUIDITY_REPLY_ID, VLP_INSTANTIATE_REPLY_ID, VLP_POOL_REGISTER_REPLY_ID},
-        state::{PENDING_REMOVE_LIQUIDITY, VLPS},
+        reply::REMOVE_LIQUIDITY_REPLY_ID,
+        state::PENDING_REMOVE_LIQUIDITY,
         testing::{
             fixtures::initialized,
             helpers::{

--- a/contracts/hub/router/src/ibc/receive/swap.rs
+++ b/contracts/hub/router/src/ibc/receive/swap.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{ensure, to_json_binary, DepsMut, Env, Response, SubMsg, Uint256, WasmMsg};
+use cosmwasm_std::{ensure, to_json_binary, DepsMut, Env, Response, SubMsg, WasmMsg};
 use euclid::{
     chain::ChainUid,
     cross_chain_user::CrossChainUser,

--- a/contracts/hub/router/src/ibc/receive/token.rs
+++ b/contracts/hub/router/src/ibc/receive/token.rs
@@ -5,7 +5,6 @@ use euclid::{
     error::ContractError,
     events::{tx_event, TxType},
     msgs::{
-        router::TokenDenom,
         virtual_balance::{
             msg::{
                 ExecuteMint, ExecuteMsg as VirtualBalanceMsg, QueryMsg as VirtualBalanceQueryMsg,

--- a/contracts/hub/router/src/query.rs
+++ b/contracts/hub/router/src/query.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{ensure, to_json_binary, Addr, Binary, Deps, Order, Uint256};
+use cosmwasm_std::{ensure, to_json_binary, Addr, Binary, Deps, Order};
 use cw_storage_plus::Bound;
 use euclid::{
     chain::ChainUid,
@@ -6,11 +6,10 @@ use euclid::{
     error::ContractError,
     msgs::{
         router::{
-            AllChainResponse, AllEscrowsResponse, AllTokensResponse, AllVlpResponse, ChainResponse,
+            AllChainResponse, AllEscrowsResponse, AllVlpResponse, ChainResponse,
             ChainTimeoutResponse, DefaultReleaseFeeResponse, EscrowResponse, FeeStateResponse,
-            LockedChainsResponse, QueryRelayerAddressesResponse, QuerySimulateSwap,
-            QueryTokenDenomsResponse, ReleaseFee, ReleaseFeesQueryResponse, SimulateSwapResponse,
-            StateResponse, TokenEscrowChainResponse, TokenEscrowsResponse, VlpResponse,
+            LockedChainsResponse, QueryRelayerAddressesResponse, QuerySimulateSwap, ReleaseFee,
+            ReleaseFeesQueryResponse, SimulateSwapResponse, StateResponse, VlpResponse,
         },
         virtual_balance::{GetTokenMetadataByDenomResponse, GetTokenStatusResponse},
         vlp::base::VlpSimulateSwapMsg,
@@ -21,9 +20,8 @@ use euclid::{
 };
 
 use crate::state::{
-    ADMIN, CHAIN_TIMEOUT_SECONDS, CHAIN_UID_TO_CHAIN, DEFAULT_RELEASE_FEE, ESCROW_BALANCES,
-    FEE_STATE, LOCKED_CHAINS, RELAYER_CONTRACT, RELEASE_FEES, STATE, TOKEN_DENOMS,
-    VIRTUAL_BALANCE_CONTRACT, VLPS,
+    ADMIN, CHAIN_TIMEOUT_SECONDS, CHAIN_UID_TO_CHAIN, DEFAULT_RELEASE_FEE, FEE_STATE,
+    LOCKED_CHAINS, RELAYER_CONTRACT, RELEASE_FEES, STATE, VIRTUAL_BALANCE_CONTRACT, VLPS,
 };
 
 pub fn query_state(deps: Deps) -> Result<Binary, ContractError> {
@@ -309,12 +307,11 @@ mod tests {
     use cosmwasm_std::{
         from_json,
         testing::{message_info, mock_env},
-        Addr, Uint128, Uint256,
+        Addr, Uint256,
     };
 
     use crate::{
         contract::execute,
-        state::TOKEN_DENOMS,
         testing::{
             fixtures::initialized,
             helpers::{
@@ -326,11 +323,10 @@ mod tests {
     use euclid::{
         chain::ChainUid,
         msgs::router::{
-            AllChainResponse, AllEscrowsResponse, AllTokensResponse, AllVlpResponse, ChainResponse,
-            ExecuteMsg, ManageRouterState, QueryRelayerAddressesResponse, QueryTokenDenomsResponse,
-            ReleaseFeesQueryResponse, StateResponse, TokenDenom, TokenEscrowsResponse, VlpResponse,
+            AllChainResponse, AllVlpResponse, ChainResponse, ExecuteMsg, ManageRouterState,
+            QueryRelayerAddressesResponse, ReleaseFeesQueryResponse, StateResponse, VlpResponse,
         },
-        token::{Pair, Token, TokenType},
+        token::{Pair, Token},
         utils::pagination::Pagination,
     };
     use rstest::*;

--- a/contracts/hub/router/src/reply.rs
+++ b/contracts/hub/router/src/reply.rs
@@ -598,7 +598,7 @@ mod tests {
     use cosmwasm_std::{
         attr,
         testing::{message_info, mock_dependencies, mock_env, MockQuerier},
-        Addr, Binary, Reply, SubMsgResponse, SubMsgResult, Uint128, Uint256,
+        Addr, Binary, Reply, SubMsgResponse, SubMsgResult, Uint256,
     };
     use euclid::{
         chain::ChainUid,

--- a/contracts/hub/router/src/testing/helpers.rs
+++ b/contracts/hub/router/src/testing/helpers.rs
@@ -5,8 +5,8 @@ use crate::state::{CHAIN_UID_TO_CHAIN, VIRTUAL_BALANCE_CONTRACT, VLPS};
 
 use cosmwasm_std::testing::{message_info, mock_dependencies, mock_env, MockQuerier};
 use cosmwasm_std::{
-    to_json_binary, Addr, ContractResult, DepsMut, MessageInfo, Response, SystemResult, Uint128,
-    Uint256, WasmQuery,
+    to_json_binary, Addr, ContractResult, DepsMut, MessageInfo, Response, SystemResult, Uint256,
+    WasmQuery,
 };
 
 use euclid::chain::{Chain, ChainType, ChainUid};

--- a/contracts/hub/stable_vlp/src/contract.rs
+++ b/contracts/hub/stable_vlp/src/contract.rs
@@ -17,7 +17,7 @@ use euclid::msgs::vlp::base::{State, NEXT_SWAP_REPLY_ID};
 use euclid::msgs::vlp::stable::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, DEFAULT_AMP_FACTOR};
 use euclid_pool::{
     add_liquidity, execute_swap, register_pool, remove_liquidity, update_admin, update_amp_factor,
-    update_fee, SwapCalculationMethod, MINIMUM_LIQUIDITY,
+    update_fee, SwapCalculationMethod,
 };
 // version info for migration info
 pub(crate) const CONTRACT_NAME: &str = "crates.io:stable_vlp";
@@ -230,7 +230,7 @@ mod tests {
     use cosmwasm_std::{
         attr,
         testing::{message_info, mock_dependencies, mock_env},
-        Addr, Uint128, Uint256, Uint64,
+        Addr, Uint256, Uint64,
     };
     use euclid::{
         admin::{AdminType, EuclidAdmin},

--- a/contracts/hub/stable_vlp/src/testing/helpers.rs
+++ b/contracts/hub/stable_vlp/src/testing/helpers.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
     testing::{message_info, mock_env, MockQuerier},
-    Addr, Response, Uint128, Uint256, Uint64,
+    Addr, Response, Uint256, Uint64,
 };
 use euclid::{
     admin::EuclidAdmin,

--- a/contracts/liquidity/escrow/src/contract.rs
+++ b/contracts/liquidity/escrow/src/contract.rs
@@ -108,7 +108,7 @@ mod tests {
     use cosmwasm_std::{
         attr,
         testing::{message_info, mock_dependencies, mock_env},
-        Addr, Uint128, Uint256,
+        Addr, Uint256,
     };
     use euclid::{
         error::ContractError,

--- a/contracts/liquidity/escrow/src/query.rs
+++ b/contracts/liquidity/escrow/src/query.rs
@@ -59,7 +59,7 @@ pub fn query_state(deps: Deps) -> Result<Binary, ContractError> {
 
 #[cfg(test)]
 mod tests {
-    use cosmwasm_std::{from_json, testing::mock_env, Uint128, Uint256};
+    use cosmwasm_std::{from_json, testing::mock_env, Uint256};
     use euclid::{
         msgs::escrow::{
             AllowedDenomsResponse, AllowedTokenResponse, ExecuteMsg, QueryMsg, StateResponse,

--- a/contracts/liquidity/factory/src/contract.rs
+++ b/contracts/liquidity/factory/src/contract.rs
@@ -355,7 +355,7 @@ pub fn reply(mut deps: DepsMut, env: Env, msg: Reply) -> Result<Response, Contra
 mod tests {
     use cosmwasm_std::{
         testing::{message_info, mock_dependencies, mock_env},
-        to_json_binary, Addr, Uint128, Uint256,
+        to_json_binary, Addr, Uint256,
     };
     use euclid::{
         chain::ChainUid,

--- a/contracts/liquidity/factory/src/execute/swap.rs
+++ b/contracts/liquidity/factory/src/execute/swap.rs
@@ -202,7 +202,7 @@ pub fn execute_swap_request(
 mod tests {
     use cosmwasm_std::{
         testing::{message_info, mock_dependencies, mock_env},
-        Uint128, Uint256,
+        Uint256,
     };
     use euclid::{
         error::ContractError,

--- a/contracts/liquidity/factory/src/execute/token.rs
+++ b/contracts/liquidity/factory/src/execute/token.rs
@@ -397,7 +397,7 @@ pub fn execute_transfer_voucher(
 mod tests {
     use cosmwasm_std::{
         testing::{message_info, mock_dependencies, mock_env},
-        Uint128, Uint256,
+        Uint256,
     };
     use euclid::{
         chain::ChainUid,

--- a/contracts/liquidity/factory/src/ibc/ack_and_timeout.rs
+++ b/contracts/liquidity/factory/src/ibc/ack_and_timeout.rs
@@ -1,4 +1,3 @@
-#[cfg(not(feature = "library"))]
 use cosmwasm_std::{
     from_json, to_json_binary, Binary, CosmosMsg, DepsMut, Env, Int256, ReplyOn, Response, SubMsg,
     WasmMsg,

--- a/contracts/liquidity/factory/src/ibc/receive.rs
+++ b/contracts/liquidity/factory/src/ibc/receive.rs
@@ -1,5 +1,4 @@
 use cosmwasm_std::Uint256;
-#[cfg(not(feature = "library"))]
 use cosmwasm_std::{ensure, to_json_binary, CosmosMsg, DepsMut, Env, Response, SubMsg, WasmMsg};
 use euclid::{
     chain::ChainUid,
@@ -172,7 +171,7 @@ mod tests {
     };
     use cosmwasm_std::{
         testing::{mock_dependencies, mock_env},
-        CosmosMsg, ReplyOn, Uint128, Uint256, WasmMsg,
+        CosmosMsg, ReplyOn, Uint256, WasmMsg,
     };
     use euclid::{
         chain::ChainUid,

--- a/contracts/liquidity/factory/src/migrate.rs
+++ b/contracts/liquidity/factory/src/migrate.rs
@@ -1,7 +1,9 @@
 use crate::contract::{CONTRACT_NAME, CONTRACT_VERSION};
 use crate::state::{State, ADMIN, STATE};
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{entry_point, DepsMut, Env, Response};
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{DepsMut, Env, Response};
 use cw2::set_contract_version;
 use cw_storage_plus::Item;
 use euclid::{admin::EuclidAdmin, error::ContractError, msgs::factory::MigrateMsg};

--- a/contracts/liquidity/factory/src/query.rs
+++ b/contracts/liquidity/factory/src/query.rs
@@ -237,7 +237,7 @@ pub fn get_chain_type(deps: Deps, env: &Env) -> Result<ChainType, ContractError>
 mod tests {
     use cosmwasm_std::{
         testing::{message_info, mock_dependencies, mock_env},
-        to_json_binary, Addr, ContractResult, SystemResult, Uint128, Uint256, WasmQuery,
+        to_json_binary, Addr, ContractResult, SystemResult, Uint256, WasmQuery,
     };
     use euclid::{
         chain::ChainUid,

--- a/packages/euclid/src/events.rs
+++ b/packages/euclid/src/events.rs
@@ -8,7 +8,7 @@ use crate::{
     cross_chain_user::CrossChainUser,
     deposit::DepositTokenRequest,
     swap::SwapRequest,
-    token::{Token, TokenMetadata, TokenType, TokenWithAmount},
+    token::{TokenMetadata, TokenType, TokenWithAmount},
 };
 
 pub fn liquidity_event(

--- a/packages/euclid/src/msgs/escrow/msg.rs
+++ b/packages/euclid/src/msgs/escrow/msg.rs
@@ -1,6 +1,6 @@
 use crate::token::{Pair, Token, TokenType};
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Uint128, Uint256};
+use cosmwasm_std::{Addr, Uint256};
 use cw20::Cw20ReceiveMsg;
 
 #[cw_serde]

--- a/packages/euclid/src/msgs/factory/msg.rs
+++ b/packages/euclid/src/msgs/factory/msg.rs
@@ -11,7 +11,7 @@ use crate::{
     utils::pagination::Pagination,
 };
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Binary, Uint128, Uint256};
+use cosmwasm_std::{Addr, Binary, Uint256};
 use cw20::Cw20ReceiveMsg;
 #[cw_serde]
 pub struct InstantiateMsg {

--- a/packages/euclid/src/msgs/router/query.rs
+++ b/packages/euclid/src/msgs/router/query.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Uint128, Uint256};
+use cosmwasm_std::{Addr, Uint256};
 
 use crate::{
     admin::EuclidAdmin,

--- a/tests-integration/src/tests/claimer.rs
+++ b/tests-integration/src/tests/claimer.rs
@@ -5,7 +5,6 @@ use cosmwasm_std::{to_json_binary, Addr, Uint128, Uint256};
 use cw_orch::{mock::MockBase, prelude::*};
 use cw_orch_interchain::{core::InterchainEnv, prelude::*};
 use euclid::normalize::normalize_token_to_voucher;
-use euclid::token::TokenMetadata;
 use factory::FactoryContract;
 use router::RouterContract;
 

--- a/tests-integration/src/tests/factory.rs
+++ b/tests-integration/src/tests/factory.rs
@@ -1,5 +1,4 @@
 #![cfg(not(target_arch = "wasm32"))]
-use std::ops::Add;
 
 use cosmwasm_std::{coin, to_json_binary, Addr, Coin, Isqrt, Uint128, Uint256, Uint512, Uint64};
 use cw_orch::{

--- a/tests-integration/src/tests_reusable/factory_add_liquidity.rs
+++ b/tests-integration/src/tests_reusable/factory_add_liquidity.rs
@@ -84,16 +84,12 @@ mod tests {
     use super::*;
     use crate::helpers::chains::{get_virtual_balance, setup_interchain, setup_router};
     use crate::helpers::relayer::extract_ack_packet_events;
-    use crate::tests_reusable::constants::{
-        FACTORY_CHAIN_ID_IBC, FACTORY_CHAIN_ID_LOCAL, ROUTER_CHAIN_ID,
-    };
+    use crate::tests_reusable::constants::ROUTER_CHAIN_ID;
     use crate::tests_reusable::factory_create_pool::create_pool;
     use crate::tests_reusable::factory_register::{setup_factory, FactorySetupMode};
     use crate::tests_reusable::factory_register_denom::register_denom;
     use crate::tests_reusable::state_sync::sync_state;
-    use crate::tests_reusable::test_macros::{
-        decimal_pair, decimal_pair_full, single_decimal, single_decimal_full,
-    };
+    use crate::tests_reusable::test_macros::{decimal_pair, single_decimal};
     use euclid::cross_chain_user::CrossChainUser;
     use euclid::limit::Limit;
     use euclid::msgs::virtual_balance::msg::QueryMsgFns as VirtualBalanceQueryMsgFns;

--- a/tests-integration/src/tests_reusable/factory_create_pool.rs
+++ b/tests-integration/src/tests_reusable/factory_create_pool.rs
@@ -5,7 +5,6 @@ use cosmwasm_std::{Uint128, Uint256};
 use cw_orch::mock::MockBase;
 use cw_orch::prelude::CwOrchError;
 use cw_orch::prelude::Environment;
-use cw_orch_interchain::prelude::InterchainEnv;
 use euclid::msgs::cross_chain_config::CrossChainConfig;
 use euclid::msgs::factory::ExecuteMsgFns as FactoryExecuteMsgFns;
 use euclid::msgs::factory::QueryMsgFns as FactoryQueryMsgFns;
@@ -59,12 +58,10 @@ mod tests {
     use super::*;
     use crate::helpers::chains::{setup_interchain, setup_router};
     use crate::helpers::relayer::{extract_ack_packet_events, relay_factory_router_factory};
-    use crate::tests_reusable::constants::{
-        FACTORY_CHAIN_ID_EVM, FACTORY_CHAIN_ID_IBC, FACTORY_CHAIN_ID_LOCAL, ROUTER_CHAIN_ID,
-    };
+    use crate::tests_reusable::constants::{FACTORY_CHAIN_ID_IBC, ROUTER_CHAIN_ID};
     use crate::tests_reusable::factory_register::{setup_factory, FactorySetupMode};
     use crate::tests_reusable::factory_register_denom::register_denom;
-    use crate::tests_reusable::test_macros::{decimal_pair, decimal_pair_full};
+    use crate::tests_reusable::test_macros::decimal_pair;
     use cosmwasm_std::Uint64;
     use cw_orch_interchain::prelude::InterchainEnv;
     use rstest_reuse::apply;

--- a/tests-integration/src/tests_reusable/factory_full.rs
+++ b/tests-integration/src/tests_reusable/factory_full.rs
@@ -97,7 +97,7 @@ mod tests {
     use crate::tests_reusable::factory_register_denom::setup_smart_denom_token;
     use crate::tests_reusable::state_sync::sync_state;
     use crate::tests_reusable::state_sync::UserFundsQuery;
-    use crate::tests_reusable::test_macros::{decimal_pair, decimal_pair_full};
+    use crate::tests_reusable::test_macros::decimal_pair;
     use cosmwasm_std::Uint64;
     use cw_orch::prelude::ContractInstance as _;
     use cw_orch::prelude::Environment;

--- a/tests-integration/src/tests_reusable/factory_register.rs
+++ b/tests-integration/src/tests_reusable/factory_register.rs
@@ -160,9 +160,7 @@ pub fn setup_factory_with_mode(
 mod tests {
     use super::*;
     use crate::helpers::chains::setup_router;
-    use crate::tests_reusable::constants::{
-        FACTORY_CHAIN_ID_EVM, FACTORY_CHAIN_ID_IBC, FACTORY_CHAIN_ID_LOCAL,
-    };
+
     use crate::tests_reusable::test_macros::factory_modes;
     use rstest::rstest;
     use rstest_reuse::apply;

--- a/tests-integration/src/tests_reusable/factory_register_denom.rs
+++ b/tests-integration/src/tests_reusable/factory_register_denom.rs
@@ -95,12 +95,7 @@ mod tests {
     use crate::helpers::chains::setup_interchain;
     use crate::tests_reusable::factory_register::setup_factory;
     use crate::tests_reusable::factory_register::FactorySetupMode;
-    use crate::{
-        helpers::chains::setup_router,
-        tests_reusable::constants::{
-            FACTORY_CHAIN_ID_EVM, FACTORY_CHAIN_ID_IBC, FACTORY_CHAIN_ID_LOCAL, ROUTER_CHAIN_ID,
-        },
-    };
+    use crate::{helpers::chains::setup_router, tests_reusable::constants::ROUTER_CHAIN_ID};
     use euclid::token::{Token, TokenType};
     use rstest::rstest;
 

--- a/tests-integration/src/tests_reusable/factory_single_sided.rs
+++ b/tests-integration/src/tests_reusable/factory_single_sided.rs
@@ -90,7 +90,7 @@ mod tests {
     use crate::tests_reusable::factory_create_pool::create_pool;
     use crate::tests_reusable::factory_register::{setup_factory, FactorySetupMode};
     use crate::tests_reusable::factory_register_denom::register_denom;
-    use crate::tests_reusable::test_macros::{decimal_pair, decimal_pair_full};
+    use crate::tests_reusable::test_macros::decimal_pair;
     use cosmwasm_std::Uint64;
     use euclid::msgs::escrow::QueryMsgFns as EscrowQueryMsgFns;
     use euclid::msgs::factory::msg::{

--- a/tests-integration/src/tests_reusable/factory_swap.rs
+++ b/tests-integration/src/tests_reusable/factory_swap.rs
@@ -106,9 +106,7 @@ mod tests {
     use crate::helpers::chains::{
         get_escrow, get_lp_token, get_virtual_balance, setup_interchain, setup_router,
     };
-    use crate::tests_reusable::constants::{
-        FACTORY_CHAIN_ID_EVM, FACTORY_CHAIN_ID_IBC, FACTORY_CHAIN_ID_LOCAL,
-    };
+
     use crate::tests_reusable::factory_add_liquidity::deposit_token;
     use crate::tests_reusable::factory_create_pool::create_pool;
     use crate::tests_reusable::factory_register::{setup_factory, FactorySetupMode};
@@ -121,7 +119,7 @@ mod tests {
     use euclid::msgs::router::query::QueryMsgFns as RouterQueryMsgFns;
     use euclid::msgs::virtual_balance::msg::QueryMsgFns as VirtualBalanceQueryMsgFns;
 
-    use crate::tests_reusable::test_macros::{decimal_pair, decimal_pair_full};
+    use crate::tests_reusable::test_macros::decimal_pair;
     use euclid::voucher::BalanceKey;
     fn native_token(name: &str, decimals: u32) -> TokenWithDenom {
         TokenWithDenom {

--- a/tests-integration/src/tests_reusable/mixed_decimal_pool.rs
+++ b/tests-integration/src/tests_reusable/mixed_decimal_pool.rs
@@ -4,15 +4,13 @@
 mod tests {
     use crate::helpers::chains::{get_lp_token, setup_interchain, setup_router};
     use crate::helpers::relayer::relay_factory_router_factory;
-    use crate::tests_reusable::constants::{
-        FACTORY_CHAIN_ID_IBC, FACTORY_CHAIN_ID_LOCAL, ROUTER_CHAIN_ID,
-    };
+    use crate::tests_reusable::constants::ROUTER_CHAIN_ID;
     use crate::tests_reusable::factory_add_liquidity::{add_liquidity, deposit_token};
     use crate::tests_reusable::factory_create_pool::create_pool;
     use crate::tests_reusable::factory_register::{setup_factory, FactorySetupMode};
     use crate::tests_reusable::factory_register_denom::register_denom;
     use crate::tests_reusable::factory_swap::swap_request;
-    use crate::tests_reusable::test_macros::{decimal_pair, decimal_pair_full};
+    use crate::tests_reusable::test_macros::decimal_pair;
     use cosmwasm_std::{to_json_binary, Uint128, Uint256};
     use cw_orch::mock::MockBase;
     use cw_orch::prelude::*;
@@ -24,7 +22,7 @@ mod tests {
     use euclid::msgs::factory::msg::QueryMsgFns as FactoryQueryMsgFns;
     use euclid::msgs::lp_token::msg::QueryMsgFns as LpTokenQueryMsgFns;
     use euclid::msgs::vlp::base::PoolConfig;
-    use euclid::normalize::{self, normalize};
+
     use euclid::swap::NextSwapPair;
     use euclid::token::{
         Pair, PairWithDenomAndAmount, Token, TokenType, TokenWithDenom, TokenWithDenomAndAmount,

--- a/tests-integration/src/tests_reusable/state_sync.rs
+++ b/tests-integration/src/tests_reusable/state_sync.rs
@@ -2,7 +2,7 @@
 
 use crate::helpers::chains::{get_escrow, get_virtual_balance, get_vlp};
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, Uint128, Uint256};
+use cosmwasm_std::{Addr, Uint256};
 use cw_orch::mock::MockBase;
 use cw_orch::prelude::{CwOrchQuery, Environment};
 use euclid::chain::ChainUid;
@@ -14,7 +14,6 @@ use euclid::msgs::vlp::base::GetLiquidityQueryResponse;
 use euclid::normalize::normalize_voucher_to_token;
 use euclid::recipient::Recipient;
 use euclid::token::{Pair, Token};
-use euclid::utils::pagination::Pagination;
 use euclid::voucher::BalanceKey;
 use factory::FactoryContract;
 use router::RouterContract;

--- a/tests-integration/src/tests_reusable/voucher_release.rs
+++ b/tests-integration/src/tests_reusable/voucher_release.rs
@@ -89,9 +89,7 @@ fn get_escrow_for_chain(
 mod tests {
     use super::*;
     use crate::helpers::chains::setup_interchain;
-    use crate::tests_reusable::constants::{
-        FACTORY_CHAIN_ID_EVM, FACTORY_CHAIN_ID_IBC, FACTORY_CHAIN_ID_LOCAL, ROUTER_CHAIN_ID,
-    };
+    use crate::tests_reusable::constants::{FACTORY_CHAIN_ID_EVM, ROUTER_CHAIN_ID};
     use crate::tests_reusable::factory_register::FactorySetupMode;
     use crate::tests_reusable::factory_register::{setup_factory, setup_factory_evm};
     use crate::tests_reusable::factory_register_denom::register_denom;


### PR DESCRIPTION
## Summary
- Fix `library` feature gating: only `entry_point` is cfg-gated; runtime types (`DepsMut`, `Env`, `Response`, etc.) are now always in scope, so contracts compile cleanly when pulled into the testing workspace with `features = ["library"]`.
- Clean up unused imports surfaced by `cargo fix` once the gating was corrected (router, factory, escrow, stable_vlp, integration tests).

## Affected files
- Split bundled `cfg(not(feature = "library"))` imports in: `cp_vlp/{contract,migrate}.rs`, `factory/migrate.rs`, `factory/ibc/{ack_and_timeout,receive}.rs`.
- Removed unused imports across router, factory, escrow, stable_vlp, integration tests, and a few `packages/euclid` event/message files.

## Test plan
- [ ] `cargo check --workspace` passes
- [ ] `cargo check -p cp_vlp -p factory -p router -p stable_vlp --features library` passes (matches how `tests-integration` pulls the contracts)
- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --all-targets --all-features` is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)